### PR TITLE
[#179] Pipe operator skips type checking for stdlib-resolved functions

### DIFF
--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -753,12 +753,47 @@ impl Checker {
                 self.used_names.insert(name.to_string());
                 let stdlib_fn = self.stdlib.lookup(m, name).unwrap();
                 let ret = stdlib_fn.return_type.clone();
+                // Validate piped value against first parameter
+                if let Some(first_param) = stdlib_fn.params.first()
+                    && !self.types_compatible(first_param, left_ty)
+                {
+                    self.diagnostics.push(
+                        Diagnostic::error(
+                            format!(
+                                "argument 1 to `{m}.{name}`: expected `{}`, found `{}`",
+                                first_param.display_name(),
+                                left_ty.display_name()
+                            ),
+                            right.span,
+                        )
+                        .with_label(format!("expected `{}`", first_param.display_name()))
+                        .with_code("E001"),
+                    );
+                }
                 self.check_pipe_right_args(right);
                 return ret;
             } else if !fallback_matches.is_empty() {
+                let stdlib_fn = fallback_matches[0];
+                // Validate piped value against first parameter
+                if let Some(first_param) = stdlib_fn.params.first()
+                    && !self.types_compatible(first_param, left_ty)
+                {
+                    self.diagnostics.push(
+                        Diagnostic::error(
+                            format!(
+                                "argument 1 to `{name}`: expected `{}`, found `{}`",
+                                first_param.display_name(),
+                                left_ty.display_name()
+                            ),
+                            right.span,
+                        )
+                        .with_label(format!("expected `{}`", first_param.display_name()))
+                        .with_code("E001"),
+                    );
+                }
                 // Found via name-based fallback (unknown left type)
                 self.used_names.insert(name.to_string());
-                let ret = fallback_matches[0].return_type.clone();
+                let ret = stdlib_fn.return_type.clone();
                 self.check_pipe_right_args(right);
                 return ret;
             }

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -694,3 +694,52 @@ const _r = "hello" |> double
         "expected `number`, found `string`"
     ));
 }
+
+#[test]
+fn pipe_stdlib_wrong_type_via_type_directed() {
+    // `5 |> trim` should error: trim expects string, got number
+    // This goes through type-directed resolution (Number -> Number module, no trim found)
+    // then falls back to name-based lookup (finds String.trim)
+    let diags = check(
+        r#"
+const _r = 5 |> trim
+"#,
+    );
+    assert!(has_error_containing(
+        &diags,
+        "expected `string`, found `number`"
+    ));
+}
+
+#[test]
+fn pipe_stdlib_wrong_type_number_to_sort() {
+    // `5 |> sort` should error: sort expects Array<T>, got number
+    let diags = check(
+        r#"
+const _r = 5 |> sort
+"#,
+    );
+    assert!(has_error_containing(&diags, "found `number`"));
+}
+
+#[test]
+fn pipe_stdlib_correct_type() {
+    // `"hello" |> trim` should NOT error
+    let diags = check(
+        r#"
+const _r = "hello" |> trim
+"#,
+    );
+    assert!(!has_error(&diags, "E001"));
+}
+
+#[test]
+fn pipe_stdlib_correct_array_type() {
+    // `[1, 2, 3] |> sort` should NOT error
+    let diags = check(
+        r#"
+const _r = [1, 2, 3] |> sort
+"#,
+    );
+    assert!(!has_error(&diags, "E001"));
+}


### PR DESCRIPTION
closes #179

## Summary
- The stdlib resolution path in `check_pipe_right` returned the function's return type without validating the piped value's type against the first parameter
- Now both the type-directed and name-based fallback paths validate that the piped type is compatible with the stdlib function's first parameter
- For example, `5 |> trim` now correctly errors with "expected `string`, found `number`"

## Test plan
- [x] Added `pipe_stdlib_wrong_type_via_type_directed` test (number piped to string function)
- [x] Added `pipe_stdlib_wrong_type_number_to_sort` test (number piped to array function)
- [x] Added `pipe_stdlib_correct_type` test (string piped to trim - no error)
- [x] Added `pipe_stdlib_correct_array_type` test (array piped to sort - no error)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)