### PR TITLE
[#11] Playground - WASM compiler and web UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +561,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,6 +848,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,6 +882,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1211,6 +1244,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,6 +1564,17 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower-lsp",
+]
+
+[[package]]
+name = "zenscript-wasm"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "wasm-bindgen",
+ "zenscript",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+members = [".", "crates/zenscript-wasm"]
+resolver = "3"
+
 [package]
 name = "zenscript"
 version = "0.1.0"

--- a/crates/zenscript-wasm/Cargo.toml
+++ b/crates/zenscript-wasm/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "zenscript-wasm"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+zenscript = { path = "../.." }
+wasm-bindgen = "0.2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde-wasm-bindgen = "0.6"

--- a/crates/zenscript-wasm/src/lib.rs
+++ b/crates/zenscript-wasm/src/lib.rs
@@ -1,0 +1,131 @@
+use serde::Serialize;
+use wasm_bindgen::prelude::*;
+
+use zenscript::checker::Checker;
+use zenscript::codegen::Codegen;
+use zenscript::diagnostic;
+use zenscript::parser::Parser;
+
+/// A diagnostic message returned to JavaScript.
+#[derive(Serialize)]
+pub struct JsDiagnostic {
+    pub severity: String,
+    pub message: String,
+    pub line: u32,
+    pub column: u32,
+    pub code: Option<String>,
+}
+
+/// The result of compiling ZenScript source code.
+#[derive(Serialize)]
+pub struct CompileResult {
+    pub output: String,
+    pub diagnostics: Vec<JsDiagnostic>,
+    pub has_jsx: bool,
+    pub success: bool,
+}
+
+/// Compile ZenScript source to TypeScript.
+///
+/// Returns a JSON-serialized `CompileResult` with the output code
+/// and any diagnostics (errors/warnings).
+#[wasm_bindgen]
+pub fn compile(source: &str) -> JsValue {
+    let result = compile_inner(source);
+    serde_wasm_bindgen::to_value(&result).unwrap_or(JsValue::NULL)
+}
+
+fn compile_inner(source: &str) -> CompileResult {
+    let mut all_diagnostics = Vec::new();
+
+    // Parse
+    let program = match Parser::new(source).parse_program() {
+        Ok(program) => program,
+        Err(errors) => {
+            let diags = diagnostic::from_parse_errors(&errors);
+            for d in &diags {
+                all_diagnostics.push(JsDiagnostic {
+                    severity: format!("{:?}", d.severity),
+                    message: d.message.clone(),
+                    line: d.span.line as u32,
+                    column: d.span.column as u32,
+                    code: d.code.clone(),
+                });
+            }
+            return CompileResult {
+                output: String::new(),
+                diagnostics: all_diagnostics,
+                has_jsx: false,
+                success: false,
+            };
+        }
+    };
+
+    // Type check
+    let check_diags = Checker::new().check(&program);
+    let has_errors = check_diags
+        .iter()
+        .any(|d| d.severity == diagnostic::Severity::Error);
+
+    for d in &check_diags {
+        all_diagnostics.push(JsDiagnostic {
+            severity: format!("{:?}", d.severity),
+            message: d.message.clone(),
+            line: d.span.line as u32,
+            column: d.span.column as u32,
+            code: d.code.clone(),
+        });
+    }
+
+    // Generate code (even with type errors, for playground preview)
+    let output = Codegen::new().generate(&program);
+
+    CompileResult {
+        output: output.code,
+        diagnostics: all_diagnostics,
+        has_jsx: output.has_jsx,
+        success: !has_errors,
+    }
+}
+
+/// Check ZenScript source without generating output.
+/// Returns diagnostics only.
+#[wasm_bindgen]
+pub fn check(source: &str) -> JsValue {
+    let mut all_diagnostics = Vec::new();
+
+    match Parser::new(source).parse_program() {
+        Ok(program) => {
+            let check_diags = Checker::new().check(&program);
+            for d in &check_diags {
+                all_diagnostics.push(JsDiagnostic {
+                    severity: format!("{:?}", d.severity),
+                    message: d.message.clone(),
+                    line: d.span.line as u32,
+                    column: d.span.column as u32,
+                    code: d.code.clone(),
+                });
+            }
+        }
+        Err(errors) => {
+            let diags = diagnostic::from_parse_errors(&errors);
+            for d in &diags {
+                all_diagnostics.push(JsDiagnostic {
+                    severity: format!("{:?}", d.severity),
+                    message: d.message.clone(),
+                    line: d.span.line as u32,
+                    column: d.span.column as u32,
+                    code: d.code.clone(),
+                });
+            }
+        }
+    }
+
+    serde_wasm_bindgen::to_value(&all_diagnostics).unwrap_or(JsValue::NULL)
+}
+
+/// Get the compiler version.
+#[wasm_bindgen]
+pub fn version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}

--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -1,0 +1,2 @@
+pkg/
+node_modules/

--- a/playground/index.html
+++ b/playground/index.html
@@ -1,0 +1,322 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ZenScript Playground</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    :root {
+      --bg: #1e1e2e;
+      --surface: #181825;
+      --overlay: #313244;
+      --text: #cdd6f4;
+      --subtext: #a6adc8;
+      --accent: #89b4fa;
+      --green: #a6e3a1;
+      --red: #f38ba8;
+      --yellow: #f9e2af;
+      --border: #45475a;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 12px 20px;
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+    }
+
+    header h1 {
+      font-size: 18px;
+      font-weight: 600;
+      color: var(--accent);
+    }
+
+    header h1 span {
+      color: var(--subtext);
+      font-weight: 400;
+    }
+
+    .header-actions {
+      display: flex;
+      gap: 8px;
+    }
+
+    .header-actions button {
+      padding: 6px 14px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--surface);
+      color: var(--text);
+      cursor: pointer;
+      font-size: 13px;
+    }
+
+    .header-actions button:hover {
+      background: var(--overlay);
+    }
+
+    .editor-container {
+      display: flex;
+      flex: 1;
+      overflow: hidden;
+    }
+
+    .pane {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .pane + .pane {
+      border-left: 1px solid var(--border);
+    }
+
+    .pane-header {
+      padding: 8px 16px;
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: var(--subtext);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .pane-header .status {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--green);
+    }
+
+    .pane-header .status.error {
+      background: var(--red);
+    }
+
+    textarea {
+      flex: 1;
+      padding: 16px;
+      background: var(--bg);
+      color: var(--text);
+      border: none;
+      resize: none;
+      font-family: 'JetBrains Mono', 'Fira Code', 'SF Mono', 'Cascadia Code', monospace;
+      font-size: 14px;
+      line-height: 1.6;
+      tab-size: 2;
+      outline: none;
+    }
+
+    .output-area {
+      flex: 1;
+      padding: 16px;
+      overflow: auto;
+      font-family: 'JetBrains Mono', 'Fira Code', 'SF Mono', 'Cascadia Code', monospace;
+      font-size: 14px;
+      line-height: 1.6;
+      white-space: pre;
+    }
+
+    .diagnostics {
+      padding: 8px 16px;
+      background: var(--surface);
+      border-top: 1px solid var(--border);
+      max-height: 150px;
+      overflow-y: auto;
+      font-family: 'JetBrains Mono', 'Fira Code', 'SF Mono', monospace;
+      font-size: 12px;
+    }
+
+    .diagnostic-item {
+      padding: 4px 0;
+      display: flex;
+      gap: 8px;
+    }
+
+    .diagnostic-item .severity {
+      font-weight: 600;
+    }
+
+    .diagnostic-item .severity.error { color: var(--red); }
+    .diagnostic-item .severity.warning { color: var(--yellow); }
+    .diagnostic-item .location { color: var(--subtext); }
+    .diagnostic-item .message { color: var(--text); }
+
+    .no-diagnostics {
+      color: var(--subtext);
+      font-style: italic;
+    }
+
+    .loading {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex: 1;
+      color: var(--subtext);
+      font-size: 16px;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>ZenScript <span>Playground</span></h1>
+    <div class="header-actions">
+      <button id="share-btn">Share</button>
+      <button id="format-btn">Format</button>
+    </div>
+  </header>
+
+  <div class="editor-container">
+    <div class="pane">
+      <div class="pane-header">
+        <span>input.zs</span>
+      </div>
+      <textarea id="input" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off">import { useState } from "react"
+
+type Todo = {
+  id: string,
+  text: string,
+  done: bool,
+}
+
+export function App(): JSX.Element {
+  const [todos, setTodos] = useState([])
+
+  const completed = todos
+    |> filter(t => t.done)
+    |> length
+
+  return &lt;div&gt;
+    &lt;h1&gt;Todos ({completed} done)&lt;/h1&gt;
+    {todos |> map(t =&gt; &lt;p key={t.id}&gt;{t.text}&lt;/p&gt;)}
+  &lt;/div&gt;
+}</textarea>
+    </div>
+
+    <div class="pane">
+      <div class="pane-header">
+        <div class="status" id="status-dot"></div>
+        <span>output.tsx</span>
+      </div>
+      <div class="output-area" id="output">
+        <div class="loading" id="loading">Loading compiler...</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="diagnostics" id="diagnostics">
+    <span class="no-diagnostics">No diagnostics</span>
+  </div>
+
+  <script type="module">
+    import init, { compile, version } from './pkg/zenscript_wasm.js';
+
+    let compileTimeout = null;
+
+    async function main() {
+      await init();
+
+      const input = document.getElementById('input');
+      const output = document.getElementById('output');
+      const diagnosticsEl = document.getElementById('diagnostics');
+      const statusDot = document.getElementById('status-dot');
+      const loading = document.getElementById('loading');
+      const shareBtn = document.getElementById('share-btn');
+
+      loading.remove();
+
+      // Load source from URL hash if present
+      const hash = window.location.hash.slice(1);
+      if (hash) {
+        try {
+          input.value = decodeURIComponent(atob(hash));
+        } catch { /* ignore invalid hash */ }
+      }
+
+      function doCompile() {
+        const source = input.value;
+        const result = compile(source);
+
+        // Show output
+        if (result.output) {
+          output.textContent = result.output;
+        } else {
+          output.textContent = '// No output';
+        }
+
+        // Show diagnostics
+        if (result.diagnostics && result.diagnostics.length > 0) {
+          statusDot.className = 'status error';
+          diagnosticsEl.innerHTML = result.diagnostics.map(d => {
+            const sev = d.severity.toLowerCase();
+            const sevClass = sev.includes('error') ? 'error' : 'warning';
+            return `<div class="diagnostic-item">
+              <span class="severity ${sevClass}">${sev}</span>
+              <span class="location">${d.line}:${d.column}</span>
+              <span class="message">${escapeHtml(d.message)}</span>
+            </div>`;
+          }).join('');
+        } else {
+          statusDot.className = 'status';
+          diagnosticsEl.innerHTML = '<span class="no-diagnostics">No diagnostics</span>';
+        }
+      }
+
+      // Debounced compile on input
+      input.addEventListener('input', () => {
+        clearTimeout(compileTimeout);
+        compileTimeout = setTimeout(doCompile, 150);
+      });
+
+      // Tab key inserts spaces
+      input.addEventListener('keydown', (e) => {
+        if (e.key === 'Tab') {
+          e.preventDefault();
+          const start = input.selectionStart;
+          const end = input.selectionEnd;
+          input.value = input.value.substring(0, start) + '  ' + input.value.substring(end);
+          input.selectionStart = input.selectionEnd = start + 2;
+          clearTimeout(compileTimeout);
+          compileTimeout = setTimeout(doCompile, 150);
+        }
+      });
+
+      // Share button
+      shareBtn.addEventListener('click', () => {
+        const encoded = btoa(encodeURIComponent(input.value));
+        window.location.hash = encoded;
+        navigator.clipboard.writeText(window.location.href).then(() => {
+          shareBtn.textContent = 'Copied!';
+          setTimeout(() => { shareBtn.textContent = 'Share'; }, 1500);
+        });
+      });
+
+      // Initial compile
+      doCompile();
+    }
+
+    function escapeHtml(str) {
+      return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    main().catch(console.error);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
closes #11
closes #69
closes #70

## Summary
- **WASM crate** (`crates/zenscript-wasm`): Compiles the ZenScript compiler to WASM via `wasm-bindgen`. Exposes `compile(source)` and `check(source)` APIs returning output code and diagnostics for browser use.
- **Web UI** (`playground/index.html`): Split-pane playground with .zs input on left, .ts output on right. Live compilation as you type (150ms debounce), inline diagnostics, shareable URLs via base64-encoded hash.
- **Workspace**: Root `Cargo.toml` now defines a Cargo workspace including the WASM crate.

To build the WASM package: `cd crates/zenscript-wasm && wasm-pack build --target web --out-dir ../../playground/pkg`

## Test plan
- [x] All 221 tests pass across workspace
- [x] cargo fmt clean
- [x] cargo clippy --workspace clean