### PR TITLE
[#138] Implement dot shorthand (.field) syntax

### DIFF
--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -428,6 +428,15 @@ impl Checker {
             }
 
             ExprKind::Spread(inner) => self.check_expr(inner),
+
+            ExprKind::DotShorthand { predicate, .. } => {
+                // Check the predicate RHS expression if present
+                if let Some((_op, rhs)) = predicate {
+                    self.check_expr(rhs);
+                }
+                // Dot shorthand produces a function
+                Type::Unknown
+            }
         }
     }
 

--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -250,6 +250,40 @@ impl Codegen {
                 self.push("...");
                 self.emit_expr(inner);
             }
+
+            ExprKind::DotShorthand { field, predicate } => {
+                match predicate {
+                    Some((op, rhs)) => match op {
+                        BinOp::Eq => {
+                            self.needs_deep_equal = true;
+                            self.push("(_x) => __zenEq(_x.");
+                            self.push(field);
+                            self.push(", ");
+                            self.emit_expr(rhs);
+                            self.push(")");
+                        }
+                        BinOp::NotEq => {
+                            self.needs_deep_equal = true;
+                            self.push("(_x) => !__zenEq(_x.");
+                            self.push(field);
+                            self.push(", ");
+                            self.emit_expr(rhs);
+                            self.push(")");
+                        }
+                        _ => {
+                            self.push("(_x) => _x.");
+                            self.push(field);
+                            self.push(&format!(" {} ", binop_str(*op)));
+                            self.emit_expr(rhs);
+                        }
+                    },
+                    None => {
+                        // `.field` → `(_x) => _x.field`
+                        self.push("(_x) => _x.");
+                        self.push(field);
+                    }
+                }
+            }
         }
     }
 

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -695,6 +695,10 @@ impl<'src> CstParser<'src> {
 
             Some(TokenKind::LessThan) => self.parse_jsx_element(),
 
+            Some(TokenKind::Dot) => {
+                self.parse_dot_shorthand();
+            }
+
             Some(TokenKind::VerticalBar) => {
                 self.parse_pipe_lambda();
             }
@@ -790,6 +794,39 @@ impl<'src> CstParser<'src> {
             self.parse_expr();
         } else {
             self.parse_expr();
+        }
+
+        self.builder.finish_node();
+    }
+
+    // ── Dot Shorthand ────────────────────────────────────────────
+
+    /// Parse `.field` or `.field op expr` dot shorthand expression.
+    fn parse_dot_shorthand(&mut self) {
+        self.builder.start_node(SyntaxKind::DOT_SHORTHAND.into());
+        self.expect(TokenKind::Dot);
+        self.eat_trivia();
+        self.expect_ident();
+        self.eat_trivia();
+
+        // Check for optional binary operator predicate
+        if self.at(TokenKind::EqualEqual)
+            || self.at(TokenKind::BangEqual)
+            || self.at(TokenKind::LessThan)
+            || self.at(TokenKind::GreaterThan)
+            || self.at(TokenKind::LessEqual)
+            || self.at(TokenKind::GreaterEqual)
+            || self.at(TokenKind::AmpAmp)
+            || self.at(TokenKind::PipePipe)
+            || self.at(TokenKind::Plus)
+            || self.at(TokenKind::Minus)
+            || self.at(TokenKind::Star)
+            || self.at(TokenKind::Slash)
+            || self.at(TokenKind::Percent)
+        {
+            self.bump(); // operator
+            self.eat_trivia();
+            self.parse_primary_expr();
         }
 
         self.builder.finish_node();

--- a/src/lower/expr.rs
+++ b/src/lower/expr.rs
@@ -363,6 +363,23 @@ impl<'src> Lowerer<'src> {
                 })
             }
 
+            SyntaxKind::DOT_SHORTHAND => {
+                let idents = self.collect_idents_direct(node);
+                let field = idents.first()?.clone();
+
+                // Check for binary op and RHS expression
+                let predicate = self.find_binary_op(node).and_then(|op| {
+                    // Find the RHS expression (child node or token after the operator)
+                    let rhs = self.lower_first_expr(node)?;
+                    Some((op, Box::new(rhs)))
+                });
+
+                Some(Expr {
+                    span,
+                    kind: ExprKind::DotShorthand { field, predicate },
+                })
+            }
+
             SyntaxKind::ERROR => None,
 
             // For other kinds, try to extract token-level expressions

--- a/src/main.rs
+++ b/src/main.rs
@@ -305,7 +305,7 @@ fn cmd_watch(path: &Path, out_dir: Option<&Path>) -> Result<()> {
             && (event.kind.is_modify() || event.kind.is_create())
         {
             for p in &event.paths {
-                if p.extension().is_some_and(|ext| ext == "zs") {
+                if p.extension().is_some_and(|ext| ext == "fl") {
                     let _ = tx.send(p.clone());
                 }
             }
@@ -397,7 +397,7 @@ export function App() {
 
 fn discover_fl_files(path: &Path) -> Result<Vec<PathBuf>> {
     if path.is_file() {
-        if path.extension().is_some_and(|ext| ext == "zs") {
+        if path.extension().is_some_and(|ext| ext == "fl") {
             return Ok(vec![path.to_path_buf()]);
         }
         bail!("{} is not a .fl file", path.display());
@@ -425,7 +425,7 @@ fn collect_fl_files(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
                 continue;
             }
             collect_fl_files(&path, files)?;
-        } else if path.extension().is_some_and(|ext| ext == "zs") {
+        } else if path.extension().is_some_and(|ext| ext == "fl") {
             files.push(path);
         }
     }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -261,6 +261,15 @@ pub enum ExprKind {
     // -- Spread --
     /// Spread: `...expr`
     Spread(Box<Expr>),
+
+    // -- Dot shorthand --
+    /// Dot shorthand: `.field` or `.field op expr` — creates an implicit lambda
+    DotShorthand {
+        /// The field name (e.g., `done` in `.done`)
+        field: String,
+        /// Optional operator and right-hand side (e.g., `== false` in `.done == false`)
+        predicate: Option<(BinOp, Box<Expr>)>,
+    },
 }
 
 /// Template literal parts for the AST.

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -456,6 +456,9 @@ impl Parser {
                 }
             }
 
+            // Dot shorthand: `.field` or `.field op expr`
+            TokenKind::Dot => self.parse_dot_shorthand(),
+
             // Pipe lambda: `|params| body` or `|| body` (zero-arg)
             TokenKind::VerticalBar => self.parse_pipe_lambda(),
 
@@ -553,6 +556,47 @@ impl Parser {
         }
 
         Ok(params)
+    }
+
+    // ── Dot Shorthand ────────────────────────────────────────────
+
+    /// Parse `.field` or `.field op expr` dot shorthand expression.
+    fn parse_dot_shorthand(&mut self) -> Result<Expr, ParseError> {
+        let start_span = self.current_span();
+        self.expect(&TokenKind::Dot)?;
+        let field = self.expect_identifier()?;
+
+        // Check for optional binary operator predicate
+        let predicate = match self.current_kind() {
+            TokenKind::EqualEqual => Some(BinOp::Eq),
+            TokenKind::BangEqual => Some(BinOp::NotEq),
+            TokenKind::LessThan => Some(BinOp::Lt),
+            TokenKind::GreaterThan => Some(BinOp::Gt),
+            TokenKind::LessEqual => Some(BinOp::LtEq),
+            TokenKind::GreaterEqual => Some(BinOp::GtEq),
+            TokenKind::AmpAmp => Some(BinOp::And),
+            TokenKind::PipePipe => Some(BinOp::Or),
+            TokenKind::Plus => Some(BinOp::Add),
+            TokenKind::Minus => Some(BinOp::Sub),
+            TokenKind::Star => Some(BinOp::Mul),
+            TokenKind::Slash => Some(BinOp::Div),
+            TokenKind::Percent => Some(BinOp::Mod),
+            _ => Option::None,
+        };
+
+        let predicate = if let Some(op) = predicate {
+            self.advance(); // consume the operator
+            let rhs = self.parse_primary_expr()?;
+            Some((op, Box::new(rhs)))
+        } else {
+            Option::None
+        };
+
+        let end_span = self.previous_span();
+        Ok(Expr {
+            kind: ExprKind::DotShorthand { field, predicate },
+            span: self.merge_spans(start_span, end_span),
+        })
     }
 
     // ── Constructors ─────────────────────────────────────────────

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -127,6 +127,7 @@ pub enum SyntaxKind {
     GROUPED_EXPR,
     ARRAY_EXPR,
     SPREAD_EXPR,
+    DOT_SHORTHAND,
     OK_EXPR,
     ERR_EXPR,
     SOME_EXPR,

--- a/tests/fixtures/dot_shorthand.fl
+++ b/tests/fixtures/dot_shorthand.fl
@@ -1,0 +1,5 @@
+const names = todos |> Array.map(.text)
+const active = todos |> Array.filter(.done == false)
+const byName = users |> Array.sortBy(.name)
+const found = items |> Array.filter(.id != id)
+const big = items |> Array.filter(.size > 100)

--- a/tests/snapshot_codegen.rs
+++ b/tests/snapshot_codegen.rs
@@ -97,3 +97,9 @@ fn snapshot_stdlib() {
     let output = compile_fixture("stdlib");
     insta::assert_snapshot!(output);
 }
+
+#[test]
+fn snapshot_dot_shorthand() {
+    let output = compile_fixture("dot_shorthand");
+    insta::assert_snapshot!(output);
+}

--- a/tests/snapshots/snapshot_codegen__snapshot_dot_shorthand.snap
+++ b/tests/snapshots/snapshot_codegen__snapshot_dot_shorthand.snap
@@ -1,0 +1,23 @@
+---
+source: tests/snapshot_codegen.rs
+expression: output
+---
+function __zenEq(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+  const ka = Object.keys(a as object);
+  const kb = Object.keys(b as object);
+  if (ka.length !== kb.length) return false;
+  return ka.every((k) => __zenEq((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]));
+}
+
+const names = todos.map((_x) => _x.text);
+
+const active = todos.filter((_x) => __zenEq(_x.done, false));
+
+const byName = [...users].sort((a, b) => ((_x) => _x.name)(a) - ((_x) => _x.name)(b));
+
+const found = items.filter((_x) => !__zenEq(_x.id, id));
+
+const big = items.filter((_x) => _x.size > 100);


### PR DESCRIPTION
closes #138

## Summary

- Implement `.field` dot shorthand syntax for implicit lambdas
- `.field` → `(_x) => _x.field` (property access)
- `.field == expr` → `(_x) => __zenEq(_x.field, expr)` (predicate with structural equality)
- `.field != expr` → `(_x) => !__zenEq(_x.field, expr)`
- `.field > expr` etc. → `(_x) => _x.field > expr`
- Fix CLI file extension check from `.zs` to `.fl`

Full pipeline: AST, parser, CST, lowerer, codegen, checker.

## Test plan
- [x] `cargo fmt` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `RUSTFLAGS="-D warnings" cargo test` — 333 tests pass
- [x] `floe check examples/todo-app/src/pages/home.fl` — no errors
- [x] `floe build examples/todo-app/src/pages/home.fl` — valid TypeScript output


🤖 Generated with [Claude Code](https://claude.com/claude-code)