### PR TITLE
[#217] Add TanStack Query + Suspense example to todo-app

### DIFF
--- a/examples/todo-app/package.json
+++ b/examples/todo-app/package.json
@@ -9,9 +9,11 @@
     "check": "floe check src/"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.71.0",
     "@tanstack/react-router": "^1.120.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-error-boundary": "^5.0.0",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/examples/todo-app/src/pages/posts.tsx
+++ b/examples/todo-app/src/pages/posts.tsx
@@ -1,0 +1,175 @@
+import { Suspense, useState } from "react";
+import {
+  QueryClient,
+  QueryClientProvider,
+  QueryErrorResetBoundary,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { ErrorBoundary } from "react-error-boundary";
+
+type Post = {
+  id: number;
+  title: string;
+  body: string;
+  userId: number;
+};
+
+type User = {
+  id: number;
+  name: string;
+  email: string;
+  company: { name: string };
+};
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60 * 1000,
+      retry: 1,
+    },
+  },
+});
+
+function PostAuthor({ userId }: { userId: number }) {
+  const { data: user } = useSuspenseQuery<User>({
+    queryKey: ["user", userId],
+    queryFn: async () => {
+      const res = await fetch(
+        `https://jsonplaceholder.typicode.com/users/${userId}`,
+      );
+      if (!res.ok) throw new Error("Failed to fetch user");
+      return res.json();
+    },
+  });
+
+  return (
+    <span className="text-indigo-400">
+      {user.name} ({user.company.name})
+    </span>
+  );
+}
+
+function PostList() {
+  const [selectedUserId, setSelectedUserId] = useState<number | null>(null);
+
+  const { data: posts } = useSuspenseQuery<Post[]>({
+    queryKey: ["posts", selectedUserId],
+    queryFn: async () => {
+      const url = selectedUserId
+        ? `https://jsonplaceholder.typicode.com/posts?userId=${selectedUserId}`
+        : "https://jsonplaceholder.typicode.com/posts?_limit=10";
+      const res = await fetch(url);
+      if (!res.ok) throw new Error("Failed to fetch posts");
+      return res.json();
+    },
+  });
+
+  return (
+    <div>
+      <div className="mb-6 flex flex-wrap gap-2">
+        <button
+          onClick={() => setSelectedUserId(null)}
+          className={`rounded px-3 py-1 text-sm transition-colors ${
+            selectedUserId === null
+              ? "bg-indigo-600 text-white"
+              : "bg-zinc-800 text-zinc-400 hover:text-zinc-200"
+          }`}
+        >
+          All
+        </button>
+        {[1, 2, 3, 4, 5].map((id) => (
+          <button
+            key={id}
+            onClick={() => setSelectedUserId(id)}
+            className={`rounded px-3 py-1 text-sm transition-colors ${
+              selectedUserId === id
+                ? "bg-indigo-600 text-white"
+                : "bg-zinc-800 text-zinc-400 hover:text-zinc-200"
+            }`}
+          >
+            User {id}
+          </button>
+        ))}
+      </div>
+
+      <div className="space-y-4">
+        {posts.map((post) => (
+          <article
+            key={post.id}
+            className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-5"
+          >
+            <h3 className="mb-1 text-lg font-semibold capitalize text-zinc-100">
+              {post.title}
+            </h3>
+            <Suspense
+              fallback={
+                <span className="text-sm text-zinc-600">Loading author...</span>
+              }
+            >
+              <p className="mb-3 text-sm">
+                by <PostAuthor userId={post.userId} />
+              </p>
+            </Suspense>
+            <p className="text-sm leading-relaxed text-zinc-400">{post.body}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div className="space-y-4">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div
+          key={i}
+          className="animate-pulse rounded-lg border border-zinc-800 bg-zinc-900/50 p-5"
+        >
+          <div className="mb-2 h-5 w-3/4 rounded bg-zinc-800" />
+          <div className="mb-3 h-4 w-1/4 rounded bg-zinc-800" />
+          <div className="space-y-2">
+            <div className="h-3 w-full rounded bg-zinc-800" />
+            <div className="h-3 w-5/6 rounded bg-zinc-800" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function PostsPage() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <h1 className="mb-2 text-3xl font-bold">Posts</h1>
+      <p className="mb-6 text-zinc-400">
+        TanStack Query + Suspense demo using JSONPlaceholder API.
+      </p>
+
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary
+            onReset={reset}
+            fallbackRender={({ resetErrorBoundary, error }) => (
+              <div className="rounded-lg border border-red-900/50 bg-red-950/30 p-6 text-center">
+                <p className="mb-3 text-red-400">
+                  Failed to load posts: {error.message}
+                </p>
+                <button
+                  onClick={resetErrorBoundary}
+                  className="rounded bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-500"
+                >
+                  Retry
+                </button>
+              </div>
+            )}
+          >
+            <Suspense fallback={<LoadingSkeleton />}>
+              <PostList />
+            </Suspense>
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
+    </QueryClientProvider>
+  );
+}

--- a/examples/todo-app/src/router.tsx
+++ b/examples/todo-app/src/router.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-router";
 import { HomePage } from "./pages/home";
 import { AboutPage } from "./pages/about";
+import { PostsPage } from "./pages/posts";
 
 const rootRoute = createRootRoute({
   component: () => (
@@ -25,6 +26,12 @@ const rootRoute = createRootRoute({
             className="text-zinc-400 hover:text-zinc-100 transition-colors [&.active]:text-zinc-100"
           >
             About
+          </Link>
+          <Link
+            to="/posts"
+            className="text-zinc-400 hover:text-zinc-100 transition-colors [&.active]:text-zinc-100"
+          >
+            Posts
           </Link>
         </div>
       </nav>
@@ -47,7 +54,13 @@ const aboutRoute = createRoute({
   component: AboutPage,
 });
 
-const routeTree = rootRoute.addChildren([homeRoute, aboutRoute]);
+const postsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/posts",
+  component: PostsPage,
+});
+
+const routeTree = rootRoute.addChildren([homeRoute, aboutRoute, postsRoute]);
 
 export const router = createRouter({ routeTree });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
 
   examples/todo-app:
     dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.71.0
+        version: 5.90.21(react@19.2.4)
       '@tanstack/react-router':
         specifier: ^1.120.0
         version: 1.166.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -50,6 +53,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.2.4(react@19.2.4)
+      react-error-boundary:
+        specifier: ^5.0.0
+        version: 5.0.0(react@19.2.4)
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -1071,6 +1077,14 @@ packages:
     resolution: {integrity: sha512-Kp/WSt411ZWYvgXy6uiv5RmhHrz9cAml05AQPrtdAp7eUqvIDbMGPnML25OKbzR3RJ1q4wgENxDTvlGPa9+Mww==}
     engines: {node: '>=20.19'}
 
+  '@tanstack/query-core@5.90.20':
+    resolution: {integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==}
+
+  '@tanstack/react-query@5.90.21':
+    resolution: {integrity: sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==}
+    peerDependencies:
+      react: ^18 || ^19
+
   '@tanstack/react-router@1.166.8':
     resolution: {integrity: sha512-EfDPSpPQetdtqi0UT9UAeZEo1cE0O57073IF84kLDvolwR3rWhOX8TgvjL6c2h723EN8EcUlcCU7Tb9Pyt/42g==}
     engines: {node: '>=20.19'}
@@ -2073,6 +2087,11 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-error-boundary@5.0.0:
+    resolution: {integrity: sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ==}
+    peerDependencies:
+      react: '>=16.13.1'
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -3326,6 +3345,13 @@ snapshots:
       vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)
 
   '@tanstack/history@1.161.4': {}
+
+  '@tanstack/query-core@5.90.20': {}
+
+  '@tanstack/react-query@5.90.21(react@19.2.4)':
+    dependencies:
+      '@tanstack/query-core': 5.90.20
+      react: 19.2.4
 
   '@tanstack/react-router@1.166.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -4838,6 +4864,11 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-error-boundary@5.0.0(react@19.2.4):
+    dependencies:
+      '@babel/runtime': 7.28.6
+      react: 19.2.4
 
   react@19.2.4: {}
 


### PR DESCRIPTION
closes #217

## Summary
- Adds a `/posts` page to the example todo-app using TanStack Query with React Suspense
- Uses `useSuspenseQuery` to fetch posts and authors from JSONPlaceholder API
- Includes `QueryErrorResetBoundary` + `ErrorBoundary` for error handling with retry
- Nested `<Suspense>` boundaries for post list and individual author lookups
- Animated loading skeletons while data is in flight
- User filter buttons to demonstrate query key changes triggering new fetches

## Test plan
- [ ] Run `pnpm dev` in `examples/todo-app/` and navigate to `/posts`
- [ ] Verify posts load with skeleton animation
- [ ] Click user filter buttons and verify filtered results
- [ ] Verify author names load with nested suspense fallback
- [ ] Throttle network in DevTools to see loading states clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)