### PR TITLE
[#199] Add tap function for pipeline debugging

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -76,6 +76,7 @@ All four of TypeScript's `?` uses (`?.`, `??`, `?:`, `? :`) are removed. `?` now
 | Default values | `fn f(x: number = 10)` | caller can omit, compiler fills in |
 | Structural equality | `==` on objects compares by value | deep equality check |
 | Unit type | `()` as return type, usable in generics | `undefined` / `void` in TS |
+| tap | `x \|> tap(Console.log)` | IIFE: calls fn, returns value unchanged |
 | Immutable sort | `Array.sort` returns new array | sorted copy, no mutation |
 | Strict parse | `Number.parse("123")` returns `Result` | no silent `NaN` or partial parse |
 
@@ -128,6 +129,12 @@ todos |> Array.map(.text)              // map(todos, x => x.text)
 // Pipe lambdas — |x| for when you need a named param
 todos |> Array.map(|t| Todo(..t, done: true))
 items |> Array.reduce(|acc, x| acc + x.price, 0)
+
+// tap — call a function for side effects, pass value through
+orders
+  |> Array.filter(.active)
+  |> tap(Console.log)              // logs filtered orders, passes through
+  |> Array.map(.total)
 
 // Pipes in JSX
 <ul>

--- a/docs/site/src/content/docs/guide/pipes.md
+++ b/docs/site/src/content/docs/guide/pipes.md
@@ -77,6 +77,20 @@ const total = orders
   |> reduce(|sum, n| sum + n, 0, _)
 ```
 
+## Debugging with `tap`
+
+Need to inspect a value mid-pipeline without breaking the chain? Use `tap`:
+
+```floe
+const result = users
+  |> Array.filter(.active)
+  |> tap(Console.log)          // logs filtered users, passes them through
+  |> Array.map(.name)
+  |> Array.sort
+```
+
+`tap` calls the function you give it (for side effects like logging), then returns the original value unchanged. It compiles to an IIFE that calls the function and returns the value.
+
 ## When to Use Pipes
 
 Pipes shine when you have a sequence of transformations. They replace:

--- a/docs/site/src/content/docs/reference/stdlib.md
+++ b/docs/site/src/content/docs/reference/stdlib.md
@@ -296,3 +296,38 @@ match JSON.parse(input) {
   Err(e) -> Console.error(e),
 }
 ```
+
+---
+
+## Pipe
+
+Utility functions for pipeline debugging and control flow.
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `tap` | `T, (T -> ()) -> T` | Call a function for side effects, return value unchanged |
+
+### Examples
+
+```floe
+// Debug a pipeline without breaking the chain
+const result = orders
+  |> Array.filter(.active)
+  |> tap(Console.log)         // logs filtered orders, passes them through
+  |> Array.map(.total)
+  |> Array.reduce(|sum, n| sum + n, 0)
+
+// Use a lambda for custom logging
+const processed = data
+  |> transform
+  |> tap(|x| Console.log("after transform:", x))
+  |> validate
+
+// Works with any type
+const name = "  Alice  "
+  |> String.trim
+  |> tap(Console.log)         // logs "Alice"
+  |> String.toUpper           // "ALICE"
+```
+
+`tap` is the pipeline equivalent of a `console.log` that doesn't interrupt the flow. The function you pass receives the value but its return is ignored -- the original value passes through unchanged.

--- a/editors/vscode/snippets/floe.json
+++ b/editors/vscode/snippets/floe.json
@@ -110,5 +110,12 @@
       "opaque type ${1:Name} = ${2:BaseType}"
     ],
     "description": "Opaque type"
+  },
+  "Tap Debug": {
+    "prefix": "tap",
+    "body": [
+      "tap(${1:Console.log})"
+    ],
+    "description": "Tap for pipeline debugging"
   }
 }

--- a/examples/todo-app/src/todo.fl
+++ b/examples/todo-app/src/todo.fl
@@ -27,6 +27,7 @@ for Array<Todo> {
     export fn remaining(self) -> number {
         self
             |> filter(.done == false)
+            |> tap(|active| Console.log("active todos:", active))
             |> length
     }
 }

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -1256,3 +1256,35 @@ const _y = age
         assert_eq!(age_ty, "number", "age should be number, got: {age_ty}");
     }
 }
+
+// ── Pipe: tap ───────────────────────────────────────────────
+
+#[test]
+fn pipe_tap_no_errors() {
+    // tap with a function should type-check without errors
+    let diags = check(
+        r#"
+const _x = [1, 2, 3] |> tap(Console.log)
+"#,
+    );
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(errors.is_empty(), "expected no errors, got: {errors:?}");
+}
+
+#[test]
+fn pipe_tap_qualified_no_errors() {
+    // Pipe.tap should also work when fully qualified
+    let diags = check(
+        r#"
+const _x = [1, 2, 3] |> Pipe.tap(Console.log)
+"#,
+    );
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(errors.is_empty(), "expected no errors, got: {errors:?}");
+}

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -636,3 +636,27 @@ fn union_variant_dot_access_non_union_passthrough() {
     let result = emit("const _x = foo.bar");
     assert!(result.contains("foo.bar"));
 }
+
+// ── Pipe: tap ───────────────────────────────────────────────
+
+#[test]
+fn stdlib_pipe_tap_qualified() {
+    let result = emit("[1, 2, 3] |> Pipe.tap(Console.log)");
+    // Console.log gets its own codegen template, so it's expanded inside tap's IIFE
+    assert!(result.contains("const _v"), "output: {result}");
+    assert!(result.contains("return _v"), "output: {result}");
+}
+
+#[test]
+fn stdlib_tap_direct_call() {
+    let result = emit("Pipe.tap([1, 2, 3], Console.log)");
+    assert!(result.contains("const _v"), "output: {result}");
+    assert!(result.contains("return _v"), "output: {result}");
+}
+
+#[test]
+fn stdlib_pipe_tap_with_lambda() {
+    let result = emit("[1, 2, 3] |> Pipe.tap(|x| Console.log(x))");
+    assert!(result.contains("const _v"), "output: {result}");
+    assert!(result.contains("return _v"), "output: {result}");
+}

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -637,6 +637,14 @@ fn build_stdlib() -> Vec<StdlibFn> {
             return_type: Type::Number,
             codegen: "Math.tan($0)",
         },
+        // ── Pipe Utilities ────────────────────────────────────────
+        StdlibFn {
+            module: "Pipe",
+            name: "tap",
+            params: vec![t.clone(), fun(vec![t.clone()], Type::Unit)],
+            return_type: t.clone(),
+            codegen: "(() => { const _v = $0; ($1)(_v); return _v; })()",
+        },
         // ── JSON ───────────────────────────────────────────────
         StdlibFn {
             module: "JSON",
@@ -691,6 +699,7 @@ mod tests {
         assert!(reg.is_module("Console"));
         assert!(reg.is_module("Math"));
         assert!(reg.is_module("JSON"));
+        assert!(reg.is_module("Pipe"));
         assert!(!reg.is_module("Foo"));
     }
 
@@ -719,6 +728,13 @@ mod tests {
         let reg = StdlibRegistry::new();
         let f = reg.lookup("Math", "floor").unwrap();
         assert_eq!(f.codegen, "Math.floor($0)");
+    }
+
+    #[test]
+    fn lookup_pipe_tap() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Pipe", "tap").unwrap();
+        assert!(f.codegen.contains("return _v"));
     }
 
     #[test]


### PR DESCRIPTION
closes #199

## Summary

- Add `Pipe.tap` stdlib function: `<T>(value: T, fn: (T) -> ()) -> T`
- Calls the given function for side effects, returns the value unchanged
- Works as bare `tap(Console.log)` in pipes via type-directed resolution
- Codegen emits an IIFE: `(() => { const _v = $0; ($1)(_v); return _v; })()`

## Changes

- `src/stdlib.rs` - Add `Pipe` module with `tap` function
- `src/checker/tests.rs` - Add checker tests for tap in pipes
- `src/codegen/tests.rs` - Add codegen tests for tap emission
- `docs/design.md` - Add tap to syntax table and pipe examples
- `docs/site/` - Add Pipe section to stdlib reference, debugging section to pipes guide
- `editors/vscode/snippets/floe.json` - Add tap snippet
- `examples/todo-app/src/todo.fl` - Use tap in `remaining` function

## Test plan

- [x] `cargo fmt` - no formatting issues
- [x] `cargo clippy -- -D warnings` - no warnings
- [x] `RUSTFLAGS="-D warnings" cargo test` - all 466 tests pass
- [x] `floe check examples/todo-app/src/` - 5 files checked, no errors


🤖 Generated with [Claude Code](https://claude.com/claude-code)