### PR TITLE
[#163] Type checker should error on unknown types in type annotations

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -35,6 +35,8 @@ pub struct Checker {
     untrusted_imports: HashSet<String>,
     /// Whether we are currently inside a `try` expression.
     inside_try: bool,
+    /// Whether we are in the type registration pass (suppress unknown type errors).
+    registering_types: bool,
 }
 
 impl Default for Checker {
@@ -56,6 +58,7 @@ impl Checker {
             stdlib: StdlibRegistry::new(),
             untrusted_imports: HashSet::new(),
             inside_try: false,
+            registering_types: false,
         }
     }
 
@@ -71,11 +74,13 @@ impl Checker {
         program: &Program,
     ) -> (Vec<Diagnostic>, HashMap<String, String>) {
         // First pass: register all type declarations
+        self.registering_types = true;
         for item in &program.items {
             if let ItemKind::TypeDecl(decl) = &item.kind {
                 self.register_type_decl(decl);
             }
         }
+        self.registering_types = false;
 
         // Second pass: check all items
         for item in &program.items {
@@ -168,9 +173,33 @@ impl Checker {
         }
     }
 
+    /// Second-pass validation of type annotations within type declarations.
+    /// The first pass (register_type_decl) skips unknown type errors for forward references.
+    fn validate_type_decl_annotations(&mut self, decl: &TypeDecl) {
+        match &decl.def {
+            TypeDef::Record(fields) => {
+                for field in fields {
+                    self.resolve_type(&field.type_ann);
+                }
+            }
+            TypeDef::Union(variants) => {
+                for variant in variants {
+                    for field in &variant.fields {
+                        self.resolve_type(&field.type_ann);
+                    }
+                }
+            }
+            TypeDef::Alias(type_expr) => {
+                self.resolve_type(type_expr);
+            }
+        }
+    }
+
     fn resolve_type(&mut self, type_expr: &TypeExpr) -> Type {
         match &type_expr.kind {
-            TypeExprKind::Named { name, type_args } => self.resolve_named_type(name, type_args),
+            TypeExprKind::Named { name, type_args } => {
+                self.resolve_named_type(name, type_args, type_expr.span)
+            }
             TypeExprKind::Record(fields) => {
                 let field_types: Vec<_> = fields
                     .iter()
@@ -196,7 +225,7 @@ impl Checker {
         }
     }
 
-    fn resolve_named_type(&mut self, name: &str, type_args: &[TypeExpr]) -> Type {
+    fn resolve_named_type(&mut self, name: &str, type_args: &[TypeExpr], span: Span) -> Type {
         // Mark type names as used (e.g. "JSX" from "JSX.Element", or "User")
         let root = name.split('.').next().unwrap_or(name);
         self.used_names.insert(root.to_string());
@@ -256,7 +285,25 @@ impl Checker {
                     tag,
                 }
             }
-            _ => Type::Named(name.to_string()),
+            _ => {
+                // Check if this is a known user-defined type or imported name.
+                // Skip validation during type registration (forward references).
+                if self.registering_types
+                    || self.env.lookup_type(name).is_some()
+                    || self.env.lookup(name).is_some()
+                    || name.contains('.')
+                {
+                    Type::Named(name.to_string())
+                } else {
+                    self.diagnostics.push(
+                        Diagnostic::error(format!("unknown type `{name}`"), span)
+                            .with_label("not defined")
+                            .with_help("Check the spelling or import/define this type")
+                            .with_code("E002"),
+                    );
+                    Type::Unknown
+                }
+            }
         }
     }
 
@@ -267,7 +314,7 @@ impl Checker {
             ItemKind::Import(decl) => self.check_import(decl),
             ItemKind::Const(decl) => self.check_const(decl, item.span),
             ItemKind::Function(decl) => self.check_function(decl, item.span),
-            ItemKind::TypeDecl(_) => {} // already registered in first pass
+            ItemKind::TypeDecl(decl) => self.validate_type_decl_annotations(decl),
             ItemKind::Expr(expr) => {
                 let ty = self.check_expr(expr);
                 // Rule 5: No floating Results/Options

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -450,3 +450,71 @@ const _v = Valid(text: "hello")
     );
     assert!(!has_error(&diags, "E015"));
 }
+
+// ── Unknown type errors ────────────────────────────────────
+
+#[test]
+fn unknown_type_in_record_field() {
+    let diags = check(
+        r#"
+type Todo = {
+    id: string,
+    text: string,
+    done: asojSIDJA,
+}
+"#,
+    );
+    assert!(has_error_containing(&diags, "unknown type `asojSIDJA`"));
+}
+
+#[test]
+fn unknown_type_in_const_annotation() {
+    let diags = check("const x: Nonexistent = 42");
+    assert!(has_error_containing(&diags, "unknown type `Nonexistent`"));
+}
+
+#[test]
+fn unknown_type_in_function_param() {
+    let diags = check("fn foo(x: BadType) -> () {}");
+    assert!(has_error_containing(&diags, "unknown type `BadType`"));
+}
+
+#[test]
+fn unknown_type_in_function_return() {
+    let diags = check("fn foo() -> BadReturn { 42 }");
+    assert!(has_error_containing(&diags, "unknown type `BadReturn`"));
+}
+
+#[test]
+fn known_type_no_error() {
+    let diags = check(
+        r#"
+type User = { name: string }
+const _u: User = User(name: "Alice")
+"#,
+    );
+    assert!(!has_error_containing(&diags, "unknown type"));
+}
+
+#[test]
+fn builtin_types_no_error() {
+    let diags = check(
+        r#"
+const _a: number = 42
+const _b: string = "hi"
+const _c: bool = true
+"#,
+    );
+    assert!(!has_error_containing(&diags, "unknown type"));
+}
+
+#[test]
+fn forward_reference_in_union_no_error() {
+    let diags = check(
+        r#"
+type Container = { item: Item }
+type Item = { name: string }
+"#,
+    );
+    assert!(!has_error_containing(&diags, "unknown type `Item`"));
+}


### PR DESCRIPTION
closes #163

## Summary

- Added unknown type validation to `resolve_named_type` - types that aren't builtins, user-defined, imported, or dotted names (e.g. `JSX.Element`) now produce an `E002` error
- Forward references in type declarations are handled by deferring validation to the second pass (after all types are registered)
- Added `validate_type_decl_annotations` in the second pass to catch unknown types in record fields, union variants, and type aliases
- Returns `Type::Unknown` for unresolved types to prevent cascading errors

## Test plan

- [x] `unknown_type_in_record_field` - catches `asojSIDJA` in record field
- [x] `unknown_type_in_const_annotation` - catches `Nonexistent` in const type
- [x] `unknown_type_in_function_param` - catches `BadType` in function param
- [x] `unknown_type_in_function_return` - catches `BadReturn` in return type
- [x] `known_type_no_error` - user-defined types pass
- [x] `builtin_types_no_error` - `number`, `string`, `bool` pass
- [x] `forward_reference_in_union_no_error` - type defined after use passes
- [x] All 345 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)