### PR TITLE
[#176] Resolve cross-file imports in stdin build path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -103,8 +103,12 @@ fn cmd_build_stdin() -> Result<()> {
         anyhow::anyhow!("{rendered}")
     })?;
 
+    // Resolve imports from other .fl files (using FLOE_FILENAME for path context)
+    let file_path = Path::new(&filename);
+    let resolved = resolve::resolve_imports(file_path, &program);
+
     // Type check
-    let (check_diags, expr_types) = Checker::new().check_full(&program);
+    let (check_diags, expr_types) = Checker::with_imports(resolved).check_full(&program);
     let type_errors: Vec<_> = check_diags
         .iter()
         .filter(|d| d.severity == diagnostic::Severity::Error)


### PR DESCRIPTION
closes #176

## Summary

- The stdin build path (`floe build --emit-stdout -`, used by the Vite plugin) was using `Checker::new()` with no resolved imports, while the file-based path used `Checker::with_imports(resolved)`
- Now uses `FLOE_FILENAME` env var (already set by the Vite plugin) to resolve imports from other `.fl` files, so cross-file types, functions, and for-block extensions are properly recognized
- This was a one-line root cause: the stdin path simply wasn't calling `resolve_imports`

## Test plan

- [x] Verified `FLOE_FILENAME=examples/todo-app/src/pages/home.fl floe build --emit-stdout -` compiles successfully (was failing with 9+ E002 errors)
- [x] All 368 existing tests pass
- [x] clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)