### PR TITLE
[#10] Error messages with ariadne

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ariadne"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f5e3dca4e09a6f340a61a0e9c7b61e030c69fc27bf29d73218f7e5e3b7638f"
+dependencies = [
+ "unicode-width",
+ "yansi",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +349,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,10 +474,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
 name = "zenscript"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ariadne",
  "clap",
  "notify",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,6 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
+ariadne = "0.5"
 clap = { version = "4", features = ["derive"] }
 notify = "7"

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -1,0 +1,223 @@
+use crate::lexer::span::Span;
+
+/// Severity level of a diagnostic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    Error,
+    Warning,
+    Help,
+}
+
+/// A compiler diagnostic with source location, message, and optional help text.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub message: String,
+    pub span: Span,
+    /// Optional label shown inline at the span location.
+    pub label: Option<String>,
+    /// Optional help/suggestion text shown below.
+    pub help: Option<String>,
+    /// Error code for categorization (e.g., "E001").
+    pub code: Option<String>,
+}
+
+impl Diagnostic {
+    pub fn error(message: impl Into<String>, span: Span) -> Self {
+        Self {
+            severity: Severity::Error,
+            message: message.into(),
+            span,
+            label: None,
+            help: None,
+            code: None,
+        }
+    }
+
+    pub fn warning(message: impl Into<String>, span: Span) -> Self {
+        Self {
+            severity: Severity::Warning,
+            message: message.into(),
+            span,
+            label: None,
+            help: None,
+            code: None,
+        }
+    }
+
+    pub fn with_label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+
+    pub fn with_help(mut self, help: impl Into<String>) -> Self {
+        self.help = Some(help.into());
+        self
+    }
+
+    pub fn with_code(mut self, code: impl Into<String>) -> Self {
+        self.code = Some(code.into());
+        self
+    }
+}
+
+impl std::fmt::Display for Diagnostic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let prefix = match self.severity {
+            Severity::Error => "error",
+            Severity::Warning => "warning",
+            Severity::Help => "help",
+        };
+        if let Some(code) = &self.code {
+            write!(f, "{prefix}[{code}]")?;
+        } else {
+            write!(f, "{prefix}")?;
+        }
+        write!(
+            f,
+            " at {}:{}: {}",
+            self.span.line, self.span.column, self.message
+        )?;
+        if let Some(help) = &self.help {
+            write!(f, "\n  help: {help}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Render diagnostics with pretty source annotations using ariadne.
+pub fn render_diagnostics(filename: &str, source: &str, diagnostics: &[Diagnostic]) -> String {
+    use ariadne::{Color, Label, Report, ReportKind, Source};
+
+    let mut output = Vec::new();
+
+    for diag in diagnostics {
+        let kind = match diag.severity {
+            Severity::Error => ReportKind::Error,
+            Severity::Warning => ReportKind::Warning,
+            Severity::Help => ReportKind::Advice,
+        };
+
+        let span = (filename, diag.span.start..diag.span.end);
+        let mut builder = Report::build(kind, span.clone());
+
+        if let Some(code) = &diag.code {
+            builder = builder.with_code(code);
+        }
+
+        builder = builder.with_message(&diag.message);
+
+        let label_text = diag.label.as_deref().unwrap_or(&diag.message);
+        let color = match diag.severity {
+            Severity::Error => Color::Red,
+            Severity::Warning => Color::Yellow,
+            Severity::Help => Color::Cyan,
+        };
+
+        builder = builder.with_label(Label::new(span).with_message(label_text).with_color(color));
+
+        if let Some(help) = &diag.help {
+            builder = builder.with_help(help);
+        }
+
+        let report = builder.finish();
+        report
+            .write((filename, Source::from(source)), &mut output)
+            .expect("failed to write diagnostic");
+    }
+
+    String::from_utf8(output).expect("diagnostic output was not valid utf-8")
+}
+
+/// Convert parser errors to diagnostics.
+pub fn from_parse_errors(errors: &[crate::parser::ParseError]) -> Vec<Diagnostic> {
+    errors
+        .iter()
+        .map(|e| {
+            let mut diag = Diagnostic::error(&e.message, e.span);
+
+            // Add helpful labels/hints for common errors
+            if e.message.contains("banned keyword") {
+                if let Some(help_start) = e.message.find(": ") {
+                    let help_text = &e.message[help_start + 2..];
+                    diag = diag.with_label("banned in ZenScript").with_help(help_text);
+                }
+            } else if e.message.contains("expected") {
+                diag = diag.with_label("unexpected token here");
+            } else if e.message.contains("mismatched closing tag") {
+                diag = diag.with_label("mismatched tag");
+            }
+
+            diag
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_display() {
+        let diag = Diagnostic::error("unexpected token", Span::new(0, 3, 1, 1));
+        assert!(diag.to_string().contains("error"));
+        assert!(diag.to_string().contains("unexpected token"));
+    }
+
+    #[test]
+    fn error_with_code() {
+        let diag = Diagnostic::error("banned keyword", Span::new(0, 3, 1, 1))
+            .with_code("E001")
+            .with_help("use const instead");
+        let s = diag.to_string();
+        assert!(s.contains("[E001]"));
+        assert!(s.contains("help: use const instead"));
+    }
+
+    #[test]
+    fn warning_display() {
+        let diag = Diagnostic::warning("unused variable", Span::new(5, 8, 1, 6));
+        assert!(diag.to_string().contains("warning"));
+    }
+
+    #[test]
+    fn render_single_error() {
+        let diag = Diagnostic::error("unexpected token", Span::new(6, 7, 1, 7)).with_label("here");
+        let output = render_diagnostics("test.zs", "const ? = 42", &[diag]);
+        assert!(output.contains("unexpected token"));
+        assert!(output.contains("test.zs"));
+    }
+
+    #[test]
+    fn render_banned_keyword() {
+        let diag = Diagnostic::error("banned keyword 'let'", Span::new(0, 3, 1, 1))
+            .with_label("banned in ZenScript")
+            .with_help("Use `const` - all bindings are immutable in ZenScript");
+        let output = render_diagnostics("test.zs", "let x = 42", &[diag]);
+        assert!(output.contains("banned"));
+        assert!(output.contains("const"));
+    }
+
+    #[test]
+    fn render_multiple_errors() {
+        let diags = vec![
+            Diagnostic::error("first error", Span::new(0, 3, 1, 1)),
+            Diagnostic::error("second error", Span::new(10, 13, 1, 11)),
+        ];
+        let output = render_diagnostics("test.zs", "let x = 42\nlet y = 20", &diags);
+        assert!(output.contains("first error"));
+        assert!(output.contains("second error"));
+    }
+
+    #[test]
+    fn from_parse_errors_converts() {
+        let parse_errors = vec![crate::parser::ParseError {
+            message: "expected identifier, found Number".to_string(),
+            span: Span::new(0, 3, 1, 1),
+        }];
+        let diags = from_parse_errors(&parse_errors);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].severity, Severity::Error);
+        assert!(diags[0].label.is_some());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 pub mod codegen;
+pub mod diagnostic;
 pub mod lexer;
 pub mod parser;
 
@@ -94,9 +95,11 @@ fn compile_file(file: &Path, out_dir: Option<&Path>) -> Result<PathBuf> {
     let source = std::fs::read_to_string(file)
         .with_context(|| format!("failed to read {}", file.display()))?;
 
+    let filename = file.to_string_lossy();
     let program = ZsParser::new(&source).parse_program().map_err(|errs| {
-        let msgs: Vec<String> = errs.iter().map(|e| e.to_string()).collect();
-        anyhow::anyhow!("{}", msgs.join("\n"))
+        let diags = diagnostic::from_parse_errors(&errs);
+        let rendered = diagnostic::render_diagnostics(&filename, &source, &diags);
+        anyhow::anyhow!("{rendered}")
     })?;
 
     let output = Codegen::new().generate(&program);
@@ -131,14 +134,15 @@ fn cmd_check(path: &Path) -> Result<()> {
         let source = std::fs::read_to_string(file)
             .with_context(|| format!("failed to read {}", file.display()))?;
 
+        let filename = file.to_string_lossy();
         match ZsParser::new(&source).parse_program() {
             Ok(_) => {
                 checked += 1;
             }
             Err(errs) => {
-                for e in &errs {
-                    eprintln!("  {}:{}", file.display(), e);
-                }
+                let diags = diagnostic::from_parse_errors(&errs);
+                let rendered = diagnostic::render_diagnostics(&filename, &source, &diags);
+                eprint!("{rendered}");
                 errors += 1;
             }
         }


### PR DESCRIPTION
closes #10

## Summary
- Add `src/diagnostic.rs` with `Severity`, `Diagnostic` struct, and builder pattern (`with_label`, `with_help`, `with_code`)
- Implement `render_diagnostics()` using ariadne 0.5 for colorful source-annotated error output
- Add `from_parse_errors()` to convert parser errors into diagnostics with smart label inference
- Integrate pretty diagnostics into CLI `build` and `check` commands
- 7 new diagnostic tests, all 142 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)