### PR TITLE
[#168] LSP hover for stdlib modules and bare pipe functions

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -1,6 +1,7 @@
 mod completion;
 mod handlers;
 mod resolution;
+mod stdlib_hover;
 mod symbols;
 
 #[cfg(test)]

--- a/src/lsp/handlers.rs
+++ b/src/lsp/handlers.rs
@@ -6,6 +6,7 @@ use tower_lsp::lsp_types::*;
 
 use super::completion::is_pipe_context;
 use super::completion::resolve_piped_type;
+use super::stdlib_hover;
 use super::symbols::symbol_kind_to_completion;
 use super::{
     BUILTINS, FloeLsp, KEYWORDS, is_word_char, offset_to_position, offset_to_range,
@@ -98,6 +99,28 @@ impl LanguageServer for FloeLsp {
                 contents: HoverContents::Markup(MarkupContent {
                     kind: MarkupKind::Markdown,
                     value: format!("```floe\n{}\n```", sym.detail),
+                }),
+                range: None,
+            }));
+        }
+
+        // Check stdlib module names (Array, String, Option, etc.)
+        if let Some(hover_text) = stdlib_hover::hover_stdlib_module(word) {
+            return Ok(Some(Hover {
+                contents: HoverContents::Markup(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value: hover_text,
+                }),
+                range: None,
+            }));
+        }
+
+        // Check bare stdlib function names (for pipe context)
+        if let Some(hover_text) = stdlib_hover::hover_stdlib_function(word) {
+            return Ok(Some(Hover {
+                contents: HoverContents::Markup(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value: hover_text,
                 }),
                 range: None,
             }));

--- a/src/lsp/stdlib_hover.rs
+++ b/src/lsp/stdlib_hover.rs
@@ -1,0 +1,278 @@
+//! Hover support for stdlib modules and functions.
+//!
+//! Provides hover text for:
+//! - Stdlib module names (Array, String, Option, etc.) showing available functions
+//! - Bare stdlib function names (sort, map, trim, etc.) showing signature and module
+
+use crate::stdlib::StdlibRegistry;
+
+/// Pretty-print a type variable index as a letter (0 -> T, 1 -> U, 2 -> V, ...).
+fn type_var_name(index: usize) -> &'static str {
+    match index {
+        0 => "T",
+        1 => "U",
+        2 => "V",
+        3 => "W",
+        _ => "T",
+    }
+}
+
+/// Format a checker Type for hover display, using readable type variable names.
+fn format_type(ty: &crate::checker::Type) -> String {
+    use crate::checker::Type;
+    match ty {
+        Type::Number => "number".to_string(),
+        Type::String => "string".to_string(),
+        Type::Bool => "boolean".to_string(),
+        Type::Undefined => "undefined".to_string(),
+        Type::Unit => "()".to_string(),
+        Type::Unknown => "unknown".to_string(),
+        Type::Named(n) => n.clone(),
+        Type::Var(id) => type_var_name(*id).to_string(),
+        Type::Array(inner) => format!("Array<{}>", format_type(inner)),
+        Type::Option(inner) => format!("Option<{}>", format_type(inner)),
+        Type::Result { ok, err } => {
+            format!("Result<{}, {}>", format_type(ok), format_type(err))
+        }
+        Type::Tuple(types) => {
+            let t: Vec<_> = types.iter().map(format_type).collect();
+            format!("[{}]", t.join(", "))
+        }
+        Type::Function {
+            params,
+            return_type,
+        } => {
+            let p: Vec<_> = params.iter().map(format_type).collect();
+            format!("({}) -> {}", p.join(", "), format_type(return_type))
+        }
+        Type::Record(fields) => {
+            let f: Vec<_> = fields
+                .iter()
+                .map(|(n, t)| format!("{n}: {}", format_type(t)))
+                .collect();
+            format!("{{ {} }}", f.join(", "))
+        }
+        Type::Brand { tag, .. } => tag.clone(),
+        Type::Opaque { name, .. } => name.clone(),
+        Type::Union { name, .. } => name.clone(),
+    }
+}
+
+/// Format a stdlib function signature for display.
+fn format_fn_signature(f: &crate::stdlib::StdlibFn) -> String {
+    let params: Vec<String> = f.params.iter().map(format_type).collect();
+    let ret = format_type(&f.return_type);
+    format!("{}.{}({}) -> {}", f.module, f.name, params.join(", "), ret)
+}
+
+/// Generate hover text for a stdlib module name (Array, String, Option, etc.).
+/// Returns None if the word is not a stdlib module.
+pub(super) fn hover_stdlib_module(word: &str) -> Option<String> {
+    let registry = StdlibRegistry::new();
+    if !registry.is_module(word) {
+        return None;
+    }
+
+    let functions = registry.module_functions(word);
+    if functions.is_empty() {
+        return None;
+    }
+
+    let mut lines = Vec::new();
+    lines.push(format!("```floe\nmodule {word}\n```"));
+    lines.push("**Available functions:**".to_string());
+    for f in &functions {
+        let params: Vec<String> = f.params.iter().map(format_type).collect();
+        let ret = format_type(&f.return_type);
+        lines.push(format!("- `{}({}) -> {}`", f.name, params.join(", "), ret));
+    }
+
+    Some(lines.join("\n"))
+}
+
+/// Generate hover text for a bare stdlib function name (sort, map, trim, etc.).
+/// Returns None if the word is not a stdlib function.
+pub(super) fn hover_stdlib_function(word: &str) -> Option<String> {
+    let registry = StdlibRegistry::new();
+    let matches = registry.lookup_by_name(word);
+    if matches.is_empty() {
+        return None;
+    }
+
+    let mut lines = Vec::new();
+    for f in &matches {
+        lines.push(format!("```floe\n{}\n```", format_fn_signature(f)));
+    }
+
+    if matches.len() == 1 {
+        lines.push(format!("Stdlib function from `{}`.", matches[0].module));
+    } else {
+        let modules: Vec<&str> = matches.iter().map(|f| f.module).collect();
+        lines.push(format!(
+            "Stdlib function available in: {}.",
+            modules
+                .iter()
+                .map(|m| format!("`{m}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+
+    Some(lines.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hover_array_module() {
+        let result = hover_stdlib_module("Array");
+        assert!(result.is_some());
+        let text = result.unwrap();
+        assert!(text.contains("module Array"));
+        assert!(text.contains("sort"));
+        assert!(text.contains("map"));
+        assert!(text.contains("filter"));
+    }
+
+    #[test]
+    fn hover_string_module() {
+        let result = hover_stdlib_module("String");
+        assert!(result.is_some());
+        let text = result.unwrap();
+        assert!(text.contains("module String"));
+        assert!(text.contains("trim"));
+        assert!(text.contains("split"));
+    }
+
+    #[test]
+    fn hover_option_module() {
+        let result = hover_stdlib_module("Option");
+        assert!(result.is_some());
+        let text = result.unwrap();
+        assert!(text.contains("module Option"));
+        assert!(text.contains("unwrapOr"));
+        assert!(text.contains("isSome"));
+    }
+
+    #[test]
+    fn hover_result_module() {
+        let result = hover_stdlib_module("Result");
+        assert!(result.is_some());
+        let text = result.unwrap();
+        assert!(text.contains("module Result"));
+        assert!(text.contains("map"));
+        assert!(text.contains("isOk"));
+    }
+
+    #[test]
+    fn hover_console_module() {
+        let result = hover_stdlib_module("Console");
+        assert!(result.is_some());
+        let text = result.unwrap();
+        assert!(text.contains("module Console"));
+        assert!(text.contains("log"));
+    }
+
+    #[test]
+    fn hover_math_module() {
+        let result = hover_stdlib_module("Math");
+        assert!(result.is_some());
+        let text = result.unwrap();
+        assert!(text.contains("module Math"));
+        assert!(text.contains("floor"));
+        assert!(text.contains("sqrt"));
+    }
+
+    #[test]
+    fn hover_json_module() {
+        let result = hover_stdlib_module("JSON");
+        assert!(result.is_some());
+        let text = result.unwrap();
+        assert!(text.contains("module JSON"));
+        assert!(text.contains("stringify"));
+        assert!(text.contains("parse"));
+    }
+
+    #[test]
+    fn hover_number_module() {
+        let result = hover_stdlib_module("Number");
+        assert!(result.is_some());
+        let text = result.unwrap();
+        assert!(text.contains("module Number"));
+        assert!(text.contains("parse"));
+        assert!(text.contains("clamp"));
+    }
+
+    #[test]
+    fn hover_non_module() {
+        assert!(hover_stdlib_module("Foo").is_none());
+        assert!(hover_stdlib_module("const").is_none());
+    }
+
+    #[test]
+    fn hover_bare_sort_function() {
+        let result = hover_stdlib_function("sort");
+        assert!(result.is_some());
+        let text = result.unwrap();
+        assert!(text.contains("Array.sort"));
+        assert!(text.contains("Array<T>"));
+        assert!(text.contains("Stdlib function from `Array`"));
+    }
+
+    #[test]
+    fn hover_bare_trim_function() {
+        let result = hover_stdlib_function("trim");
+        assert!(result.is_some());
+        let text = result.unwrap();
+        assert!(text.contains("String.trim"));
+        assert!(text.contains("string"));
+        assert!(text.contains("Stdlib function from `String`"));
+    }
+
+    #[test]
+    fn hover_bare_map_function_multiple_modules() {
+        let result = hover_stdlib_function("map");
+        assert!(result.is_some());
+        let text = result.unwrap();
+        // map exists in Array, Option, and Result
+        assert!(text.contains("Array.map"));
+        assert!(text.contains("Option.map"));
+        assert!(text.contains("Result.map"));
+        assert!(text.contains("available in:"));
+    }
+
+    #[test]
+    fn hover_bare_unwrap_or_function() {
+        let result = hover_stdlib_function("unwrapOr");
+        assert!(result.is_some());
+        let text = result.unwrap();
+        assert!(text.contains("unwrapOr"));
+    }
+
+    #[test]
+    fn hover_bare_nonexistent_function() {
+        assert!(hover_stdlib_function("nonexistent").is_none());
+        assert!(hover_stdlib_function("const").is_none());
+    }
+
+    #[test]
+    fn hover_bare_floor_function() {
+        let result = hover_stdlib_function("floor");
+        assert!(result.is_some());
+        let text = result.unwrap();
+        assert!(text.contains("Math.floor"));
+        assert!(text.contains("number"));
+        assert!(text.contains("Stdlib function from `Math`"));
+    }
+
+    #[test]
+    fn hover_bare_log_function() {
+        let result = hover_stdlib_function("log");
+        assert!(result.is_some());
+        let text = result.unwrap();
+        // log exists in Console and Math
+        assert!(text.contains("Console.log") || text.contains("Math.log"));
+    }
+}


### PR DESCRIPTION
closes #168
closes #169

## Summary

- Hovering over stdlib module names (`Array`, `String`, `Option`, `Result`, `Number`, `Console`, `Math`, `JSON`) now shows all available functions with signatures
- Hovering over bare stdlib function names (`sort`, `map`, `trim`, `unwrapOr`, etc.) now shows the function signature and which module it belongs to
- Functions that exist in multiple modules (e.g. `map` in Array/Option/Result) show all signatures

## Test plan

- [x] 16 unit tests for stdlib hover (module hover + function hover)
- [x] All 384 existing tests pass
- [x] `cargo fmt`, `cargo clippy -- -D warnings`, `RUSTFLAGS="-D warnings" cargo test` all pass