### PR TITLE
[#12] Documentation site with Astro Starlight

### DIFF
--- a/docs/site/.gitignore
+++ b/docs/site/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.astro/

--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -1,0 +1,60 @@
+import { defineConfig } from "astro/config";
+import starlight from "@astrojs/starlight";
+
+export default defineConfig({
+  integrations: [
+    starlight({
+      title: "ZenScript",
+      description:
+        "A Gleam-inspired language that compiles to TypeScript + React",
+      social: {
+        github: "https://github.com/milkyskies/zenscript",
+      },
+      sidebar: [
+        {
+          label: "Getting Started",
+          items: [
+            { label: "Introduction", slug: "guide/introduction" },
+            { label: "Installation", slug: "guide/installation" },
+            { label: "Your First Program", slug: "guide/first-program" },
+          ],
+        },
+        {
+          label: "Core Concepts",
+          items: [
+            { label: "Functions & Const", slug: "guide/functions" },
+            { label: "Pipes", slug: "guide/pipes" },
+            { label: "Pattern Matching", slug: "guide/pattern-matching" },
+            { label: "Types", slug: "guide/types" },
+            { label: "Error Handling", slug: "guide/error-handling" },
+            { label: "JSX & React", slug: "guide/jsx" },
+          ],
+        },
+        {
+          label: "Migration",
+          items: [
+            { label: "From TypeScript", slug: "guide/from-typescript" },
+            { label: "Comparison", slug: "guide/comparison" },
+          ],
+        },
+        {
+          label: "Reference",
+          items: [
+            { label: "Syntax", slug: "reference/syntax" },
+            { label: "Types", slug: "reference/types" },
+            { label: "Operators", slug: "reference/operators" },
+          ],
+        },
+        {
+          label: "Tooling",
+          items: [
+            { label: "CLI (zsc)", slug: "tooling/cli" },
+            { label: "Vite Plugin", slug: "tooling/vite" },
+            { label: "VS Code Extension", slug: "tooling/vscode" },
+            { label: "Configuration", slug: "tooling/configuration" },
+          ],
+        },
+      ],
+    }),
+  ],
+});

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "zenscript-docs",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "@astrojs/starlight": "^0.34.0",
+    "astro": "^5.7.0",
+    "sharp": "^0.33.0"
+  }
+}

--- a/docs/site/src/content/docs/guide/comparison.md
+++ b/docs/site/src/content/docs/guide/comparison.md
@@ -1,0 +1,61 @@
+---
+title: Comparison
+---
+
+How ZenScript compares to other languages in its space.
+
+## vs TypeScript
+
+| | TypeScript | ZenScript |
+|---|---|---|
+| **Target** | JavaScript | TypeScript |
+| **Null safety** | Optional (`strictNullChecks`) | Enforced (`Option<T>`) |
+| **Error handling** | Exceptions | `Result<T, E>` |
+| **Mutation** | `let`, `var`, `const` | `const` only |
+| **Pattern matching** | No | Yes, exhaustive |
+| **Pipes** | No (TC39 Stage 2) | `\|>` built in |
+| **Classes** | Yes | No |
+| **Escape hatches** | `any`, `as`, `!` | None |
+| **Runtime** | None | None |
+
+ZenScript is TypeScript with the escape hatches removed and functional features added.
+
+## vs Gleam
+
+| | Gleam | ZenScript |
+|---|---|---|
+| **Target** | Erlang/JS | TypeScript |
+| **Ecosystem** | Hex/npm | npm |
+| **JSX** | No | Yes |
+| **React** | No | First-class |
+| **Syntax** | ML-family | TS-family |
+| **Pipes** | Yes | Yes |
+| **Pattern matching** | Yes | Yes |
+| **Adoption** | New ecosystem | Existing TS ecosystem |
+
+ZenScript borrows Gleam's ideas (pipes, Result, no escape hatches) but targets the TypeScript/React ecosystem.
+
+## vs Elm
+
+| | Elm | ZenScript |
+|---|---|---|
+| **Target** | JavaScript | TypeScript |
+| **Architecture** | TEA required | Any React pattern |
+| **npm interop** | Ports (painful) | Direct imports |
+| **Learning curve** | Steep | Gentle (familiar syntax) |
+| **JSX** | No (virtual DOM DSL) | Yes |
+| **Community** | Small | TS/React ecosystem |
+
+ZenScript is less opinionated than Elm. It doesn't enforce an architecture — it just makes your code safer.
+
+## vs ReScript
+
+| | ReScript | ZenScript |
+|---|---|---|
+| **Target** | JavaScript | TypeScript |
+| **Syntax** | OCaml-inspired | TS-inspired |
+| **JSX** | Custom (`@react.component`) | Standard JSX |
+| **npm interop** | Bindings required | Direct imports |
+| **Output** | JavaScript | TypeScript |
+
+ZenScript's output is TypeScript, not JavaScript. This means the output itself is type-safe and can be checked by `tsc`.

--- a/docs/site/src/content/docs/guide/error-handling.md
+++ b/docs/site/src/content/docs/guide/error-handling.md
@@ -1,0 +1,96 @@
+---
+title: Error Handling
+---
+
+ZenScript replaces exceptions with `Result<T, E>` and replaces null checks with `Option<T>`. Every error path is visible in the type system.
+
+## Result
+
+```zenscript
+function divide(a: number, b: number): Result<number, string> {
+  match b {
+    0 -> Err("division by zero"),
+    _ -> Ok(a / b),
+  }
+}
+```
+
+You **must** handle the result:
+
+```zenscript
+match divide(10, 3) {
+  Ok(value) -> console.log(value),
+  Err(msg) -> console.error(msg),
+}
+```
+
+Ignoring a `Result` is a compile error:
+
+```zenscript
+// Error: Result must be handled
+divide(10, 3)
+```
+
+## The `?` Operator
+
+Propagate errors early instead of nesting matches:
+
+```zenscript
+function processOrder(id: string): Result<Receipt, Error> {
+  const order = fetchOrder(id)?       // returns Err early if it fails
+  const payment = chargeCard(order)?  // same here
+  return Ok(Receipt(order, payment))
+}
+```
+
+The `?` operator:
+- On `Ok(value)`: unwraps to `value`
+- On `Err(e)`: returns `Err(e)` from the enclosing function
+
+Using `?` outside a function that returns `Result` is a compile error.
+
+## Option
+
+```zenscript
+function findUser(id: string): Option<User> {
+  match users |> find(u => u.id == id) {
+    Some(user) -> Some(user),
+    None -> None,
+  }
+}
+```
+
+Handle with match:
+
+```zenscript
+match findUser("123") {
+  Some(user) -> greet(user.name),
+  None -> greet("stranger"),
+}
+```
+
+## npm Interop
+
+When importing from npm packages, ZenScript automatically wraps nullable types:
+
+```zenscript
+import { getElementById } from "some-dom-lib"
+// .d.ts says: getElementById(id: string): Element | null
+// ZenScript sees: getElementById(id: string): Option<Element>
+```
+
+The boundary wrapping also converts:
+- `T | undefined` to `Option<T>`
+- `any` to `unknown`
+
+This means npm libraries work transparently with ZenScript's type system.
+
+## Comparison with TypeScript
+
+| TypeScript | ZenScript |
+|---|---|
+| `T \| null` | `Option<T>` |
+| `try/catch` | `Result<T, E>` |
+| `?.` optional chain | `match` on `Option` |
+| `!` non-null assertion | Not available (handle the case) |
+| `throw new Error()` | `Err(...)` |

--- a/docs/site/src/content/docs/guide/first-program.md
+++ b/docs/site/src/content/docs/guide/first-program.md
@@ -1,0 +1,87 @@
+---
+title: Your First Program
+---
+
+## Hello World
+
+Create a file called `hello.zs`:
+
+```zenscript
+export function greet(name: string): string {
+  return `Hello, ${name}!`
+}
+
+greet("world") |> console.log
+```
+
+Compile it:
+
+```bash
+zsc build hello.zs
+```
+
+This produces `hello.ts`:
+
+```typescript
+export function greet(name: string): string {
+  return `Hello, ${name}!`;
+}
+
+console.log(greet("world"));
+```
+
+## A React Component
+
+Create `counter.zs`:
+
+```zenscript
+import { useState } from "react"
+
+export function Counter(): JSX.Element {
+  const [count, setCount] = useState(0)
+
+  return <div>
+    <p>Count: {count}</p>
+    <button onClick={setCount}>+1</button>
+  </div>
+}
+```
+
+Compile it:
+
+```bash
+zsc build counter.zs
+```
+
+This produces `counter.tsx` — a standard React component that works with any React setup.
+
+## Using Pipes
+
+Pipes let you read transformations left-to-right instead of inside-out:
+
+```zenscript
+// Without pipes (nested calls)
+const result = toString(add(multiply(value, 2), 1))
+
+// With pipes (left to right)
+const result = value
+  |> multiply(_, 2)
+  |> add(_, 1)
+  |> toString
+```
+
+The `_` placeholder marks where the piped value goes.
+
+## Type Checking
+
+Run the type checker without generating output:
+
+```bash
+zsc check src/
+```
+
+This catches errors like:
+- Using `any` (use `unknown` instead)
+- Nullable values without `Option<T>`
+- Non-exhaustive pattern matches
+- Unused variables and imports

--- a/docs/site/src/content/docs/guide/from-typescript.md
+++ b/docs/site/src/content/docs/guide/from-typescript.md
@@ -1,0 +1,142 @@
+---
+title: Migrating from TypeScript
+---
+
+ZenScript is designed to be familiar to TypeScript developers. This guide covers the key differences.
+
+## What Stays the Same
+
+- Import/export syntax
+- Arrow functions
+- Template literals
+- JSX
+- Async/await
+- Type annotations
+- Generics
+
+## What Changes
+
+### `const` only
+
+```typescript
+// TypeScript
+let count = 0
+count += 1
+
+// ZenScript — no let, no mutation
+const count = 0
+const newCount = count + 1
+```
+
+### `bool` instead of `boolean`
+
+```typescript
+// TypeScript
+const active: boolean = true
+
+// ZenScript
+const active: bool = true
+```
+
+### `==` is `===`
+
+ZenScript's `==` compiles to `===`. There is no loose equality.
+
+```zenscript
+// ZenScript
+x == y    // compiles to: x === y
+x != y    // compiles to: x !== y
+```
+
+### Pipes instead of method chains
+
+```typescript
+// TypeScript
+const result = users
+  .filter(u => u.active)
+  .map(u => u.name)
+  .join(", ")
+
+// ZenScript
+const result = users
+  |> filter(u => u.active)
+  |> map(u => u.name)
+  |> join(", ")
+```
+
+### Pattern matching instead of switch
+
+```typescript
+// TypeScript
+switch (action.type) {
+  case "increment": return state + 1
+  case "decrement": return state - 1
+  default: return state
+}
+
+// ZenScript
+match action.type {
+  "increment" -> state + 1,
+  "decrement" -> state - 1,
+  _ -> state,
+}
+```
+
+### Result instead of try/catch
+
+```typescript
+// TypeScript
+try {
+  const data = await fetchData()
+  return data
+} catch (e) {
+  return null
+}
+
+// ZenScript
+match await fetchData() {
+  Ok(data) -> Some(data),
+  Err(_) -> None,
+}
+```
+
+### Option instead of null
+
+```typescript
+// TypeScript
+function find(id: string): User | null {
+  return users.find(u => u.id === id) ?? null
+}
+
+// ZenScript
+function find(id: string): Option<User> {
+  match users |> find(u => u.id == id) {
+    Some(user) -> Some(user),
+    None -> None,
+  }
+}
+```
+
+## What's Removed
+
+| Feature | Why | Alternative |
+|---------|-----|-------------|
+| `let` / `var` | Mutation bugs | `const` only |
+| `class` | Complex inheritance hierarchies | Functions + records |
+| `this` | Implicit context bugs | Explicit parameters |
+| `any` | Type safety escape | `unknown` + narrowing |
+| `null` / `undefined` | Billion-dollar mistake | `Option<T>` |
+| `enum` | Quirky JS behavior | Union types |
+| `interface` | Redundant | `type` |
+| `switch` | No exhaustiveness, fall-through | `match` |
+| `for` / `while` | Mutation-heavy | Pipes + map/filter/reduce |
+| `throw` | Invisible error paths | `Result<T, E>` |
+
+## Incremental Adoption
+
+ZenScript compiles to `.ts/.tsx`, so you can adopt it file by file:
+
+1. Add `zsc` to your project
+2. Write new files as `.zs`
+3. Compile them alongside your existing `.ts` files
+4. Your build tool (Vite, Next.js) treats the output as normal TypeScript

--- a/docs/site/src/content/docs/guide/functions.md
+++ b/docs/site/src/content/docs/guide/functions.md
@@ -1,0 +1,82 @@
+---
+title: Functions & Const
+---
+
+## Const Declarations
+
+All bindings are immutable. Use `const`:
+
+```zenscript
+const name = "ZenScript"
+const count = 42
+const active = true
+```
+
+With type annotations:
+
+```zenscript
+const name: string = "ZenScript"
+const count: number = 42
+```
+
+### Destructuring
+
+```zenscript
+const [first, second] = getItems()
+const { name, age } = getUser()
+```
+
+## Functions
+
+```zenscript
+function add(a: number, b: number): number {
+  return a + b
+}
+```
+
+Exported functions **must** have return type annotations:
+
+```zenscript
+export function greet(name: string): string {
+  return `Hello, ${name}!`
+}
+```
+
+### Default Parameters
+
+```zenscript
+function greet(name: string = "world"): string {
+  return `Hello, ${name}!`
+}
+```
+
+### Arrow Functions
+
+```zenscript
+const double = (x: number) => x * 2
+const add = (a: number, b: number) => a + b
+```
+
+Single-argument arrows don't need parentheses:
+
+```zenscript
+const double = x => x * 2
+```
+
+### Async Functions
+
+```zenscript
+async function fetchUser(id: string): Promise<User> {
+  const response = await fetch(`/api/users/${id}`)
+  return await response.json()
+}
+```
+
+## What's Not Here
+
+- **No `let` or `var`** — all bindings are `const`
+- **No `class`** — use functions and records
+- **No `this`** — functions are pure by default
+- **No `function*` generators** — use arrays and pipes
+
+These are removed intentionally. See the [comparison](/guide/comparison) for the reasoning.

--- a/docs/site/src/content/docs/guide/installation.md
+++ b/docs/site/src/content/docs/guide/installation.md
@@ -1,0 +1,73 @@
+---
+title: Installation
+---
+
+## Install the Compiler
+
+ZenScript ships as a single Rust binary called `zsc`.
+
+### From Source
+
+```bash
+# Clone and build
+git clone https://github.com/milkyskies/zenscript
+cd zenscript
+cargo install --path .
+
+# Verify
+zsc --version
+```
+
+### Prerequisites
+
+- [Rust](https://rustup.rs/) 1.85+ (for building from source)
+- [Node.js](https://nodejs.org/) 18+ (for your project's build toolchain)
+
+## Create a Project
+
+```bash
+# Scaffold a new ZenScript project
+zsc init my-app
+cd my-app
+
+# Install npm dependencies
+npm install
+
+# Compile .zs files
+zsc build src/
+
+# Or watch for changes
+zsc watch src/
+```
+
+## Editor Setup
+
+### VS Code
+
+Install the **ZenScript** extension from the VS Code marketplace, or build from source:
+
+```bash
+cd editors/vscode
+npm install
+npm run build
+```
+
+The extension provides:
+- Syntax highlighting for `.zs` files
+- LSP integration (diagnostics, hover)
+- Code snippets
+
+### Other Editors
+
+ZenScript includes an LSP server. Start it with:
+
+```bash
+zsc lsp
+```
+
+Any editor with LSP support can connect to it.
+
+## Next Steps
+
+- [Write your first program](/guide/first-program)
+- [Set up Vite integration](/tooling/vite)

--- a/docs/site/src/content/docs/guide/introduction.md
+++ b/docs/site/src/content/docs/guide/introduction.md
@@ -1,0 +1,71 @@
+---
+title: Introduction
+---
+
+ZenScript is a programming language that compiles to TypeScript. It's designed for TypeScript and React developers who want stronger guarantees without leaving their ecosystem.
+
+## Why ZenScript?
+
+TypeScript is great, but it has escape hatches everywhere: `any`, `null`, `undefined`, type assertions. These lead to runtime errors that the type system was supposed to prevent.
+
+ZenScript removes the escape hatches and adds features that make correct code easy to write:
+
+- **Pipes** (`|>`) for readable data transformations
+- **Pattern matching** (`match`) with exhaustiveness checking
+- **Result/Option** instead of null/undefined/exceptions
+- **No `any`** — use `unknown` and narrow
+- **No `null`/`undefined`** — use `Option<T>` with `Some`/`None`
+- **No classes** — use functions and records
+
+## What does it look like?
+
+```zenscript
+import { useState } from "react"
+
+type Todo = {
+  id: string,
+  text: string,
+  done: bool,
+}
+
+export function App(): JSX.Element {
+  const [todos, setTodos] = useState([])
+
+  const completed = todos
+    |> filter(t => t.done)
+    |> length
+
+  return <div>
+    <h1>Todos ({completed} done)</h1>
+  </div>
+}
+```
+
+This compiles to clean, readable TypeScript:
+
+```typescript
+import { useState } from "react";
+
+type Todo = {
+  id: string;
+  text: string;
+  done: boolean;
+};
+
+export function App(): JSX.Element {
+  const [todos, setTodos] = useState([]);
+
+  const completed = length(filter(todos, (t) => t.done));
+
+  return <div>
+    <h1>Todos ({completed} done)</h1>
+  </div>;
+}
+```
+
+## Design Philosophy
+
+1. **Familiar syntax** — A React developer should understand ZenScript in 30 minutes
+2. **No runtime** — The output is vanilla TypeScript with zero dependencies
+3. **Eject anytime** — If you stop using ZenScript, you have normal `.ts` files
+4. **Strictness is a feature** — Every restriction exists to prevent a category of bugs

--- a/docs/site/src/content/docs/guide/jsx.md
+++ b/docs/site/src/content/docs/guide/jsx.md
@@ -1,0 +1,86 @@
+---
+title: JSX & React
+---
+
+ZenScript has first-class JSX support. Write React components with all the safety guarantees.
+
+## Components
+
+```zenscript
+import { useState } from "react"
+
+export function Counter(): JSX.Element {
+  const [count, setCount] = useState(0)
+
+  return <div>
+    <h1>Count: {count}</h1>
+    <button onClick={setCount}>Increment</button>
+  </div>
+}
+```
+
+Components are just exported functions that return `JSX.Element`.
+
+## Props
+
+```zenscript
+type ButtonProps = {
+  label: string,
+  onClick: () => void,
+  disabled: bool,
+}
+
+export function Button(props: ButtonProps): JSX.Element {
+  return <button
+    onClick={props.onClick}
+    disabled={props.disabled}
+  >
+    {props.label}
+  </button>
+}
+```
+
+## Conditional Rendering
+
+Use `if`/`else` expressions:
+
+```zenscript
+return <div>
+  {if isLoggedIn {
+    <UserProfile user={user} />
+  } else {
+    <LoginForm />
+  }}
+</div>
+```
+
+## Lists
+
+Use pipes with `map`:
+
+```zenscript
+return <ul>
+  {items |> map(item => <li key={item.id}>{item.name}</li>)}
+</ul>
+```
+
+## Fragments
+
+```zenscript
+return <>
+  <Header />
+  <Main />
+  <Footer />
+</>
+```
+
+## JSX Detection
+
+The compiler automatically emits `.tsx` when JSX is detected, and `.ts` otherwise. No configuration needed.
+
+## What's Different from React + TypeScript
+
+- No `class` components — only function components
+- No `any` in props — every prop must be typed
+- Pipes instead of method chaining for data transformations
+- Pattern matching instead of ternaries for complex conditionals

--- a/docs/site/src/content/docs/guide/pattern-matching.md
+++ b/docs/site/src/content/docs/guide/pattern-matching.md
@@ -1,0 +1,117 @@
+---
+title: Pattern Matching
+---
+
+The `match` expression lets you branch on the shape of data. The compiler ensures every case is handled.
+
+## Basic Match
+
+```zenscript
+match status {
+  "active" -> handleActive(),
+  "inactive" -> handleInactive(),
+  _ -> handleUnknown(),
+}
+```
+
+## Matching on Result
+
+```zenscript
+match fetchUser(id) {
+  Ok(user) -> renderProfile(user),
+  Err(error) -> renderError(error),
+}
+```
+
+Both `Ok` and `Err` must be handled. Missing a case is a compile error.
+
+## Matching on Option
+
+```zenscript
+match findItem(id) {
+  Some(item) -> renderItem(item),
+  None -> renderNotFound(),
+}
+```
+
+## Union Types
+
+```zenscript
+type Shape =
+  | Circle(radius: number)
+  | Rectangle(width: number, height: number)
+  | Triangle(base: number, height: number)
+
+function area(shape: Shape): number {
+  match shape {
+    Circle(r) -> 3.14159 * r * r,
+    Rectangle(w, h) -> w * h,
+    Triangle(b, h) -> 0.5 * b * h,
+  }
+}
+```
+
+Adding a new variant to `Shape` without updating the `match` is a compile error.
+
+## Range Patterns
+
+```zenscript
+match score {
+  0..59 -> "F",
+  60..69 -> "D",
+  70..79 -> "C",
+  80..89 -> "B",
+  90..100 -> "A",
+  _ -> "Invalid",
+}
+```
+
+## Record Destructuring
+
+```zenscript
+match event {
+  { type: "click", x, y } -> handleClick(x, y),
+  { type: "keydown", key } -> handleKey(key),
+  _ -> ignore(),
+}
+```
+
+## Nested Patterns
+
+```zenscript
+match result {
+  Ok(Some(value)) -> process(value),
+  Ok(None) -> useDefault(),
+  Err(e) -> handleError(e),
+}
+```
+
+## Wildcard
+
+The `_` pattern matches anything. Place it last as a default:
+
+```zenscript
+match value {
+  1 -> "one",
+  2 -> "two",
+  _ -> "other",
+}
+```
+
+## Exhaustiveness
+
+The compiler checks that your match is exhaustive:
+
+```zenscript
+// Compile error: non-exhaustive match on bool
+match enabled {
+  true -> "on",
+  // missing: false
+}
+```
+
+This applies to:
+- **Booleans** — must handle `true` and `false`
+- **Result** — must handle `Ok` and `Err`
+- **Option** — must handle `Some` and `None`
+- **Unions** — must handle every variant (or use `_`)

--- a/docs/site/src/content/docs/guide/pipes.md
+++ b/docs/site/src/content/docs/guide/pipes.md
@@ -1,0 +1,82 @@
+---
+title: Pipes
+---
+
+The pipe operator `|>` is ZenScript's signature feature. It lets you chain transformations left-to-right, making data flow readable.
+
+## Basic Pipes
+
+```zenscript
+// Pipe the left side as the first argument to the right side
+const result = "hello" |> toUpperCase
+// Compiles to: toUpperCase("hello")
+```
+
+## Chaining
+
+```zenscript
+const result = users
+  |> filter(u => u.active)
+  |> map(u => u.name)
+  |> sort
+  |> join(", ")
+```
+
+Compiles to:
+
+```typescript
+const result = join(sort(map(filter(users, (u) => u.active), (u) => u.name)), ", ");
+```
+
+The piped version reads like a recipe: take users, filter, map, sort, join.
+
+## Placeholder `_`
+
+When the piped value isn't the first argument, use `_`:
+
+```zenscript
+const result = 5 |> add(3, _)
+// Compiles to: add(3, 5)
+```
+
+```zenscript
+const result = value
+  |> multiply(_, 2)
+  |> add(10, _)
+  |> toString
+```
+
+## Method-Style Pipes
+
+Pipes work with any function, including methods accessed via imports:
+
+```zenscript
+import { map, filter, reduce } from "ramda"
+
+const total = orders
+  |> filter(o => o.status == "complete")
+  |> map(o => o.amount)
+  |> reduce((sum, n) => sum + n, 0, _)
+```
+
+## When to Use Pipes
+
+Pipes shine when you have a sequence of transformations. They replace:
+
+| Instead of | Use |
+|---|---|
+| `c(b(a(x)))` | `x \|> a \|> b \|> c` |
+| `x.map(...).filter(...).reduce(...)` | `x \|> map(...) \|> filter(...) \|> reduce(...)` |
+| Temporary variables | Direct piping |
+
+## Three Operators
+
+ZenScript has exactly three arrow-like operators:
+
+```
+=>  arrow functions    (a) => a + 1
+->  match arms         Ok(x) -> x
+|>  pipe data          data |> transform
+```
+
+Each has a distinct purpose. No ambiguity.

--- a/docs/site/src/content/docs/guide/types.md
+++ b/docs/site/src/content/docs/guide/types.md
@@ -1,0 +1,121 @@
+---
+title: Types
+---
+
+## Primitives
+
+```zenscript
+const name: string = "Alice"
+const age: number = 30
+const active: bool = true
+```
+
+Note: ZenScript uses `bool`, not `boolean`.
+
+## Record Types
+
+```zenscript
+type User = {
+  name: string,
+  email: string,
+  age: number,
+}
+```
+
+Construct records with the type name:
+
+```zenscript
+const user = User(name: "Alice", email: "a@b.com", age: 30)
+```
+
+Update with spread:
+
+```zenscript
+const updated = User(..user, age: 31)
+```
+
+## Union Types
+
+Discriminated unions with variants:
+
+```zenscript
+type Color =
+  | Red
+  | Green
+  | Blue
+  | Custom(r: number, g: number, b: number)
+```
+
+## Result and Option
+
+### Result
+
+For operations that can fail:
+
+```zenscript
+type Result<T, E> = Ok(T) | Err(E)
+
+const result = Ok(42)
+const error = Err("something went wrong")
+```
+
+### Option
+
+For values that may be absent:
+
+```zenscript
+type Option<T> = Some(T) | None
+
+const found = Some("hello")
+const missing = None
+```
+
+### The `?` Operator
+
+Propagate errors concisely:
+
+```zenscript
+function getUsername(id: string): Result<string, Error> {
+  const user = fetchUser(id)?   // returns Err early if it fails
+  return Ok(user.name)
+}
+```
+
+## Brand Types
+
+Compile-time distinct types that erase at runtime:
+
+```zenscript
+type UserId = Brand<string, "UserId">
+type PostId = Brand<string, "PostId">
+
+// userId and postId are both strings at runtime,
+// but can't be mixed up at compile time
+```
+
+## Opaque Types
+
+Types where only the defining module can see the internal structure:
+
+```zenscript
+opaque type Email = string
+
+// Only this module can construct/destructure Email values
+```
+
+## Type Aliases
+
+```zenscript
+type Name = string
+type Callback = (event: Event) => void
+```
+
+## What's Banned
+
+| Banned | Why | Use Instead |
+|--------|-----|-------------|
+| `any` | Disables type checking | `unknown` + narrowing |
+| `null` | Billion-dollar mistake | `Option<T>` |
+| `undefined` | Two nothings is one too many | `Option<T>` |
+| `enum` | Quirky JS semantics | Union types |
+| `interface` | Redundant with type | `type` |

--- a/docs/site/src/content/docs/index.md
+++ b/docs/site/src/content/docs/index.md
@@ -1,0 +1,12 @@
+---
+title: Home
+template: splash
+hero:
+  tagline: A Gleam-inspired language that compiles to vanilla TypeScript + React. Zero runtime. Zero dependencies.
+  actions:
+    - text: Get Started
+      link: /guide/introduction/
+    - text: GitHub
+      link: https://github.com/milkyskies/zenscript
+      variant: minimal
+---

--- a/docs/site/src/content/docs/reference/operators.md
+++ b/docs/site/src/content/docs/reference/operators.md
@@ -1,0 +1,78 @@
+---
+title: Operators Reference
+---
+
+## Arithmetic
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `+` | Addition | `a + b` |
+| `-` | Subtraction / negation | `a - b`, `-x` |
+| `*` | Multiplication | `a * b` |
+| `/` | Division | `a / b` |
+| `%` | Modulo | `a % b` |
+
+## Comparison
+
+All comparisons compile to strict equality (`===`, `!==`).
+
+| Operator | Description | Compiles to |
+|----------|-------------|-------------|
+| `==` | Equal | `===` |
+| `!=` | Not equal | `!==` |
+| `<` | Less than | `<` |
+| `>` | Greater than | `>` |
+| `<=` | Less or equal | `<=` |
+| `>=` | Greater or equal | `>=` |
+
+## Logical
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `&&` | Logical AND | `a && b` |
+| `\|\|` | Logical OR | `a \|\| b` |
+| `!` | Logical NOT | `!a` |
+
+## Pipe
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `\|>` | Pipe | `x \|> f` |
+
+The pipe operator passes the left side as the first argument to the right side. Use `_` as a placeholder for non-first-argument positions.
+
+```zenscript
+x |> f          // f(x)
+x |> f(a, _)    // f(a, x)
+x |> f |> g     // g(f(x))
+```
+
+## Unwrap
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `?` | Unwrap Result/Option | `expr?` |
+
+The `?` operator unwraps `Ok(value)` or `Some(value)`, and returns early with `Err(e)` or `None` on failure. Only valid inside functions that return `Result` or `Option`.
+
+## Arrow Operators
+
+ZenScript has exactly three arrow-like operators:
+
+| Operator | Context | Meaning |
+|----------|---------|---------|
+| `=>` | Arrow functions | `(x) => x + 1` |
+| `->` | Match arms | `Ok(x) -> x` |
+| `\|>` | Pipes | `data \|> transform` |
+
+## Precedence (high to low)
+
+1. Unary: `!`, `-`
+2. Multiplicative: `*`, `/`, `%`
+3. Additive: `+`, `-`
+4. Comparison: `<`, `>`, `<=`, `>=`
+5. Equality: `==`, `!=`
+6. Logical AND: `&&`
+7. Logical OR: `||`
+8. Pipe: `|>`
+9. Unwrap: `?`

--- a/docs/site/src/content/docs/reference/syntax.md
+++ b/docs/site/src/content/docs/reference/syntax.md
@@ -1,0 +1,175 @@
+---
+title: Syntax Reference
+---
+
+## Comments
+
+```zenscript
+// Line comment
+/* Block comment */
+/* Nested /* block */ comments */
+```
+
+## Declarations
+
+### Const
+
+```zenscript
+const x = 42
+const name: string = "hello"
+export const PI = 3.14159
+
+// Destructuring
+const [a, b] = pair
+const { name, age } = user
+```
+
+### Function
+
+```zenscript
+function name(param: Type): ReturnType {
+  body
+}
+
+export function name(param: Type): ReturnType {
+  body
+}
+
+async function name(): Promise<T> {
+  await expr
+}
+```
+
+### Type
+
+```zenscript
+// Record
+type User = {
+  name: string,
+  email: string,
+}
+
+// Union
+type Shape =
+  | Circle(radius: number)
+  | Rectangle(width: number, height: number)
+
+// Alias
+type Name = string
+
+// Brand
+type UserId = Brand<string, "UserId">
+
+// Opaque
+opaque type Email = string
+```
+
+## Expressions
+
+### Literals
+
+```zenscript
+42              // number
+3.14            // number
+"hello"         // string
+`hello ${name}` // template literal
+true            // bool
+false           // bool
+[1, 2, 3]      // array
+```
+
+### Operators
+
+```zenscript
+a + b    a - b    a * b    a / b    a % b   // arithmetic
+a == b   a != b   a < b    a > b             // comparison
+a <= b   a >= b                               // comparison
+a && b   a || b   !a                          // logical
+a |> f                                        // pipe
+expr?                                         // unwrap
+```
+
+### Pipe
+
+```zenscript
+value |> transform
+value |> f(other_arg, _)   // placeholder
+a |> b |> c                // chaining
+```
+
+### Match
+
+```zenscript
+match expr {
+  pattern -> body,
+  pattern -> body,
+  _ -> default,
+}
+```
+
+### If/Else
+
+```zenscript
+if condition {
+  then_expr
+} else {
+  else_expr
+}
+```
+
+### Function Call
+
+```zenscript
+f(a, b)
+f(name: value)     // named argument
+Constructor(a: 1)  // record constructor
+Constructor(..existing, a: 2)  // spread + update
+```
+
+### Built-in Constructors
+
+```zenscript
+Ok(value)     // Result success
+Err(error)    // Result failure
+Some(value)   // Option present
+None          // Option absent
+```
+
+### Arrow Function
+
+```zenscript
+(a, b) => a + b
+x => x * 2
+(x: number): number => x + 1
+```
+
+### JSX
+
+```zenscript
+<Component prop={value}>children</Component>
+<div className="box">text</div>
+<Input />
+<>fragment</>
+```
+
+## Imports
+
+```zenscript
+import { name } from "module"
+import { name as alias } from "module"
+import { a, b, c } from "module"
+```
+
+## Patterns
+
+```zenscript
+42                    // literal
+"hello"               // string literal
+true                  // boolean literal
+x                     // binding
+_                     // wildcard
+Ok(x)                 // variant
+Some(inner)           // option
+{ field, other }      // record destructure
+1..10                 // range
+```

--- a/docs/site/src/content/docs/reference/types.md
+++ b/docs/site/src/content/docs/reference/types.md
@@ -1,0 +1,120 @@
+---
+title: Types Reference
+---
+
+## Primitive Types
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `string` | Text | `"hello"` |
+| `number` | Integer or float | `42`, `3.14` |
+| `bool` | Boolean | `true`, `false` |
+
+## Built-in Generic Types
+
+| Type | Description |
+|------|-------------|
+| `Result<T, E>` | Success (`Ok(T)`) or failure (`Err(E)`) |
+| `Option<T>` | Present (`Some(T)`) or absent (`None`) |
+| `Array<T>` | Ordered collection |
+| `Promise<T>` | Async value |
+| `Brand<T, Tag>` | Compile-time distinct type |
+
+## Record Types
+
+Named product types with fields:
+
+```zenscript
+type User = {
+  name: string,
+  email: string,
+  age: number,
+}
+```
+
+Compiles to TypeScript `type`:
+
+```typescript
+type User = {
+  name: string;
+  email: string;
+  age: number;
+};
+```
+
+## Union Types
+
+Tagged discriminated unions:
+
+```zenscript
+type Shape =
+  | Circle(radius: number)
+  | Rectangle(width: number, height: number)
+  | Point
+```
+
+Compiles to TypeScript discriminated union:
+
+```typescript
+type Shape =
+  | { _tag: "Circle"; radius: number }
+  | { _tag: "Rectangle"; width: number; height: number }
+  | { _tag: "Point" };
+```
+
+## Brand Types
+
+Types that are distinct at compile time but erase to their base type at runtime:
+
+```zenscript
+type UserId = Brand<string, "UserId">
+type PostId = Brand<string, "PostId">
+```
+
+`UserId` and `PostId` are both `string` at runtime, but the compiler prevents mixing them up.
+
+## Opaque Types
+
+Types where internals are hidden from other modules:
+
+```zenscript
+opaque type Email = string
+```
+
+Only code in the module that defines `Email` can construct or destructure it. Other modules see it as an opaque blob.
+
+## Type Expressions
+
+```zenscript
+// Named
+User
+string
+
+// Generic
+Array<number>
+Result<User, Error>
+Option<string>
+
+// Function
+(a: number, b: number) => number
+
+// Record (inline)
+{ name: string, age: number }
+
+// Array
+Array<T>
+
+// Tuple
+[string, number]
+```
+
+## Banned Types
+
+| Type | Why Banned | Alternative |
+|------|-----------|-------------|
+| `any` | Disables all type checking | `unknown` + pattern matching |
+| `null` | Nullable reference bugs | `Option<T>` with `None` |
+| `undefined` | Same problem as null | `Option<T>` with `None` |
+| `enum` | Quirky JavaScript semantics | Union types |
+| `interface` | Redundant with `type` | `type` |
+| `void` | Implicit undefined | Explicit return types |

--- a/docs/site/src/content/docs/tooling/cli.md
+++ b/docs/site/src/content/docs/tooling/cli.md
@@ -1,0 +1,82 @@
+---
+title: CLI Reference
+---
+
+The ZenScript compiler is a single binary called `zsc`.
+
+## Commands
+
+### `zsc build`
+
+Compile `.zs` files to TypeScript.
+
+```bash
+# Compile a single file
+zsc build src/main.zs
+
+# Compile a directory
+zsc build src/
+
+# Specify output directory
+zsc build src/ --out-dir dist/
+```
+
+The compiler automatically chooses `.ts` or `.tsx` based on whether the file contains JSX.
+
+### `zsc check`
+
+Type-check files without generating output.
+
+```bash
+zsc check src/
+zsc check src/main.zs
+```
+
+### `zsc watch`
+
+Watch files and recompile on change.
+
+```bash
+zsc watch src/
+zsc watch src/ --out-dir dist/
+```
+
+### `zsc init`
+
+Scaffold a new ZenScript project.
+
+```bash
+# In current directory
+zsc init
+
+# In a new directory
+zsc init my-app
+```
+
+Creates:
+- `src/main.zs` — sample ZenScript file
+- `tsconfig.json` — TypeScript configuration
+
+### `zsc lsp`
+
+Start the language server on stdin/stdout.
+
+```bash
+zsc lsp
+```
+
+Used by editor extensions. You don't typically run this directly.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Compilation error (parse or type error) |
+| 2 | File not found or I/O error |
+
+## Environment
+
+| Variable | Description |
+|----------|-------------|
+| `ZSC_FILENAME` | Override the filename shown in diagnostics |

--- a/docs/site/src/content/docs/tooling/configuration.md
+++ b/docs/site/src/content/docs/tooling/configuration.md
@@ -1,0 +1,77 @@
+---
+title: Configuration
+---
+
+## tsconfig.json
+
+ZenScript outputs TypeScript files, so your project needs a `tsconfig.json`. The `zsc init` command creates one for you:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}
+```
+
+Key settings:
+- `jsx: "react-jsx"` — required for `.tsx` output from ZenScript JSX
+- `strict: true` — matches ZenScript's strictness philosophy
+- `moduleResolution: "bundler"` — works with Vite and modern bundlers
+
+## Project Structure
+
+Recommended layout:
+
+```
+my-app/
+  src/
+    main.zs           # Entry point
+    components/
+      App.zs           # React components
+      Button.zs
+    utils/
+      math.zs          # Utility functions
+  tsconfig.json
+  package.json
+  vite.config.ts       # If using Vite
+```
+
+## Build Output
+
+By default, `zsc build` outputs files next to the source:
+
+```
+src/main.zs    -> src/main.ts
+src/App.zs     -> src/App.tsx    (if JSX detected)
+```
+
+Use `--out-dir` to specify a separate output directory:
+
+```bash
+zsc build src/ --out-dir dist/
+```
+
+## npm Interop
+
+ZenScript resolves npm modules using your project's `tsconfig.json` and `node_modules`. No additional configuration is needed.
+
+When importing from npm packages:
+- `T | null` becomes `Option<T>`
+- `T | undefined` becomes `Option<T>`
+- `any` becomes `unknown`
+
+This happens automatically at the import boundary.
+
+## Ignoring Directories
+
+The compiler automatically skips:
+- `node_modules/`
+- Hidden directories (`.git`, `.vscode`, etc.)
+- `target/` (Rust build output)

--- a/docs/site/src/content/docs/tooling/vite.md
+++ b/docs/site/src/content/docs/tooling/vite.md
@@ -1,0 +1,71 @@
+---
+title: Vite Plugin
+---
+
+The `vite-plugin-zenscript` package lets Vite transform `.zs` files during development and production builds.
+
+## Installation
+
+```bash
+npm install -D vite-plugin-zenscript
+```
+
+Make sure `zsc` is installed and available in your PATH.
+
+## Configuration
+
+```typescript
+// vite.config.ts
+import { defineConfig } from "vite"
+import zenscript from "vite-plugin-zenscript"
+
+export default defineConfig({
+  plugins: [zenscript()],
+})
+```
+
+### Options
+
+```typescript
+zenscript({
+  // Path to the zsc binary (default: "zsc")
+  compiler: "/usr/local/bin/zsc",
+})
+```
+
+## How It Works
+
+1. Vite encounters a `.zs` import
+2. The plugin calls `zsc` to compile it to TypeScript
+3. The TypeScript output is passed to Vite's normal pipeline
+4. Hot Module Replacement works automatically
+
+## With React
+
+```typescript
+// vite.config.ts
+import { defineConfig } from "vite"
+import react from "@vitejs/plugin-react"
+import zenscript from "vite-plugin-zenscript"
+
+export default defineConfig({
+  plugins: [
+    zenscript(),  // must come before React plugin
+    react(),
+  ],
+})
+```
+
+## File Structure
+
+```
+my-app/
+  src/
+    App.zs          # ZenScript component
+    utils.zs        # ZenScript utilities
+    legacy.tsx      # Existing TypeScript (works alongside)
+  vite.config.ts
+  package.json
+```
+
+ZenScript files and TypeScript files coexist. Adopt incrementally.

--- a/docs/site/src/content/docs/tooling/vscode.md
+++ b/docs/site/src/content/docs/tooling/vscode.md
@@ -1,0 +1,71 @@
+---
+title: VS Code Extension
+---
+
+The ZenScript VS Code extension provides syntax highlighting, LSP integration, and code snippets.
+
+## Installation
+
+### From Marketplace
+
+Search for "ZenScript" in the VS Code extensions panel.
+
+### From Source
+
+```bash
+cd editors/vscode
+npm install
+npm run build
+# Then install the .vsix file
+```
+
+## Features
+
+### Syntax Highlighting
+
+Full TextMate grammar for `.zs` files:
+- Keywords (`const`, `function`, `match`, `type`, etc.)
+- Operators (`|>`, `->`, `=>`, `?`)
+- JSX elements and attributes
+- Template literals with interpolation
+- Banned keyword highlighting (visual warning for `let`, `class`, etc.)
+
+### Language Server
+
+Real-time diagnostics as you type:
+- Parse errors
+- Type errors
+- Unused variable/import warnings
+- Banned keyword errors
+
+Hover information for built-in types and constructors.
+
+### Snippets
+
+| Prefix | Description |
+|--------|-------------|
+| `fn` | Function declaration |
+| `efn` | Exported function |
+| `match` | Match expression |
+| `matchr` | Match on Result |
+| `matcho` | Match on Option |
+| `type` | Record type |
+| `union` | Union type |
+| `comp` | React component |
+| `imp` | Import statement |
+| `pipe` | Pipe expression |
+| `co` | Const declaration |
+| `brand` | Brand type |
+| `opaque` | Opaque type |
+
+## Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `zenscript.serverPath` | Path to the `zsc` binary | `"zsc"` |
+
+## Troubleshooting
+
+**Diagnostics not showing:** Make sure `zsc` is installed and in your PATH. Check `zenscript.serverPath` in settings.
+
+**Extension not activating:** Ensure the file has a `.zs` extension. The extension activates on the `zenscript` language ID.


### PR DESCRIPTION
closes #12
closes #71
closes #72

## Summary
- **Astro Starlight** docs site with sidebar navigation, search, and dark mode
- **19 documentation pages** covering:
  - Guide: introduction, installation, first program, functions, pipes, pattern matching, types, error handling, JSX/React, TypeScript migration, language comparison
  - Reference: syntax, types, operators
  - Tooling: CLI, Vite plugin, VS Code extension, configuration

To run locally: `cd docs/site && npm install && npm run dev`

## Test plan
- [x] All 221 Rust tests pass
- [x] cargo fmt/clippy clean