### PR TITLE
[#275] Formatter: add blank line before final expression

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1294,11 +1294,36 @@ export default function floe(): Plugin {
 ```bash
 floe build src/           # compile all .fl → .tsx
 floe check src/           # type-check only, no output
+floe fmt src/             # format .fl files in place
 floe test src/            # run inline test blocks
 floe watch src/           # watch mode
 floe init                 # scaffold new project
 floe migrate file.tsx     # attempt to convert .tsx to .fl
 ```
+
+### Formatter (`floe fmt`)
+
+The formatter enforces a canonical style. Key conventions:
+
+- **Blank line before final expression:** In multi-statement blocks (2+ statements/expressions), the formatter inserts a blank line before the last expression (the implicit return value). Single-expression bodies are unaffected.
+
+```floe
+// Multi-statement: blank line before final expression
+fn loadProfile(id: string) -> Result<Profile, ApiError> {
+    const user = fetchUser(id)?
+    const posts = fetchPosts(user.id)?
+    const stats = computeStats(posts)
+
+    Profile(user, posts, stats)
+}
+
+// Single expression: no blank line
+fn add(a: number, b: number) -> number {
+    a + b
+}
+```
+
+This applies to `fn` bodies, `for`-block functions, match arms with block bodies, and lambdas with block bodies.
 
 ---
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -495,3 +495,4 @@ match key {
 11. **`Console.log`** not `console.log` (capital C in Floe)
 12. **`Array<T>`** not `T[]` for array types
 13. **Implicit returns** — last expression in a block is the return value; `return` keyword is banned
+14. **Blank line before final expression** — `floe fmt` inserts a blank line before the last expression in multi-statement blocks (2+ statements) to visually separate the return value

--- a/docs/site/src/content/docs/guide/functions.md
+++ b/docs/site/src/content/docs/guide/functions.md
@@ -36,6 +36,18 @@ fn add(a: number, b: number) -> number {
 
 The last expression in a function body is the return value. The `return` keyword is not used in Floe.
 
+In multi-statement functions, `floe fmt` adds a blank line before the final expression to visually separate the return value:
+
+```floe
+fn loadProfile(id: string) -> Result<Profile, ApiError> {
+    const user = fetchUser(id)?
+    const posts = fetchPosts(user.id)?
+    const stats = computeStats(posts)
+
+    Profile(user, posts, stats)
+}
+```
+
 Exported functions **must** have return type annotations:
 
 ```floe

--- a/docs/site/src/content/docs/tooling/cli.md
+++ b/docs/site/src/content/docs/tooling/cli.md
@@ -32,6 +32,20 @@ floe check src/
 floe check src/main.fl
 ```
 
+### `floe fmt`
+
+Format `.fl` files in place.
+
+```bash
+floe fmt src/
+floe fmt src/main.fl
+```
+
+The formatter enforces a canonical style. Notable conventions:
+- Blank line before the final expression in multi-statement blocks (visually separates the return value)
+- Named arg punning (`name: name` becomes `name:`)
+- Consistent spacing around operators
+
 ### `floe test`
 
 Run inline test blocks.

--- a/src/formatter/expr.rs
+++ b/src/formatter/expr.rs
@@ -21,8 +21,13 @@ impl Formatter<'_> {
             return;
         }
 
+        let child_count = children.len();
         self.indent += 1;
-        for child in &children {
+        for (i, child) in children.iter().enumerate() {
+            // Insert a blank line before the final expression in multi-statement blocks
+            if child_count >= 2 && i == child_count - 1 {
+                self.newline();
+            }
             self.newline();
             self.write_indent();
             self.fmt_node(child);

--- a/src/formatter/tests.rs
+++ b/src/formatter/tests.rs
@@ -132,6 +132,58 @@ fn format_jsx_fragment() {
     assert_fmt("<>{x}</>", "<>{x}</>");
 }
 
+// ── Blank line before final expression ──────────────────────
+
+#[test]
+fn format_blank_line_before_final_expr_in_multi_stmt_fn() {
+    assert_fmt(
+        "fn load(id: string) -> number {\n    const x = fetch(id)\n    const y = process(x)\n    x + y\n}",
+        "fn load(id: string) -> number {\n    const x = fetch(id)\n    const y = process(x)\n\n    x + y\n}",
+    );
+}
+
+#[test]
+fn format_single_expr_fn_no_blank_line() {
+    assert_fmt(
+        "fn add(a: number, b: number) -> number { a + b }",
+        "fn add(a: number, b: number) -> number {\n    a + b\n}",
+    );
+}
+
+#[test]
+fn format_already_has_blank_line_no_double() {
+    // Even if the input doesn't have one, the formatter always produces
+    // the canonical output with exactly one blank line before the last expr
+    assert_fmt(
+        "fn f() -> number {\n    const x = 1\n\n    x\n}",
+        "fn f() -> number {\n    const x = 1\n\n    x\n}",
+    );
+}
+
+#[test]
+fn format_two_statement_block_gets_blank_line() {
+    assert_fmt(
+        "fn f() -> number {\n    const x = 1\n    x\n}",
+        "fn f() -> number {\n    const x = 1\n\n    x\n}",
+    );
+}
+
+#[test]
+fn format_match_arm_block_body_blank_line() {
+    assert_fmt(
+        "const r = match x {\n    Some(v) -> {\n        const y = v + 1\n        y\n    },\n    None -> 0,\n}",
+        "const r = match x {\n    Some(v) -> {\n        const y = v + 1\n\n        y\n    },\n    None -> 0,\n}",
+    );
+}
+
+#[test]
+fn format_lambda_block_body_blank_line() {
+    assert_fmt(
+        "const f = |x| {\n    const y = x + 1\n    y\n}",
+        "const f = |x| {\n    const y = x + 1\n\n    y\n}",
+    );
+}
+
 // ── Named arg punning ──────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
closes #275

## Summary

- The formatter now inserts a blank line before the final expression in multi-statement blocks (2+ statements), visually separating the implicit return value from setup code
- Applies to `fn` bodies, `for`-block functions, match arms with block bodies, and lambdas with block bodies
- Single-expression bodies remain unaffected
- Added 6 new test cases covering all scenarios (multi-stmt fn, single-expr fn, idempotent formatting, match arm blocks, lambda blocks)
- Updated docs: `design.md`, `llms.txt`, site `functions.md`, and site `cli.md`

## Test plan

- [x] Multi-statement function gets blank line before last expression
- [x] Single-expression function stays unchanged (no blank line added)
- [x] Already has blank line - formatter is idempotent (no double blank line)
- [x] Two-statement block gets blank line
- [x] Match arms with block bodies get blank line
- [x] Lambda block bodies get blank line
- [x] All existing formatter tests still pass
- [x] `cargo fmt`, `cargo clippy -- -D warnings`, `RUSTFLAGS="-D warnings" cargo test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)