### PR TITLE
[#174] Add docs for for-blocks, stdlib modules, and qualified variants

### DIFF
--- a/docs/site/src/content/docs/guide/for-blocks.md
+++ b/docs/site/src/content/docs/guide/for-blocks.md
@@ -1,0 +1,143 @@
+---
+title: For Blocks
+---
+
+`for` blocks let you group functions under a type. Think of them as methods without classes — `self` is an explicit parameter, not magic.
+
+## Basic Usage
+
+```floe
+type User = { name: string, age: number }
+
+for User {
+  fn display(self) -> string {
+    `${self.name} (${self.age})`
+  }
+
+  fn isAdult(self) -> boolean {
+    self.age >= 18
+  }
+
+  fn greet(self, greeting: string) -> string {
+    `${greeting}, ${self.name}!`
+  }
+}
+```
+
+The `self` parameter's type is inferred from the `for` block — no annotation needed.
+
+## Pipes
+
+For-block functions are pipe-friendly. `self` is always the first argument:
+
+```floe
+user |> display           // display(user)
+user |> greet("Hello")    // greet(user, "Hello")
+```
+
+This gives you method-call ergonomics without OOP:
+
+```floe
+const message = user
+  |> greet("Hi")
+  |> String.toUpper
+```
+
+## Generic Types
+
+For blocks work with generic types:
+
+```floe
+for Array<User> {
+  fn adults(self) -> Array<User> {
+    self |> Array.filter(.age >= 18)
+  }
+}
+
+users |> adults  // only adult users
+```
+
+## Real-World Example
+
+From the todo app — validating input strings and filtering todos:
+
+```floe
+for string {
+  export fn validate(self) -> Validation {
+    const trimmed = self |> trim
+    const len = trimmed |> String.length
+    match len {
+      0 -> Empty,
+      1 -> TooShort,
+      _ -> match len > 100 {
+        true -> TooLong,
+        false -> Valid(trimmed),
+      },
+    }
+  }
+}
+
+for Array<Todo> {
+  export fn filterBy(self, f: Filter) -> Array<Todo> {
+    match f {
+      All -> self,
+      Active -> self |> filter(.done == false),
+      Completed -> self |> filter(.done == true),
+    }
+  }
+
+  export fn remaining(self) -> number {
+    self
+      |> filter(.done == false)
+      |> length
+  }
+}
+```
+
+Use them naturally in components:
+
+```floe
+const visible = todos |> filterBy(filter)
+const remaining = todos |> remaining
+```
+
+## Export
+
+For-block functions can be exported just like regular functions:
+
+```floe
+for User {
+  export fn display(self) -> string {
+    `${self.name} (${self.age})`
+  }
+}
+```
+
+Importing a type automatically imports for-block functions defined in the same file. Cross-file for blocks require their own import.
+
+## Rules
+
+1. `self` is always the explicit first parameter — its type is inferred
+2. No `this`, no implicit context
+3. Multiple `for` blocks per type are allowed, even across files
+4. Compiles to standalone TypeScript functions (no classes)
+
+## What It Compiles To
+
+```floe
+for User {
+  fn display(self) -> string {
+    `${self.name} (${self.age})`
+  }
+}
+```
+
+Becomes:
+
+```typescript
+function display(self: User): string {
+  return `${self.name} (${self.age})`;
+}
+```
+
+No class wrappers, no prototype chains — just functions.

--- a/docs/site/src/content/docs/guide/types.md
+++ b/docs/site/src/content/docs/guide/types.md
@@ -44,6 +44,33 @@ type Color =
   | Custom(r: number, g: number, b: number)
 ```
 
+### Qualified Variants
+
+When a variant name could be ambiguous (e.g., multiple unions have a variant called `Active`), use qualified syntax:
+
+```floe
+type Filter = All | Active | Completed
+
+const f = Filter.All
+const g = Filter.Active
+```
+
+This is especially useful when passing variants as arguments:
+
+```floe
+setFilter(Filter.Completed)
+```
+
+Unambiguous variants can still be used without qualification:
+
+```floe
+match filter {
+  All -> showAll(),
+  Active -> showActive(),
+  Completed -> showCompleted(),
+}
+```
+
 ## Result and Option
 
 ### Result

--- a/docs/site/src/content/docs/reference/stdlib.md
+++ b/docs/site/src/content/docs/reference/stdlib.md
@@ -211,3 +211,88 @@ match Number.parse(input) {
 // Clamp to range
 const score = rawScore |> Number.clamp(0, 100)
 ```
+
+---
+
+## Console
+
+Output functions for debugging. These compile directly to their JavaScript `console` equivalents.
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `Console.log` | `T -> ()` | Log a value |
+| `Console.warn` | `T -> ()` | Log a warning |
+| `Console.error` | `T -> ()` | Log an error |
+| `Console.info` | `T -> ()` | Log info |
+| `Console.debug` | `T -> ()` | Log debug info |
+| `Console.time` | `string -> ()` | Start a named timer |
+| `Console.timeEnd` | `string -> ()` | End a named timer and print duration |
+
+### Examples
+
+```floe
+Console.log("hello")
+Console.warn("careful")
+
+// Timing
+Console.time("fetch")
+const data = try fetchData()?
+Console.timeEnd("fetch")
+```
+
+---
+
+## Math
+
+Standard math functions. Compile directly to JavaScript `Math` methods.
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `Math.floor` | `number -> number` | Round down |
+| `Math.ceil` | `number -> number` | Round up |
+| `Math.round` | `number -> number` | Round to nearest integer |
+| `Math.abs` | `number -> number` | Absolute value |
+| `Math.min` | `number, number -> number` | Smaller of two values |
+| `Math.max` | `number, number -> number` | Larger of two values |
+| `Math.pow` | `number, number -> number` | Exponentiation |
+| `Math.sqrt` | `number -> number` | Square root |
+| `Math.sign` | `number -> number` | Sign (-1, 0, or 1) |
+| `Math.trunc` | `number -> number` | Remove fractional digits |
+| `Math.log` | `number -> number` | Natural logarithm |
+| `Math.sin` | `number -> number` | Sine |
+| `Math.cos` | `number -> number` | Cosine |
+| `Math.tan` | `number -> number` | Tangent |
+
+### Examples
+
+```floe
+const rounded = 3.7 |> Math.floor    // 3
+const clamped = Math.max(0, Math.min(score, 100))
+const hyp = Math.sqrt(a * a + b * b)
+```
+
+---
+
+## JSON
+
+JSON serialization and parsing. `JSON.parse` returns `Result` instead of throwing.
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `JSON.stringify` | `T -> string` | Serialize a value to JSON |
+| `JSON.parse` | `string -> Result<T, ParseError>` | Parse JSON string safely |
+
+### Examples
+
+```floe
+const json = user |> JSON.stringify
+// '{"name":"Alice","age":30}'
+
+const parsed = json |> JSON.parse
+// Ok({name: "Alice", age: 30})
+
+match JSON.parse(input) {
+  Ok(data) -> process(data),
+  Err(e) -> Console.error(e),
+}
+```

--- a/docs/site/src/content/docs/reference/syntax.md
+++ b/docs/site/src/content/docs/reference/syntax.md
@@ -64,6 +64,22 @@ type UserId = Brand<string, "UserId">
 opaque type Email = string
 ```
 
+### For Block
+
+```floe
+for Type {
+  fn method(self) -> ReturnType {
+    body
+  }
+}
+
+for Array<User> {
+  fn adults(self) -> Array<User> {
+    self |> Array.filter(.age >= 18)
+  }
+}
+```
+
 ## Expressions
 
 ### Literals
@@ -126,13 +142,22 @@ Constructor(a: 1)  // record constructor
 Constructor(..existing, a: 2)  // spread + update
 ```
 
-### Built-in Constructors
+### Constructors
 
 ```floe
 Ok(value)     // Result success
 Err(error)    // Result failure
 Some(value)   // Option present
 None          // Option absent
+```
+
+### Qualified Variants
+
+```floe
+Filter.All              // zero-arg variant
+Filter.Active           // zero-arg variant
+Option.Some(value)      // variant with data
+Result.Ok(value)        // variant with data
 ```
 
 ### Anonymous Functions (Lambdas)
@@ -181,7 +206,7 @@ import { a, b, c } from "module"
 ```floe
 42                    // literal
 "hello"               // string literal
-true                  // booleanean literal
+true                  // boolean literal
 x                     // binding
 _                     // wildcard
 Ok(x)                 // variant


### PR DESCRIPTION
closes #174

## Summary
- New **for-blocks** guide page covering syntax, pipes, generics, exports, and codegen output
- Added **Console** (7 functions), **Math** (14 functions), and **JSON** (2 functions) to the stdlib reference
- Documented **qualified variant syntax** (e.g. `Filter.All`, `Option.Some(x)`) in both the types guide and syntax reference
- Added for-block declaration syntax to the syntax reference
- Fixed "booleanean" typo in syntax reference

## Test plan
- [x] Docs site builds successfully (`npx astro build` - 23 pages, no errors)
- [ ] Review for-blocks guide page for accuracy against design.md spec
- [ ] Verify stdlib entries match actual compiler implementation