### PR TITLE
[#118] Vite plugin for ZenScript (.zs files)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+node_modules/
+dist/

--- a/integrations/vite-plugin-zenscript/package.json
+++ b/integrations/vite-plugin-zenscript/package.json
@@ -5,17 +5,24 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "npm run build"
   },
-  "keywords": ["vite", "vite-plugin", "zenscript"],
+  "keywords": [
+    "vite",
+    "vite-plugin",
+    "zenscript"
+  ],
   "license": "MIT",
   "peerDependencies": {
     "vite": "^5.0.0 || ^6.0.0"
   },
   "devDependencies": {
+    "@types/node": "^25.5.0",
     "typescript": "^5.0.0",
     "vite": "^6.0.0"
   }

--- a/integrations/vite-plugin-zenscript/src/index.ts
+++ b/integrations/vite-plugin-zenscript/src/index.ts
@@ -29,13 +29,6 @@ export default function zenscript(options: ZenScriptOptions = {}): Plugin {
     name: "vite-plugin-zenscript",
     enforce: "pre",
 
-    resolveId(source) {
-      // Let Vite resolve .zs files
-      if (source.endsWith(".zs")) {
-        return null; // defer to default resolution
-      }
-    },
-
     transform(code, id) {
       if (!id.endsWith(".zs")) return null;
 
@@ -74,8 +67,6 @@ function compileZenScript(
   filename: string,
 ): CompileResult {
   try {
-    // Use zsc build --stdin to compile from stdin
-    // Falls back to writing a temp file if stdin mode isn't available
     const output = execFileSync(compiler, ["build", "--emit-stdout", "-"], {
       input: source,
       encoding: "utf-8",
@@ -86,15 +77,8 @@ function compileZenScript(
       },
     });
 
-    // Check if output contains JSX
-    const hasJsx =
-      output.includes("React") ||
-      output.includes("jsx") ||
-      output.includes("<");
-
     return {
       code: output,
-      // Source maps will be added when zsc supports --source-map
       map: null,
     };
   } catch (error) {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.94.0"
 components = ["rustfmt", "clippy"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,11 +19,14 @@ struct Cli {
 enum Command {
     /// Compile .zs files to .ts/.tsx
     Build {
-        /// File or directory to compile
+        /// File or directory to compile ("-" for stdin)
         path: PathBuf,
         /// Output directory (defaults to same directory as input)
         #[arg(short, long)]
         out_dir: Option<PathBuf>,
+        /// Emit compiled output to stdout instead of writing files
+        #[arg(long)]
+        emit_stdout: bool,
     },
     /// Type-check .zs files without emitting output
     Check {
@@ -51,7 +54,17 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Build { path, out_dir } => cmd_build(&path, out_dir.as_deref()),
+        Command::Build {
+            path,
+            out_dir,
+            emit_stdout,
+        } => {
+            if emit_stdout || path.as_os_str() == "-" {
+                cmd_build_stdin()
+            } else {
+                cmd_build(&path, out_dir.as_deref())
+            }
+        }
         Command::Check { path } => cmd_check(&path),
         Command::Watch { path, out_dir } => cmd_watch(&path, out_dir.as_deref()),
         Command::Init { path } => cmd_init(path.as_deref()),
@@ -60,6 +73,41 @@ fn main() -> Result<()> {
             Ok(())
         }
     }
+}
+
+// ── Build (stdin → stdout) ───────────────────────────────────────
+
+fn cmd_build_stdin() -> Result<()> {
+    use std::io::Read;
+
+    let mut source = String::new();
+    std::io::stdin()
+        .read_to_string(&mut source)
+        .context("failed to read from stdin")?;
+
+    let filename = std::env::var("ZSC_FILENAME").unwrap_or_else(|_| "<stdin>".to_string());
+
+    let program = ZsParser::new(&source).parse_program().map_err(|errs| {
+        let diags = diagnostic::from_parse_errors(&errs);
+        let rendered = diagnostic::render_diagnostics(&filename, &source, &diags);
+        anyhow::anyhow!("{rendered}")
+    })?;
+
+    // Type check
+    let check_diags = Checker::new().check(&program);
+    let type_errors: Vec<_> = check_diags
+        .iter()
+        .filter(|d| d.severity == diagnostic::Severity::Error)
+        .collect();
+    if !type_errors.is_empty() {
+        let rendered = diagnostic::render_diagnostics(&filename, &source, &check_diags);
+        return Err(anyhow::anyhow!("{rendered}"));
+    }
+
+    let output = Codegen::new().generate(&program);
+    print!("{}", output.code);
+
+    Ok(())
 }
 
 // ── Build ────────────────────────────────────────────────────────


### PR DESCRIPTION
closes #118

## Summary
- Add `zsc build --emit-stdout -` CLI mode: reads ZenScript from stdin, compiles, and emits TypeScript to stdout. Uses `ZSC_FILENAME` env var for error context.
- Finalize the Vite plugin (`vite-plugin-zenscript`): clean up unused code, add `@types/node`, make it build cleanly.
- Upgrade Rust toolchain from 1.86.0 to 1.94.0 (enables stable `let` chains used elsewhere in the codebase).
- Add `node_modules/` and `dist/` to `.gitignore`.

## How it works
The Vite plugin intercepts `.zs` file imports, pipes the source to `zsc build --emit-stdout -` via stdin, and returns the compiled TypeScript to Vite. HMR is supported via `handleHotUpdate`.

## Usage
```ts
import { defineConfig } from "vite"
import zenscript from "vite-plugin-zenscript"

export default defineConfig({
  plugins: [zenscript()],
})
```

## Test plan
- [x] `echo 'const x = 42' | cargo run -- build --emit-stdout -` outputs `const x = 42;`
- [x] `cargo clippy -- -D warnings` passes
- [x] `RUSTFLAGS="-D warnings" cargo test` passes (12/12)
- [x] `cd integrations/vite-plugin-zenscript && npm run build` compiles cleanly