### PR TITLE
[#267] Add record type composition with spread syntax

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -309,6 +309,25 @@ type User = {
   email: Email
 }
 
+// Record type composition with spread
+type BaseProps = {
+  className: string,
+  disabled: boolean,
+}
+
+type ButtonProps = {
+  ...BaseProps,
+  onClick: () -> (),
+  label: string,
+}
+// ButtonProps has: className, disabled, onClick, label
+
+// Multiple spreads
+type A = { x: number }
+type B = { y: string }
+type C = { ...A, ...B, z: boolean }
+// C has: x, y, z
+
 // Simple union type (has |)
 type Route =
   | Home

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -76,6 +76,24 @@ type ApiError =
     | NotFound
     | ServerError(status: number)
 
+// Record type composition with spread
+type BaseProps = {
+    className: string,
+    disabled: boolean,
+}
+
+type ButtonProps = {
+    ...BaseProps,
+    onClick: () -> (),
+    label: string,
+}
+// ButtonProps has: className, disabled, onClick, label
+
+// Multiple spreads
+type A = { x: number }
+type B = { y: string }
+type C = { ...A, ...B, z: boolean }
+
 // Branded types
 type UserId = Brand<string, "UserId">
 type Email = Brand<string, "Email">

--- a/docs/site/src/content/docs/guide/types.md
+++ b/docs/site/src/content/docs/guide/types.md
@@ -32,6 +32,37 @@ Update with spread:
 const updated = User(..user, age: 31)
 ```
 
+### Record Type Composition
+
+Include fields from other record types using spread syntax:
+
+```floe
+type BaseProps = {
+  className: string,
+  disabled: boolean,
+}
+
+type ButtonProps = {
+  ...BaseProps,
+  onClick: () -> (),
+  label: string,
+}
+// ButtonProps has: className, disabled, onClick, label
+```
+
+Multiple spreads are allowed:
+
+```floe
+type A = { x: number }
+type B = { y: string }
+type C = { ...A, ...B, z: boolean }
+```
+
+Rules:
+- Spread must reference a record type (not a union or alias)
+- Field name conflicts between spreads or with direct fields are compile errors
+- The resulting type is a flat record
+
 ## Union Types
 
 Discriminated unions with variants:

--- a/docs/site/src/content/docs/reference/types.md
+++ b/docs/site/src/content/docs/reference/types.md
@@ -42,6 +42,32 @@ type User = {
 };
 ```
 
+### Record Type Composition
+
+Include fields from other record types using `...` spread:
+
+```floe
+type BaseProps = {
+  className: string,
+  disabled: boolean,
+}
+
+type ButtonProps = {
+  ...BaseProps,
+  onClick: () -> (),
+  label: string,
+}
+```
+
+Compiles to TypeScript intersection:
+
+```typescript
+type BaseProps = { className: string; disabled: boolean };
+type ButtonProps = BaseProps & { onClick: () => void; label: string };
+```
+
+Multiple spreads are allowed. Field name conflicts are compile errors.
+
 ## Union Types
 
 Tagged discriminated unions:

--- a/examples/todo-app/src/types.fl
+++ b/examples/todo-app/src/types.fl
@@ -15,6 +15,16 @@ export type Validation =
     | TooLong
     | Empty
 
+export type Timestamped = {
+    createdAt: number,
+    updatedAt: number,
+}
+
+export type TodoWithTimestamp = {
+    ...Todo,
+    ...Timestamped,
+}
+
 export trait Display {
     fn display(self) -> string
 }

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -462,15 +462,18 @@ impl Checker {
     // ── Type Registration ────────────────────────────────────────
 
     fn register_type_decl(&mut self, decl: &TypeDecl) {
+        // Flatten record spreads into a flat record definition
+        let flattened_def = self.flatten_record_spreads(&decl.def, &decl.name);
+
         let info = TypeInfo {
-            def: decl.def.clone(),
+            def: flattened_def.clone(),
             opaque: decl.opaque,
             type_params: decl.type_params.clone(),
         };
         self.env.define_type(&decl.name, info);
 
         // Register the type name in the value namespace too (for constructors)
-        match &decl.def {
+        match &flattened_def {
             TypeDef::Record(_) => {
                 self.env.define(&decl.name, Type::Named(decl.name.clone()));
             }
@@ -503,13 +506,136 @@ impl Checker {
         }
     }
 
+    /// Flatten record type spreads (`...OtherType`) into regular fields.
+    /// Returns the original `TypeDef` unchanged if it's not a record or has no spreads.
+    fn flatten_record_spreads(&mut self, def: &TypeDef, type_name: &str) -> TypeDef {
+        let entries = match def {
+            TypeDef::Record(entries) => entries,
+            other => return other.clone(),
+        };
+
+        // Check if there are any spreads at all
+        let has_spreads = entries.iter().any(|e| matches!(e, RecordEntry::Spread(_)));
+        if !has_spreads {
+            return def.clone();
+        }
+
+        let mut flat_fields: Vec<RecordField> = Vec::new();
+        let mut seen_names: std::collections::HashMap<String, Span> =
+            std::collections::HashMap::new();
+
+        for entry in entries {
+            match entry {
+                RecordEntry::Field(field) => {
+                    if seen_names.contains_key(&field.name) {
+                        self.diagnostics.push(
+                            Diagnostic::error(
+                                format!(
+                                    "duplicate field `{}` in record type `{}`",
+                                    field.name, type_name
+                                ),
+                                field.span,
+                            )
+                            .with_label("duplicate field")
+                            .with_help("field was already defined elsewhere in this record type")
+                            .with_code("E030"),
+                        );
+                    } else {
+                        seen_names.insert(field.name.clone(), field.span);
+                        flat_fields.push(field.as_ref().clone());
+                    }
+                }
+                RecordEntry::Spread(spread) => {
+                    // Look up the referenced type
+                    if let Some(info) = self.env.lookup_type(&spread.type_name) {
+                        let info = info.clone();
+                        match &info.def {
+                            TypeDef::Record(spread_entries) => {
+                                // Get only the direct fields from the spread target
+                                // (which should already be flattened if it was registered first)
+                                let spread_fields: Vec<RecordField> = spread_entries
+                                    .iter()
+                                    .filter_map(|e| e.as_field().cloned())
+                                    .collect();
+                                for field in &spread_fields {
+                                    if seen_names.contains_key(&field.name) {
+                                        self.diagnostics.push(
+                                            Diagnostic::error(
+                                                format!(
+                                                    "field `{}` from spread `...{}` conflicts with existing field in `{}`",
+                                                    field.name, spread.type_name, type_name
+                                                ),
+                                                spread.span,
+                                            )
+                                            .with_label(format!("field `{}` already defined", field.name))
+                                            .with_help("field was already defined elsewhere in this record type")
+                                            .with_code("E031"),
+                                        );
+                                    } else {
+                                        seen_names.insert(field.name.clone(), spread.span);
+                                        flat_fields.push(field.clone());
+                                    }
+                                }
+                            }
+                            TypeDef::Union(_) => {
+                                self.diagnostics.push(
+                                    Diagnostic::error(
+                                        format!(
+                                            "cannot spread union type `{}` into record type `{}`",
+                                            spread.type_name, type_name
+                                        ),
+                                        spread.span,
+                                    )
+                                    .with_label("spread target must be a record type")
+                                    .with_code("E032"),
+                                );
+                            }
+                            TypeDef::Alias(_) => {
+                                self.diagnostics.push(
+                                    Diagnostic::error(
+                                        format!(
+                                            "cannot spread type alias `{}` into record type `{}`; spread target must be a record type",
+                                            spread.type_name, type_name
+                                        ),
+                                        spread.span,
+                                    )
+                                    .with_label("spread target must be a record type")
+                                    .with_code("E032"),
+                                );
+                            }
+                        }
+                    } else {
+                        self.diagnostics.push(
+                            Diagnostic::error(
+                                format!("unknown type `{}` in spread", spread.type_name),
+                                spread.span,
+                            )
+                            .with_label("type not found")
+                            .with_code("E002"),
+                        );
+                    }
+                }
+            }
+        }
+
+        TypeDef::Record(
+            flat_fields
+                .into_iter()
+                .map(|f| RecordEntry::Field(Box::new(f)))
+                .collect(),
+        )
+    }
+
     /// Second-pass validation of type annotations within type declarations.
     /// The first pass (register_type_decl) skips unknown type errors for forward references.
     fn validate_type_decl_annotations(&mut self, decl: &TypeDecl) {
         match &decl.def {
-            TypeDef::Record(fields) => {
-                for field in fields {
-                    self.resolve_type(&field.type_ann);
+            TypeDef::Record(entries) => {
+                for entry in entries {
+                    if let RecordEntry::Field(field) = entry {
+                        self.resolve_type(&field.type_ann);
+                    }
+                    // Spreads are validated during register_type_decl
                 }
             }
             TypeDef::Union(variants) => {

--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -314,9 +314,13 @@ impl Checker {
                 // Collect valid field names for this type
                 let valid_fields: Option<Vec<String>> = if let Some(ref info) = type_info {
                     match &info.def {
-                        TypeDef::Record(fields) => {
-                            Some(fields.iter().map(|f| f.name.clone()).collect())
-                        }
+                        TypeDef::Record(entries) => Some(
+                            entries
+                                .iter()
+                                .filter_map(|e| e.as_field())
+                                .map(|f| f.name.clone())
+                                .collect(),
+                        ),
                         _ => None,
                     }
                 } else {
@@ -379,9 +383,10 @@ impl Checker {
                     // Check for missing required fields (only when no spread)
                     if spread.is_none() {
                         let has_defaults: Vec<String> = if let Some(ref info) = type_info {
-                            if let TypeDef::Record(record_fields) = &info.def {
-                                record_fields
+                            if let TypeDef::Record(record_entries) = &info.def {
+                                record_entries
                                     .iter()
+                                    .filter_map(|e| e.as_field())
                                     .filter(|f| f.default.is_some())
                                     .map(|f| f.name.clone())
                                     .collect()
@@ -449,9 +454,10 @@ impl Checker {
                 let field_type_map: Option<Vec<(String, Type)>> = if let Some(ref info) = type_info
                 {
                     match &info.def {
-                        TypeDef::Record(fields) => Some(
-                            fields
+                        TypeDef::Record(entries) => Some(
+                            entries
                                 .iter()
+                                .filter_map(|e| e.as_field())
                                 .map(|f| (f.name.clone(), self.resolve_type(&f.type_ann)))
                                 .collect(),
                         ),

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -1935,7 +1935,7 @@ fn cross_file_trait_resolution() {
         opaque: false,
         name: "User".to_string(),
         type_params: vec![],
-        def: TypeDef::Record(vec![RecordField {
+        def: TypeDef::Record(vec![RecordEntry::Field(Box::new(RecordField {
             name: "name".to_string(),
             type_ann: TypeExpr {
                 kind: TypeExprKind::Named {
@@ -1947,7 +1947,7 @@ fn cross_file_trait_resolution() {
             },
             default: None,
             span: dummy_span,
-        }]),
+        }))]),
     });
     imports.insert("./types".to_string(), resolved);
 
@@ -2227,5 +2227,153 @@ fn test() -> Result<string, Error> {
             .filter(|d| d.severity == Severity::Error)
             .map(|d| &d.message)
             .collect::<Vec<_>>()
+    );
+}
+
+// ── Record type composition with spread ──────────────────────
+
+#[test]
+fn record_spread_basic() {
+    let diags = check(
+        r#"
+type BaseProps = {
+    className: string,
+    disabled: boolean,
+}
+
+type ButtonProps = {
+    ...BaseProps,
+    onClick: () -> (),
+    label: string,
+}
+
+const btn = ButtonProps(className: "btn", disabled: false, onClick: || (), label: "Click")
+"#,
+    );
+    assert!(
+        !diags.iter().any(|d| d.severity == Severity::Error),
+        "expected no errors, got: {:?}",
+        diags
+    );
+}
+
+#[test]
+fn record_spread_multiple() {
+    let diags = check(
+        r#"
+type A = {
+    x: number,
+}
+
+type B = {
+    y: string,
+}
+
+type C = {
+    ...A,
+    ...B,
+    z: boolean,
+}
+
+const c = C(x: 1, y: "hello", z: true)
+"#,
+    );
+    assert!(
+        !diags.iter().any(|d| d.severity == Severity::Error),
+        "expected no errors, got: {:?}",
+        diags
+    );
+}
+
+#[test]
+fn record_spread_conflict_error() {
+    let diags = check(
+        r#"
+type A = {
+    name: string,
+}
+
+type B = {
+    ...A,
+    name: number,
+}
+"#,
+    );
+    assert!(
+        has_error(&diags, "E030"),
+        "expected duplicate field error E030, got: {:?}",
+        diags
+    );
+}
+
+#[test]
+fn record_spread_union_error() {
+    let diags = check(
+        r#"
+type Status = | Active | Inactive
+
+type Bad = {
+    ...Status,
+    extra: string,
+}
+"#,
+    );
+    assert!(
+        has_error(&diags, "E032"),
+        "expected spread-of-non-record error E032, got: {:?}",
+        diags
+    );
+}
+
+#[test]
+fn record_spread_nested() {
+    let diags = check(
+        r#"
+type A = {
+    x: number,
+}
+
+type B = {
+    ...A,
+    y: string,
+}
+
+type C = {
+    ...B,
+    z: boolean,
+}
+
+const c = C(x: 1, y: "hello", z: true)
+"#,
+    );
+    assert!(
+        !diags.iter().any(|d| d.severity == Severity::Error),
+        "expected no errors for nested spread, got: {:?}",
+        diags
+    );
+}
+
+#[test]
+fn record_spread_conflict_between_spreads() {
+    let diags = check(
+        r#"
+type A = {
+    name: string,
+}
+
+type B = {
+    name: string,
+}
+
+type C = {
+    ...A,
+    ...B,
+}
+"#,
+    );
+    assert!(
+        has_error(&diags, "E031"),
+        "expected conflict error E031 between spreads, got: {:?}",
+        diags
     );
 }

--- a/src/checker/types.rs
+++ b/src/checker/types.rs
@@ -205,9 +205,10 @@ impl TypeEnv {
             Type::Named(name) => {
                 if let Some(info) = self.lookup_type(name) {
                     match &info.def {
-                        crate::parser::ast::TypeDef::Record(fields) => {
-                            let field_types: Vec<_> = fields
+                        crate::parser::ast::TypeDef::Record(entries) => {
+                            let field_types: Vec<_> = entries
                                 .iter()
+                                .filter_map(|e| e.as_field())
                                 .map(|f| (f.name.clone(), resolve_type_fn(&f.type_ann)))
                                 .collect();
                             Type::Record(field_types)

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -534,8 +534,8 @@ impl Codegen {
         self.push(" = ");
 
         match &decl.def {
-            TypeDef::Record(fields) => {
-                self.emit_record_type(fields);
+            TypeDef::Record(entries) => {
+                self.emit_record_type_entries(entries);
             }
             TypeDef::Union(variants) => {
                 self.emit_union_type(variants);
@@ -547,6 +547,36 @@ impl Codegen {
         }
 
         self.push(";");
+    }
+
+    fn emit_record_type_entries(&mut self, entries: &[RecordEntry]) {
+        let spreads: Vec<&RecordSpread> = entries.iter().filter_map(|e| e.as_spread()).collect();
+        let fields: Vec<&RecordField> = entries.iter().filter_map(|e| e.as_field()).collect();
+
+        // Emit spreads as intersection types
+        for spread in &spreads {
+            self.push(&spread.type_name);
+            if !fields.is_empty() || spread != spreads.last().unwrap() {
+                self.push(" & ");
+            }
+        }
+
+        if !fields.is_empty() || spreads.is_empty() {
+            self.emit_record_type_fields(&fields);
+        }
+    }
+
+    fn emit_record_type_fields(&mut self, fields: &[&RecordField]) {
+        self.push("{ ");
+        for (i, field) in fields.iter().enumerate() {
+            if i > 0 {
+                self.push("; ");
+            }
+            self.push(&field.name);
+            self.push(": ");
+            self.emit_type_expr(&field.type_ann);
+        }
+        self.push(" }");
     }
 
     fn emit_record_type(&mut self, fields: &[RecordField]) {

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -387,8 +387,22 @@ impl<'src> CstParser<'src> {
     fn parse_record_fields(&mut self) {
         self.expect(TokenKind::LeftBrace);
         self.eat_trivia();
-        self.parse_comma_separated(Self::parse_record_field, TokenKind::RightBrace);
+        self.parse_comma_separated(Self::parse_record_entry, TokenKind::RightBrace);
         self.expect(TokenKind::RightBrace);
+    }
+
+    fn parse_record_entry(&mut self) {
+        // Check for spread: `...TypeName`
+        if self.at(TokenKind::DotDotDot) {
+            self.builder.start_node(SyntaxKind::RECORD_SPREAD.into());
+            self.bump(); // consume `...`
+            self.eat_trivia();
+            self.expect_ident(); // TypeName
+            self.builder.finish_node();
+            return;
+        }
+
+        self.parse_record_field();
     }
 
     fn parse_record_field(&mut self) {

--- a/src/interop/tsgo.rs
+++ b/src/interop/tsgo.rs
@@ -673,16 +673,40 @@ fn type_decl_to_ts(decl: &TypeDecl) -> String {
     };
 
     match &decl.def {
-        TypeDef::Record(fields) => {
-            let fs: Vec<String> = fields
+        TypeDef::Record(entries) => {
+            let fs: Vec<String> = entries
                 .iter()
+                .filter_map(|e| e.as_field())
                 .map(|f| format!("  {}: {};", f.name, type_expr_to_ts(&f.type_ann)))
                 .collect();
-            format!(
-                "type {}{type_params} = {{\n{}\n}};",
-                decl.name,
-                fs.join("\n")
-            )
+            let spreads: Vec<String> = entries
+                .iter()
+                .filter_map(|e| e.as_spread())
+                .map(|s| s.type_name.clone())
+                .collect();
+            if spreads.is_empty() {
+                format!(
+                    "type {}{type_params} = {{\n{}\n}};",
+                    decl.name,
+                    fs.join("\n")
+                )
+            } else {
+                let spread_parts: Vec<String> = spreads.to_vec();
+                if fs.is_empty() {
+                    format!(
+                        "type {}{type_params} = {};",
+                        decl.name,
+                        spread_parts.join(" & ")
+                    )
+                } else {
+                    format!(
+                        "type {}{type_params} = {} & {{\n{}\n}};",
+                        decl.name,
+                        spread_parts.join(" & "),
+                        fs.join("\n")
+                    )
+                }
+            }
         }
         TypeDef::Alias(ty) => {
             format!("type {}{type_params} = {};", decl.name, type_expr_to_ts(ty))

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -130,11 +130,16 @@ impl<'src> Lexer<'src> {
             b'*' => TokenKind::Star,
             b'%' => TokenKind::Percent,
 
-            // Dot or DotDot
+            // Dot, DotDot, or DotDotDot
             b'.' => {
                 if self.peek() == Some(b'.') {
                     self.advance();
-                    TokenKind::DotDot
+                    if self.peek() == Some(b'.') {
+                        self.advance();
+                        TokenKind::DotDotDot
+                    } else {
+                        TokenKind::DotDot
+                    }
                 } else {
                     TokenKind::Dot
                 }
@@ -623,6 +628,15 @@ mod tests {
         assert_eq!(
             lex(". .."),
             vec![TokenKind::Dot, TokenKind::DotDot, TokenKind::Eof]
+        );
+    }
+
+    #[test]
+    fn dot_dot_dot() {
+        assert_eq!(lex("..."), vec![TokenKind::DotDotDot, TokenKind::Eof]);
+        assert_eq!(
+            lex(".. ."),
+            vec![TokenKind::DotDot, TokenKind::Dot, TokenKind::Eof]
         );
     }
 

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -83,6 +83,8 @@ pub enum TokenKind {
     Underscore,
     /// `..` — spread in constructors
     DotDot,
+    /// `...` — spread in type definitions (record type composition)
+    DotDotDot,
 
     // Arithmetic
     /// `+`

--- a/src/lower.rs
+++ b/src/lower.rs
@@ -546,15 +546,28 @@ impl<'src> Lowerer<'src> {
     }
 
     fn lower_type_def_record(&mut self, node: &SyntaxNode) -> TypeDef {
-        let mut fields = Vec::new();
+        let mut entries = Vec::new();
         for child in node.children() {
-            if child.kind() == SyntaxKind::RECORD_FIELD
-                && let Some(field) = self.lower_record_field(&child)
-            {
-                fields.push(field);
+            match child.kind() {
+                SyntaxKind::RECORD_FIELD => {
+                    if let Some(field) = self.lower_record_field(&child) {
+                        entries.push(RecordEntry::Field(Box::new(field)));
+                    }
+                }
+                SyntaxKind::RECORD_SPREAD => {
+                    let span = self.node_span(&child);
+                    let idents = self.collect_idents_direct(&child);
+                    if let Some(type_name) = idents.first() {
+                        entries.push(RecordEntry::Spread(RecordSpread {
+                            type_name: type_name.clone(),
+                            span,
+                        }));
+                    }
+                }
+                _ => {}
             }
         }
-        TypeDef::Record(fields)
+        TypeDef::Record(entries)
     }
 
     fn lower_type_def_union(&mut self, node: &SyntaxNode) -> TypeDef {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -516,8 +516,8 @@ impl Parser {
 
         // Check if this is a record type (starts with `{`)
         if self.check(&TokenKind::LeftBrace) {
-            let fields = self.parse_record_fields()?;
-            return Ok(TypeDef::Record(fields));
+            let entries = self.parse_record_entries()?;
+            return Ok(TypeDef::Record(entries));
         }
 
         // Otherwise it's a type alias
@@ -588,11 +588,35 @@ impl Parser {
         })
     }
 
+    fn parse_record_entries(&mut self) -> Result<Vec<RecordEntry>, ParseError> {
+        self.expect(&TokenKind::LeftBrace)?;
+        let entries = self.parse_comma_separated(|p| p.parse_record_entry())?;
+        self.expect(&TokenKind::RightBrace)?;
+        Ok(entries)
+    }
+
     fn parse_record_fields(&mut self) -> Result<Vec<RecordField>, ParseError> {
         self.expect(&TokenKind::LeftBrace)?;
         let fields = self.parse_comma_separated(|p| p.parse_record_field())?;
         self.expect(&TokenKind::RightBrace)?;
         Ok(fields)
+    }
+
+    fn parse_record_entry(&mut self) -> Result<RecordEntry, ParseError> {
+        // Check for spread: `...TypeName`
+        if self.check(&TokenKind::DotDotDot) {
+            let start_span = self.current_span();
+            self.advance(); // consume `...`
+            let type_name = self.expect_identifier()?;
+            let end_span = self.previous_span();
+            return Ok(RecordEntry::Spread(RecordSpread {
+                type_name,
+                span: self.merge_spans(start_span, end_span),
+            }));
+        }
+
+        self.parse_record_field()
+            .map(|f| RecordEntry::Field(Box::new(f)))
     }
 
     fn parse_record_field(&mut self) -> Result<RecordField, ParseError> {

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -131,12 +131,21 @@ pub struct TypeDecl {
 /// The right-hand side of a type declaration.
 #[derive(Debug, Clone, PartialEq)]
 pub enum TypeDef {
-    /// Record type: `{ field: Type, ... }`
-    Record(Vec<RecordField>),
+    /// Record type: `{ field: Type, ...OtherType, ... }`
+    Record(Vec<RecordEntry>),
     /// Union type: `| Variant1 | Variant2(field: Type)`
     Union(Vec<Variant>),
     /// Type alias: `type X = SomeOtherType`
     Alias(TypeExpr),
+}
+
+/// An entry inside a record type definition — either a regular field or a spread.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RecordEntry {
+    /// A regular field: `name: Type`
+    Field(Box<RecordField>),
+    /// A spread: `...OtherType` — includes all fields from the referenced record type
+    Spread(RecordSpread),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -145,6 +154,49 @@ pub struct RecordField {
     pub type_ann: TypeExpr,
     pub default: Option<Expr>,
     pub span: Span,
+}
+
+/// A spread entry in a record type: `...TypeName`
+#[derive(Debug, Clone, PartialEq)]
+pub struct RecordSpread {
+    pub type_name: String,
+    pub span: Span,
+}
+
+impl RecordEntry {
+    /// Returns the field if this is a `RecordEntry::Field`, otherwise `None`.
+    pub fn as_field(&self) -> Option<&RecordField> {
+        match self {
+            RecordEntry::Field(f) => Some(f),
+            RecordEntry::Spread(_) => None,
+        }
+    }
+
+    /// Returns the spread if this is a `RecordEntry::Spread`, otherwise `None`.
+    pub fn as_spread(&self) -> Option<&RecordSpread> {
+        match self {
+            RecordEntry::Spread(s) => Some(s),
+            RecordEntry::Field(_) => None,
+        }
+    }
+}
+
+impl TypeDef {
+    /// Returns only the direct fields (excluding spreads) from a record type definition.
+    pub fn record_fields(&self) -> Vec<&RecordField> {
+        match self {
+            TypeDef::Record(entries) => entries.iter().filter_map(RecordEntry::as_field).collect(),
+            _ => Vec::new(),
+        }
+    }
+
+    /// Returns the spread entries from a record type definition.
+    pub fn record_spreads(&self) -> Vec<&RecordSpread> {
+        match self {
+            TypeDef::Record(entries) => entries.iter().filter_map(RecordEntry::as_spread).collect(),
+            _ => Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -597,8 +597,47 @@ fn type_record() {
         ItemKind::TypeDecl(decl) => {
             assert_eq!(decl.name, "User");
             match decl.def {
-                TypeDef::Record(fields) => assert_eq!(fields.len(), 2),
-                other => panic!("expected record, got {other:?}"),
+                TypeDef::Record(ref entries) => assert_eq!(entries.len(), 2),
+                ref other => panic!("expected record, got {other:?}"),
+            }
+        }
+        other => panic!("expected type decl, got {other:?}"),
+    }
+}
+
+#[test]
+fn type_record_with_spread() {
+    match first_item("type B = { ...A, extra: string }") {
+        ItemKind::TypeDecl(decl) => {
+            assert_eq!(decl.name, "B");
+            match decl.def {
+                TypeDef::Record(ref entries) => {
+                    assert_eq!(entries.len(), 2);
+                    assert!(entries[0].as_spread().is_some());
+                    assert_eq!(entries[0].as_spread().unwrap().type_name, "A");
+                    assert!(entries[1].as_field().is_some());
+                    assert_eq!(entries[1].as_field().unwrap().name, "extra");
+                }
+                ref other => panic!("expected record, got {other:?}"),
+            }
+        }
+        other => panic!("expected type decl, got {other:?}"),
+    }
+}
+
+#[test]
+fn type_record_with_multiple_spreads() {
+    match first_item("type C = { ...A, ...B, extra: string }") {
+        ItemKind::TypeDecl(decl) => {
+            assert_eq!(decl.name, "C");
+            match decl.def {
+                TypeDef::Record(ref entries) => {
+                    assert_eq!(entries.len(), 3);
+                    assert_eq!(entries[0].as_spread().unwrap().type_name, "A");
+                    assert_eq!(entries[1].as_spread().unwrap().type_name, "B");
+                    assert_eq!(entries[2].as_field().unwrap().name, "extra");
+                }
+                ref other => panic!("expected record, got {other:?}"),
             }
         }
         other => panic!("expected type decl, got {other:?}"),

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -54,6 +54,7 @@ pub enum SyntaxKind {
     QUESTION,      // ?
     UNDERSCORE,    // _
     DOT_DOT,       // ..
+    DOT_DOT_DOT,   // ...
     PLUS,          // +
     MINUS,         // -
     STAR,          // *
@@ -109,6 +110,7 @@ pub enum SyntaxKind {
     TEST_BLOCK,
     ASSERT_EXPR,
     RECORD_FIELD,
+    RECORD_SPREAD,
     VARIANT,
     VARIANT_FIELD,
     TYPE_EXPR,
@@ -239,6 +241,7 @@ pub fn token_kind_to_syntax(kind: &TokenKind) -> SyntaxKind {
         TokenKind::Question => SyntaxKind::QUESTION,
         TokenKind::Underscore => SyntaxKind::UNDERSCORE,
         TokenKind::DotDot => SyntaxKind::DOT_DOT,
+        TokenKind::DotDotDot => SyntaxKind::DOT_DOT_DOT,
         TokenKind::Plus => SyntaxKind::PLUS,
         TokenKind::Minus => SyntaxKind::MINUS,
         TokenKind::Star => SyntaxKind::STAR,

--- a/tests/fixtures/record_spread.fl
+++ b/tests/fixtures/record_spread.fl
@@ -1,0 +1,24 @@
+type BaseProps = {
+    className: string,
+    disabled: boolean,
+}
+
+type ButtonProps = {
+    ...BaseProps,
+    onClick: () -> (),
+    label: string,
+}
+
+type A = {
+    x: number,
+}
+
+type B = {
+    y: string,
+}
+
+type C = {
+    ...A,
+    ...B,
+    z: boolean,
+}

--- a/tests/snapshot_codegen.rs
+++ b/tests/snapshot_codegen.rs
@@ -147,3 +147,9 @@ fn snapshot_todo_unreachable() {
     let output = compile_fixture("todo_unreachable");
     insta::assert_snapshot!(output);
 }
+
+#[test]
+fn snapshot_record_spread() {
+    let output = compile_fixture("record_spread");
+    insta::assert_snapshot!(output);
+}

--- a/tests/snapshots/snapshot_codegen__snapshot_record_spread.snap
+++ b/tests/snapshots/snapshot_codegen__snapshot_record_spread.snap
@@ -1,0 +1,13 @@
+---
+source: tests/snapshot_codegen.rs
+expression: output
+---
+type BaseProps = { className: string; disabled: boolean };
+
+type ButtonProps = BaseProps & { onClick: () => void; label: string };
+
+type A = { x: number };
+
+type B = { y: string };
+
+type C = A & B & { z: boolean };


### PR DESCRIPTION
closes #267

## Summary

- Add `...TypeName` spread syntax inside record type definitions to compose record types
- Multiple spreads allowed: `type C = { ...A, ...B, extra: string }`
- Checker flattens spreads at type registration, detecting field name conflicts as compile errors
- Codegen emits TypeScript intersection types (e.g. `A & { extra: string }`)
- Spread of non-record types (unions, aliases) produces a compile error

## Changes

Full compiler pipeline: lexer (DotDotDot token), AST (RecordEntry enum), parser (direct + CST), lowering, checker (flatten + conflict detection), codegen (intersection types), interop (.d.ts generation).

## Test plan

- [x] Parser tests: basic spread, multiple spreads
- [x] Checker tests: basic spread, multiple spreads, conflict detection, union spread error, nested spreads, cross-spread conflicts
- [x] Codegen snapshot: `record_spread.fl` fixture
- [x] Lexer test: `...` token
- [x] All 691 existing unit tests pass
- [x] All 22 codegen snapshot tests pass
- [x] All 16 error snapshot tests pass
- [x] `cargo fmt`, `cargo clippy -- -D warnings`, `RUSTFLAGS="-D warnings" cargo test` all pass
- [x] Docs updated: design.md, site guide/types.md, site reference/types.md, llms.txt
- [x] Example app updated with TodoWithTimestamp type using spread