### PR TITLE
[#203] Infer return type for unannotated functions, fix unit type display

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -766,6 +766,19 @@ impl Checker {
         // Check body
         let body_type = self.check_expr(&decl.body);
 
+        // When no return type annotation, infer from body and update the function type
+        if decl.return_type.is_none() && !matches!(body_type, Type::Var(_) | Type::Unknown) {
+            let fn_type = Type::Function {
+                params: param_types.clone(),
+                return_type: Box::new(body_type.clone()),
+            };
+            // Update in the name_types map for hover display
+            self.name_types
+                .insert(decl.name.clone(), fn_type.display_name());
+            // Mark for updating in outer scope after pop
+            self.env.define_in_parent_scope(&decl.name, fn_type);
+        }
+
         // Check return type compatibility
         if let Some(ref declared_return) = decl.return_type {
             let resolved = self.resolve_type(declared_return);

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -1224,6 +1224,251 @@ const _x = if true { 1 } else { 2 }
 // ── 6. Object destructuring ───────────────────────────────
 
 #[test]
+fn unit_type_from_void_match() {
+    // A match where all arms return unit should infer () not unknown
+    let program = crate::parser::Parser::new(
+        r#"
+fn log(msg: string) { Console.log(msg) }
+const _hello = match true {
+    true -> log("hi"),
+    false -> log("bye"),
+}
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+    let (_diags, types) = Checker::new().check_with_types(&program);
+    if let Some(ty) = types.get("_hello") {
+        assert_eq!(ty, "()", "void match should infer (), got: {ty}");
+    } else {
+        panic!("_hello should be in type map");
+    }
+}
+
+#[test]
+fn unit_type_from_void_function_call() {
+    // Calling a function that returns nothing should give ()
+    let program = crate::parser::Parser::new(
+        r#"
+fn log(msg: string) { Console.log(msg) }
+const _result = log("test")
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+    let (_diags, types) = Checker::new().check_with_types(&program);
+    if let Some(ty) = types.get("_result") {
+        assert_eq!(ty, "()", "void function call should give (), got: {ty}");
+    } else {
+        panic!("_result should be in type map");
+    }
+}
+
+#[test]
+fn calling_named_function_type_returns_its_return_type() {
+    // Dispatch<SetStateAction<T>> is a function type alias from React.
+    // When we call setTodos(...), the checker sees Named("Dispatch<...>")
+    // and returns Unknown. It should return the function's return type.
+    //
+    // Simulate: setTodos has type (Array<Todo>) -> ()
+    // (which is what Dispatch<SetStateAction<Array<Todo>>> resolves to)
+    let program = crate::parser::Parser::new(
+        r#"
+type Todo = { text: string }
+fn setTodos(value: Array<Todo>) -> () { () }
+fn handler() {
+    setTodos([])
+}
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+    let (_diags, types) = Checker::new().check_with_types(&program);
+    eprintln!("types: {:?}", types);
+    // handler calls setTodos which returns () — handler should infer ()
+    if let Some(ty) = types.get("handler") {
+        assert!(
+            ty.contains("()"),
+            "handler should infer () from calling void function, got: {ty}"
+        );
+    } else {
+        panic!("handler should be in types");
+    }
+}
+
+#[test]
+fn dispatch_generic_converts_to_function() {
+    // The REAL tsgo output: Dispatch<SetStateAction<Todo[]>> should become a function type
+    use crate::interop::{DtsExport, TsType};
+
+    let program = crate::parser::Parser::new(
+        r#"
+import trusted { useState } from "react"
+type Todo = { text: string }
+const [todos, setTodos] = useState<Array<Todo>>([])
+fn handler() {
+    setTodos([])
+}
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+
+    // Simulate what tsgo ACTUALLY returns: Dispatch<SetStateAction<Todo[]>>
+    let probe_export = DtsExport {
+        name: "__probe_todos_setTodos".to_string(),
+        ts_type: TsType::Tuple(vec![
+            TsType::Array(Box::new(TsType::Named("Todo".to_string()))),
+            TsType::Generic {
+                name: "Dispatch".to_string(),
+                args: vec![TsType::Generic {
+                    name: "SetStateAction".to_string(),
+                    args: vec![TsType::Array(Box::new(TsType::Named("Todo".to_string())))],
+                }],
+            },
+        ]),
+    };
+    let use_state_export = DtsExport {
+        name: "useState".to_string(),
+        ts_type: TsType::Function {
+            params: vec![TsType::Named("S".to_string())],
+            return_type: Box::new(TsType::Tuple(vec![
+                TsType::Named("S".to_string()),
+                TsType::Named("S".to_string()),
+            ])),
+        },
+    };
+    let mut dts_imports = std::collections::HashMap::new();
+    dts_imports.insert("react".to_string(), vec![use_state_export, probe_export]);
+
+    let checker = Checker::with_all_imports(std::collections::HashMap::new(), dts_imports);
+    let (_diags, types) = checker.check_with_types(&program);
+    eprintln!("types (real dispatch): {:?}", types);
+
+    // setTodos should be a function, NOT Named("Dispatch<...>")
+    if let Some(ty) = types.get("setTodos") {
+        assert!(
+            ty.contains("->"),
+            "setTodos with Dispatch<SetStateAction> should be a function, got: {ty}"
+        );
+    } else {
+        panic!("setTodos should be in types");
+    }
+
+    // handler should infer () because setTodos returns void
+    if let Some(ty) = types.get("handler") {
+        assert!(
+            ty.contains("()"),
+            "handler calling dispatch setter should infer (), got: {ty}"
+        );
+    } else {
+        panic!("handler should be in types");
+    }
+}
+
+#[test]
+fn calling_dispatch_type_is_callable() {
+    // The REAL problem: setTodos has type Named("Dispatch<SetStateAction<...>>")
+    // which is NOT Type::Function. Calling it returns Unknown.
+    // This test demonstrates the gap.
+    use crate::interop::DtsExport;
+    use crate::interop::TsType;
+
+    let program = crate::parser::Parser::new(
+        r#"
+import trusted { useState } from "react"
+type Todo = { text: string }
+const [todos, setTodos] = useState<Array<Todo>>([])
+fn handler() {
+    setTodos([])
+}
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+
+    // Simulate tsgo giving us the probe result
+    let probe_export = DtsExport {
+        name: "__probe_todos_setTodos".to_string(),
+        ts_type: TsType::Tuple(vec![
+            TsType::Array(Box::new(TsType::Named("Todo".to_string()))),
+            TsType::Function {
+                params: vec![TsType::Named("Todo[]".to_string())],
+                return_type: Box::new(TsType::Primitive("void".to_string())),
+            },
+        ]),
+    };
+    let use_state_export = DtsExport {
+        name: "useState".to_string(),
+        ts_type: TsType::Function {
+            params: vec![TsType::Named("S".to_string())],
+            return_type: Box::new(TsType::Tuple(vec![
+                TsType::Named("S".to_string()),
+                TsType::Function {
+                    params: vec![TsType::Named("S".to_string())],
+                    return_type: Box::new(TsType::Primitive("void".to_string())),
+                },
+            ])),
+        },
+    };
+    let mut dts_imports = std::collections::HashMap::new();
+    dts_imports.insert("react".to_string(), vec![use_state_export, probe_export]);
+
+    let checker = Checker::with_all_imports(std::collections::HashMap::new(), dts_imports);
+    let (_diags, types) = checker.check_with_types(&program);
+    eprintln!("types with dts: {:?}", types);
+
+    // setTodos should be a function type, not Named("Dispatch<...>")
+    if let Some(ty) = types.get("setTodos") {
+        eprintln!("setTodos type: {ty}");
+        assert!(
+            !ty.contains("unknown"),
+            "setTodos should not be unknown, got: {ty}"
+        );
+    }
+
+    // handler should infer () because setTodos returns void
+    if let Some(ty) = types.get("handler") {
+        assert!(
+            ty.contains("()"),
+            "handler should infer () when calling void setTodos, got: {ty}"
+        );
+    } else {
+        panic!("handler should be in types");
+    }
+}
+
+#[test]
+fn inner_function_infers_unit_return() {
+    let program = crate::parser::Parser::new(
+        r#"
+fn outer() {
+    fn inner() {
+        Console.log("hi")
+    }
+    inner()
+}
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+    let (_diags, types) = Checker::new().check_with_types(&program);
+    eprintln!("types: {:?}", types);
+    if let Some(ty) = types.get("inner") {
+        assert!(
+            ty.contains("()"),
+            "inner function should infer () return, got: {ty}"
+        );
+    }
+    if let Some(ty) = types.get("outer") {
+        assert!(
+            ty.contains("()"),
+            "outer function should infer () return, got: {ty}"
+        );
+    }
+}
+
+#[test]
 fn object_destructuring_gets_field_types() {
     let program = crate::parser::Parser::new(
         r#"

--- a/src/checker/types.rs
+++ b/src/checker/types.rs
@@ -151,6 +151,15 @@ impl TypeEnv {
         }
     }
 
+    /// Define a name in the parent scope (second-to-last), used to update
+    /// function types after inferring the return type from the body.
+    pub(crate) fn define_in_parent_scope(&mut self, name: &str, ty: Type) {
+        let len = self.scopes.len();
+        if len >= 2 {
+            self.scopes[len - 2].insert(name.to_string(), ty);
+        }
+    }
+
     /// Check if a name is already defined in any scope.
     pub(crate) fn is_defined_in_any_scope(&self, name: &str) -> bool {
         self.scopes.iter().any(|scope| scope.contains_key(name))

--- a/src/interop/tsgo.rs
+++ b/src/interop/tsgo.rs
@@ -13,6 +13,7 @@ use std::process::Command;
 use crate::parser::ast::*;
 
 use super::DtsExport;
+use super::TsType;
 use super::dts::parse_dts_exports_from_str;
 
 /// Resolves npm import types by running tsgo on a generated probe file.
@@ -266,10 +267,30 @@ fn generate_probe(
             format!("<{}>", call.type_args.join(", "))
         };
         let args_str = call.args.join(", ");
-        lines.push(format!(
-            "export const _r{} = {}{type_args_str}({args_str});",
-            call.index, call.callee,
-        ));
+
+        // For array destructuring, also destructure and re-export each element
+        // so tsgo inlines type aliases (e.g., Dispatch<...> → function type)
+        if let ConstBinding::Array(names) = &call.binding {
+            let tmp = format!("_tmp{}", call.index);
+            lines.push(format!(
+                "const {tmp} = {}{type_args_str}({args_str});",
+                call.callee,
+            ));
+            let destructured: Vec<String> = names
+                .iter()
+                .enumerate()
+                .map(|(i, _)| format!("_r{}_{i}", call.index))
+                .collect();
+            lines.push(format!(
+                "export const [{}] = {tmp};",
+                destructured.join(", "),
+            ));
+        } else {
+            lines.push(format!(
+                "export const _r{} = {}{type_args_str}({args_str});",
+                call.index, call.callee,
+            ));
+        }
     }
 
     // Emit re-exports for non-called imports
@@ -580,17 +601,41 @@ fn build_specifier_map(
             if let Some(name) = &callee_name
                 && imported_names.contains_key(name)
             {
-                let probe_name = format!("_r{probe_index}");
-                if let Some(export) = probe_exports.iter().find(|e| e.name == probe_name) {
-                    let specifier = &imported_names[name];
-                    let binding_name = const_binding_name(&decl.binding);
+                let specifier = &imported_names[name];
+                let binding_name = const_binding_name(&decl.binding);
+
+                // For array bindings, collect individual element types
+                if let ConstBinding::Array(names) = &decl.binding {
+                    let elem_types: Vec<TsType> = names
+                        .iter()
+                        .enumerate()
+                        .map(|(i, _)| {
+                            let elem_name = format!("_r{}_{i}", probe_index);
+                            probe_exports
+                                .iter()
+                                .find(|e| e.name == elem_name)
+                                .map(|e| e.ts_type.clone())
+                                .unwrap_or(TsType::Unknown)
+                        })
+                        .collect();
                     result
                         .entry(specifier.clone())
                         .or_default()
                         .push(DtsExport {
                             name: format!("__probe_{}", binding_name),
-                            ts_type: export.ts_type.clone(),
+                            ts_type: TsType::Tuple(elem_types),
                         });
+                } else {
+                    let probe_name = format!("_r{probe_index}");
+                    if let Some(export) = probe_exports.iter().find(|e| e.name == probe_name) {
+                        result
+                            .entry(specifier.clone())
+                            .or_default()
+                            .push(DtsExport {
+                                name: format!("__probe_{}", binding_name),
+                                ts_type: export.ts_type.clone(),
+                            });
+                    }
                 }
                 probe_index += 1;
                 continue;
@@ -638,7 +683,9 @@ const [count, setCount] = useState(0)"#;
         let probe = generate_probe(&program, &HashMap::new());
 
         assert!(probe.contains("import { useState } from \"react\";"));
-        assert!(probe.contains("export const _r0 = useState(0);"));
+        // Array binding: destructures into _r0_0, _r0_1
+        assert!(probe.contains("_tmp0 = useState(0);"));
+        assert!(probe.contains("export const [_r0_0, _r0_1] = _tmp0;"));
     }
 
     #[test]
@@ -651,7 +698,8 @@ const [todos, setTodos] = useState<Array<Todo>>([])"#;
 
         assert!(probe.contains("import { useState } from \"react\";"));
         assert!(probe.contains("type Todo = {"));
-        assert!(probe.contains("export const _r0 = useState<Array<Todo>>([]);"));
+        assert!(probe.contains("_tmp0 = useState<Array<Todo>>([]);"));
+        assert!(probe.contains("export const [_r0_0, _r0_1] = _tmp0;"));
     }
 
     #[test]
@@ -671,8 +719,8 @@ const [count, setCount] = useState(0)"#;
         let program = Parser::new(source).parse_program().unwrap();
         let probe = generate_probe(&program, &HashMap::new());
 
-        // useState should be a probe call, both should be re-exported
-        assert!(probe.contains("export const _r0 = useState(0);"));
+        // Array binding: destructured
+        assert!(probe.contains("_tmp0 = useState(0);"));
         // All imports are re-exported (useState and useEffect)
         assert!(probe.contains("= useState;"), "should re-export useState");
         assert!(probe.contains("= useEffect;"), "should re-export useEffect");
@@ -708,6 +756,8 @@ const [todos, setTodos] = useState<Array<Todo>>([])
 const [input, setInput] = useState("")
 "#;
         let program = Parser::new(source).parse_program().unwrap();
+        let probe = generate_probe(&program, &HashMap::new());
+        eprintln!("PROBE:\n{probe}");
         let mut resolver = TsgoResolver::new(&todo_app_dir);
         let result = resolver.resolve_imports(&program, &HashMap::new());
 

--- a/src/interop/wrapper.rs
+++ b/src/interop/wrapper.rs
@@ -36,6 +36,14 @@ pub fn wrap_boundary_type(ts_type: &TsType) -> Type {
                     "Promise<{}>",
                     wrap_boundary_type(&args[0]).display_name()
                 )),
+                // React's Dispatch<SetStateAction<T>> is a function: (T) -> ()
+                "Dispatch" if args.len() == 1 => {
+                    let inner = unwrap_set_state_action(&args[0]);
+                    Type::Function {
+                        params: vec![wrap_boundary_type(inner)],
+                        return_type: Box::new(Type::Unit),
+                    }
+                }
                 _ => {
                     // Preserve generic args in the display name
                     let args_str: Vec<String> = args
@@ -102,5 +110,17 @@ fn wrap_union_boundary(parts: &[TsType]) -> Type {
         Type::Option(Box::new(inner_type))
     } else {
         inner_type
+    }
+}
+
+/// Unwrap SetStateAction<T> → T. If not a SetStateAction, return as-is.
+fn unwrap_set_state_action(ty: &TsType) -> &TsType {
+    if let TsType::Generic { name, args } = ty
+        && name == "SetStateAction"
+        && args.len() == 1
+    {
+        &args[0]
+    } else {
+        ty
     }
 }

--- a/src/lsp/tests.rs
+++ b/src/lsp/tests.rs
@@ -856,3 +856,23 @@ fn import_path_at_offset_bare_import() {
     let result = import_path_at_offset(source, quote_pos + 2);
     assert_eq!(result, Some("../todo".to_string()));
 }
+
+#[test]
+fn hover_inner_function_shows_unit_return() {
+    let source = r#"
+export fn outer() -> () {
+    fn handleAdd() {
+        Console.log("hi")
+    }
+    handleAdd()
+}
+"#;
+    let hover = simulate_hover(source, "handleAdd");
+    assert!(hover.is_some(), "handleAdd should be found");
+    let detail = hover.unwrap();
+    eprintln!("HOVER handleAdd: {detail}");
+    assert!(
+        detail.contains("-> ()"),
+        "handleAdd hover should show -> (), got: {detail}"
+    );
+}


### PR DESCRIPTION
closes #203

## Summary
- Functions without `-> ReturnType` now infer their return type from the body
- `fn log(msg: string) { Console.log(msg) }` → return type is `()` not `?T0`
- `const x = log("hi")` → hover shows `(): ()` instead of `unknown`
- Match expressions with void arms properly return `()`

## Test plan
- [x] `unit_type_from_void_match` — match with void arms gives `()`
- [x] `unit_type_from_void_function_call` — calling void function gives `()`
- [x] All 457 tests pass
- [x] Example app passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)