### PR TITLE
[#190] Enforce no shadowing across all scopes

### DIFF
--- a/examples/todo-app/src/pages/home.fl
+++ b/examples/todo-app/src/pages/home.fl
@@ -10,7 +10,7 @@ export fn HomePage() -> JSX.Element {
     const [error, setError] = useState("")
 
     const visible = todos |> filterBy(filter)
-    const remaining = todos |> remaining
+    const remainingCount = todos |> remaining
 
     fn handleAdd() {
         match input |> validate {
@@ -128,7 +128,7 @@ export fn HomePage() -> JSX.Element {
         </ul>
 
         <p className="mt-6 text-sm text-zinc-500">
-            {`${remaining} item(s) remaining`}
+            {`${remainingCount} item(s) remaining`}
         </p>
     </div>
 }

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -224,13 +224,16 @@ impl Checker {
         Type::Var(id)
     }
 
-    /// Emit an error if `name` is already defined in the current scope.
+    /// Emit an error if `name` is already defined in any scope (no shadowing allowed).
     fn check_no_redefinition(&mut self, name: &str, span: Span) {
-        if self.env.is_defined_in_current_scope(name) {
+        if self.env.is_defined_in_any_scope(name) {
             self.diagnostics.push(
-                Diagnostic::error(format!("`{name}` is already defined in this scope"), span)
-                    .with_label("already defined")
-                    .with_code("E016"),
+                Diagnostic::error(
+                    format!("`{name}` is already defined and cannot be shadowed"),
+                    span,
+                )
+                .with_label("already defined")
+                .with_code("E016"),
             );
         }
     }
@@ -674,8 +677,11 @@ impl Checker {
 
         self.env.push_scope();
 
-        // Define parameters
+        // Define parameters (check for shadowing, but skip `self`)
         for (param, ty) in decl.params.iter().zip(param_types.iter()) {
+            if param.name != "self" {
+                self.check_no_redefinition(&param.name, span);
+            }
             self.env.define(&param.name, ty.clone());
         }
 

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -825,13 +825,77 @@ fn foo() -> string { "hi" }
 }
 
 #[test]
-fn shadow_allowed_in_inner_scope() {
-    // Shadowing in an inner scope (e.g., function params) should be OK
+fn shadow_not_allowed_in_inner_scope() {
+    // No shadowing ever — even function params can't shadow outer names
     let diags = check(
         r#"
 const x = 5
 fn double(x: number) -> number { x * 2 }
 "#,
     );
-    assert!(!has_error_containing(&diags, "already defined"));
+    assert!(has_error_containing(&diags, "already defined"));
+}
+
+#[test]
+fn shadow_inner_scope_const_shadows_for_block_fn() {
+    // A const INSIDE a function body shadowing a for-block function should error
+    let diags = check(
+        r#"
+type Todo = { text: string, done: boolean }
+for Array<Todo> {
+    export fn remaining(self) -> number { 0 }
+}
+fn test() -> number {
+    const remaining = 5
+    remaining
+}
+"#,
+    );
+    assert!(
+        has_error_containing(&diags, "already defined"),
+        "inner-scope const should not shadow for-block fn, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn shadow_inner_scope_const_shadows_outer_const() {
+    // A const inside a function body shadowing an outer const should error
+    let diags = check(
+        r#"
+const x = 5
+fn test() -> number {
+    const x = 10
+    x
+}
+"#,
+    );
+    assert!(
+        has_error_containing(&diags, "already defined"),
+        "inner-scope const should not shadow outer const, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn for_block_pipe_then_shadow_errors() {
+    // Real-world case: piping into for-block fn then shadowing its name
+    let diags = check(
+        r#"
+type Todo = { text: string, done: boolean }
+for Array<Todo> {
+    export fn remaining(self) -> number { 0 }
+}
+fn test() -> number {
+    const _todos: Array<Todo> = []
+    const remaining = _todos |> remaining
+    remaining
+}
+"#,
+    );
+    assert!(
+        has_error_containing(&diags, "already defined"),
+        "should error on shadowing for-block fn, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
 }

--- a/src/checker/types.rs
+++ b/src/checker/types.rs
@@ -151,11 +151,9 @@ impl TypeEnv {
         }
     }
 
-    /// Check if a name is already defined in the current scope (not parent scopes).
-    pub(crate) fn is_defined_in_current_scope(&self, name: &str) -> bool {
-        self.scopes
-            .last()
-            .is_some_and(|scope| scope.contains_key(name))
+    /// Check if a name is already defined in any scope.
+    pub(crate) fn is_defined_in_any_scope(&self, name: &str) -> bool {
+        self.scopes.iter().any(|scope| scope.contains_key(name))
     }
 
     pub(crate) fn lookup(&self, name: &str) -> Option<&Type> {


### PR DESCRIPTION
closes #190

## Summary
- Variable shadowing is now an error everywhere, not just within the same scope
- Consts inside function bodies cannot shadow for-block functions, outer consts, or any name from an enclosing scope
- Function params also cannot shadow outer names (except `self`)
- Updated todo-app: `remaining` -> `remainingCount` to avoid shadowing the for-block function

## Test plan
- [x] 9 shadowing tests covering same-scope, inner-scope, function params, and for-block conflicts
- [x] Example app passes `floe check`
- [x] All 453 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)