### PR TITLE
[#262] Add Map stdlib module

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -86,6 +86,7 @@ All four of TypeScript's `?` uses (`?.`, `??`, `?:`, `? :`) are removed. `?` now
 | Tuple match patterns | `(0, _) -> ...` | index-based match conditions |
 | tap | `x \|> tap(Console.log)` | IIFE: calls fn, returns value unchanged |
 | Immutable sort | `Array.sort` returns new array | sorted copy, no mutation |
+| Immutable maps | `Map.set`, `Map.remove` return new maps | `new Map([...old, [k, v]])` |
 | Strict parse | `Number.parse("123")` returns `Result` | no silent `NaN` or partial parse |
 | Number separators | `1_000_000`, `3.141_592`, `0xFF_FF` | underscores stripped in output |
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -272,6 +272,13 @@ match user.nickname {
 // Option helpers
 user.nickname |> Option.unwrapOr(user.name)
 user.nickname |> Option.map(|n| toUpper(n))
+
+// Map<K, V> — immutable key-value maps
+const config = Map.fromArray([("host", "localhost"), ("port", "8080")])
+const updated = config |> Map.set("port", "3000")
+const port = Map.get(config, "port")     // Option<string>
+const keys = config |> Map.keys          // Array<string>
+const merged = Map.merge(defaults, config)
 ```
 
 ## Imports

--- a/docs/site/src/content/docs/reference/stdlib.md
+++ b/docs/site/src/content/docs/reference/stdlib.md
@@ -321,6 +321,55 @@ match JSON.parse(input) {
 
 ---
 
+## Map
+
+Immutable key-value map operations. All functions return new maps -- they never mutate the original.
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `Map.empty` | `() -> Map<K, V>` | Create an empty map |
+| `Map.fromArray` | `Array<[K, V]> -> Map<K, V>` | Create a map from key-value pairs |
+| `Map.get` | `Map<K, V>, K -> Option<V>` | Look up a value by key |
+| `Map.set` | `Map<K, V>, K, V -> Map<K, V>` | Add or update a key-value pair |
+| `Map.remove` | `Map<K, V>, K -> Map<K, V>` | Remove a key-value pair |
+| `Map.has` | `Map<K, V>, K -> boolean` | Check if a key exists |
+| `Map.keys` | `Map<K, V> -> Array<K>` | Get all keys |
+| `Map.values` | `Map<K, V> -> Array<V>` | Get all values |
+| `Map.entries` | `Map<K, V> -> Array<[K, V]>` | Get all key-value pairs |
+| `Map.size` | `Map<K, V> -> number` | Number of entries |
+| `Map.isEmpty` | `Map<K, V> -> boolean` | True if map has no entries |
+| `Map.merge` | `Map<K, V>, Map<K, V> -> Map<K, V>` | Merge two maps (second wins on conflict) |
+
+### Examples
+
+```floe
+// Create a map from key-value pairs
+const config = Map.fromArray([("host", "localhost"), ("port", "8080")])
+
+// All operations are immutable
+const updated = config
+  |> Map.set("port", "3000")
+  |> Map.set("debug", "true")
+
+// Safe lookup returns Option
+const port = Map.get(config, "port")   // Some("8080")
+const missing = Map.get(config, "foo") // None
+
+// Check membership
+const hasHost = config |> Map.has("host")   // true
+
+// Convert to arrays
+const keys = config |> Map.keys      // ["host", "port"]
+const values = config |> Map.values  // ["localhost", "8080"]
+
+// Merge maps (second map's values win on key conflict)
+const defaults = Map.fromArray([("port", "80"), ("host", "0.0.0.0")])
+const merged = Map.merge(defaults, config)
+// Map { "port" => "8080", "host" => "localhost" }
+```
+
+---
+
 ## Pipe
 
 Utility functions for pipeline debugging and control flow.

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1673,6 +1673,9 @@ impl Checker {
                 true // empty array [] is compatible with any Array<T>
             }
             (Type::Array(a), Type::Array(b)) => self.types_compatible(a, b),
+            (Type::Map { key: k1, value: v1 }, Type::Map { key: k2, value: v2 }) => {
+                self.types_compatible(k1, k2) && self.types_compatible(v1, v2)
+            }
             (Type::Tuple(a), Type::Tuple(b)) => {
                 a.len() == b.len()
                     && a.iter()

--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -1083,6 +1083,10 @@ impl Checker {
                 Self::collect_generic_params_from_type(ok, names, seen);
                 Self::collect_generic_params_from_type(err, names, seen);
             }
+            Type::Map { key, value } => {
+                Self::collect_generic_params_from_type(key, names, seen);
+                Self::collect_generic_params_from_type(value, names, seen);
+            }
             _ => {}
         }
     }
@@ -1117,6 +1121,10 @@ impl Checker {
             (Type::Array(p), Type::Array(a)) => {
                 Self::unify_for_inference(p, a, generics, subs);
             }
+            (Type::Map { key: pk, value: pv }, Type::Map { key: ak, value: av }) => {
+                Self::unify_for_inference(pk, ak, generics, subs);
+                Self::unify_for_inference(pv, av, generics, subs);
+            }
             (Type::Option(p), Type::Option(a)) => {
                 Self::unify_for_inference(p, a, generics, subs);
             }
@@ -1138,6 +1146,10 @@ impl Checker {
         match ty {
             Type::Named(n) if subs.contains_key(n) => subs[n].clone(),
             Type::Array(inner) => Type::Array(Box::new(Self::substitute_generics(inner, subs))),
+            Type::Map { key, value } => Type::Map {
+                key: Box::new(Self::substitute_generics(key, subs)),
+                value: Box::new(Self::substitute_generics(value, subs)),
+            },
             Type::Option(inner) => Type::Option(Box::new(Self::substitute_generics(inner, subs))),
             Type::Tuple(types) => Type::Tuple(
                 types
@@ -1166,6 +1178,7 @@ impl Checker {
     fn type_to_stdlib_module(ty: &Type) -> Option<&'static str> {
         match ty {
             Type::Array(_) => Some(type_names::MOD_ARRAY),
+            Type::Map { .. } => Some(type_names::MOD_MAP),
             Type::String => Some(type_names::MOD_STRING),
             Type::Number => Some(type_names::MOD_NUMBER),
             Type::Option(_) => Some(type_names::MOD_OPTION),

--- a/src/checker/types.rs
+++ b/src/checker/types.rs
@@ -39,6 +39,11 @@ pub enum Type {
     },
     /// Array type
     Array(Box<Type>),
+    /// Map type: Map<K, V>
+    Map {
+        key: Box<Type>,
+        value: Box<Type>,
+    },
     /// Tuple type
     Tuple(Vec<Type>),
     /// Record/struct type
@@ -97,6 +102,9 @@ impl Type {
                 format!("({}) -> {}", p.join(", "), return_type.display_name())
             }
             Type::Array(inner) => format!("Array<{}>", inner.display_name()),
+            Type::Map { key, value } => {
+                format!("Map<{}, {}>", key.display_name(), value.display_name())
+            }
             Type::Tuple(types) => {
                 let t: Vec<_> = types.iter().map(|t| t.display_name()).collect();
                 format!("({})", t.join(", "))

--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -491,6 +491,7 @@ impl Codegen {
         use crate::checker::Type;
         match ty {
             Type::Array(_) => Some("Array"),
+            Type::Map { .. } => Some("Map"),
             Type::String => Some("String"),
             Type::Number => Some("Number"),
             Type::Option(_) => Some("Option"),

--- a/src/lsp/stdlib_hover.rs
+++ b/src/lsp/stdlib_hover.rs
@@ -30,6 +30,7 @@ fn format_type(ty: &crate::checker::Type) -> String {
         Type::Named(n) => n.clone(),
         Type::Var(id) => type_var_name(*id).to_string(),
         Type::Array(inner) => format!("Array<{}>", format_type(inner)),
+        Type::Map { key, value } => format!("Map<{}, {}>", format_type(key), format_type(value)),
         Type::Option(inner) => format!("Option<{}>", format_type(inner)),
         Type::Result { ok, err } => {
             format!("Result<{}, {}>", format_type(ok), format_type(err))
@@ -205,6 +206,18 @@ mod tests {
         assert!(text.contains("module Number"));
         assert!(text.contains("parse"));
         assert!(text.contains("clamp"));
+    }
+
+    #[test]
+    fn hover_map_module() {
+        let result = hover_stdlib_module("Map");
+        assert!(result.is_some());
+        let text = result.unwrap();
+        assert!(text.contains("module Map"));
+        assert!(text.contains("get"));
+        assert!(text.contains("set"));
+        assert!(text.contains("keys"));
+        assert!(text.contains("merge"));
     }
 
     #[test]

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -79,6 +79,12 @@ fn result_of(ok: Type, err: Type) -> Type {
         err: Box::new(err),
     }
 }
+fn map_of(k: Type, v: Type) -> Type {
+    Type::Map {
+        key: Box::new(k),
+        value: Box::new(v),
+    }
+}
 fn fun(params: Vec<Type>, ret: Type) -> Type {
     Type::Function {
         params,
@@ -195,6 +201,19 @@ fn build_stdlib() -> Vec<StdlibFn> {
         stdlib_fn!("Math", "sin", [Type::Number], Type::Number, "Math.sin($0)"),
         stdlib_fn!("Math", "cos", [Type::Number], Type::Number, "Math.cos($0)"),
         stdlib_fn!("Math", "tan", [Type::Number], Type::Number, "Math.tan($0)"),
+        // ── Map ────────────────────────────────────────────────────
+        stdlib_fn!("Map", "empty", [], map_of(t.clone(), u.clone()), "new Map()"),
+        stdlib_fn!("Map", "fromArray", [array_of(Type::Tuple(vec![t.clone(), u.clone()]))], map_of(t.clone(), u.clone()), "new Map($0)"),
+        stdlib_fn!("Map", "get", [map_of(t.clone(), u.clone()), t.clone()], option_of(u.clone()), "$0.has($1) ? $0.get($1) : undefined"),
+        stdlib_fn!("Map", "set", [map_of(t.clone(), u.clone()), t.clone(), u.clone()], map_of(t.clone(), u.clone()), "new Map([...$0, [$1, $2]])"),
+        stdlib_fn!("Map", "remove", [map_of(t.clone(), u.clone()), t.clone()], map_of(t.clone(), u.clone()), "new Map([...$0].filter(([k]) => k !== $1))"),
+        stdlib_fn!("Map", "has", [map_of(t.clone(), u.clone()), t.clone()], Type::Bool, "$0.has($1)"),
+        stdlib_fn!("Map", "keys", [map_of(t.clone(), u.clone())], array_of(t.clone()), "[...$0.keys()]"),
+        stdlib_fn!("Map", "values", [map_of(t.clone(), u.clone())], array_of(u.clone()), "[...$0.values()]"),
+        stdlib_fn!("Map", "entries", [map_of(t.clone(), u.clone())], array_of(Type::Tuple(vec![t.clone(), u.clone()])), "[...$0.entries()]"),
+        stdlib_fn!("Map", "size", [map_of(t.clone(), u.clone())], Type::Number, "$0.size"),
+        stdlib_fn!("Map", "isEmpty", [map_of(t.clone(), u.clone())], Type::Bool, "$0.size === 0"),
+        stdlib_fn!("Map", "merge", [map_of(t.clone(), u.clone()), map_of(t.clone(), u.clone())], map_of(t.clone(), u.clone()), "new Map([...$0, ...$1])"),
         // ── Pipe Utilities ────────────────────────────────────────
         stdlib_fn!("Pipe", "tap", [t.clone(), fun(vec![t.clone()], Type::Unit)], t.clone(), "(() => { const _v = $0; ($1)(_v); return _v; })()"),
         // ── JSON ───────────────────────────────────────────────
@@ -278,6 +297,90 @@ mod tests {
     }
 
     #[test]
+    fn lookup_map_empty() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Map", "empty").unwrap();
+        assert_eq!(f.codegen, "new Map()");
+    }
+
+    #[test]
+    fn lookup_map_from_array() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Map", "fromArray").unwrap();
+        assert_eq!(f.codegen, "new Map($0)");
+    }
+
+    #[test]
+    fn lookup_map_get() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Map", "get").unwrap();
+        assert_eq!(f.codegen, "$0.has($1) ? $0.get($1) : undefined");
+    }
+
+    #[test]
+    fn lookup_map_set() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Map", "set").unwrap();
+        assert_eq!(f.codegen, "new Map([...$0, [$1, $2]])");
+    }
+
+    #[test]
+    fn lookup_map_remove() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Map", "remove").unwrap();
+        assert!(f.codegen.contains("filter"));
+    }
+
+    #[test]
+    fn lookup_map_has() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Map", "has").unwrap();
+        assert_eq!(f.codegen, "$0.has($1)");
+    }
+
+    #[test]
+    fn lookup_map_keys() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Map", "keys").unwrap();
+        assert_eq!(f.codegen, "[...$0.keys()]");
+    }
+
+    #[test]
+    fn lookup_map_values() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Map", "values").unwrap();
+        assert_eq!(f.codegen, "[...$0.values()]");
+    }
+
+    #[test]
+    fn lookup_map_entries() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Map", "entries").unwrap();
+        assert_eq!(f.codegen, "[...$0.entries()]");
+    }
+
+    #[test]
+    fn lookup_map_size() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Map", "size").unwrap();
+        assert_eq!(f.codegen, "$0.size");
+    }
+
+    #[test]
+    fn lookup_map_is_empty() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Map", "isEmpty").unwrap();
+        assert_eq!(f.codegen, "$0.size === 0");
+    }
+
+    #[test]
+    fn lookup_map_merge() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Map", "merge").unwrap();
+        assert_eq!(f.codegen, "new Map([...$0, ...$1])");
+    }
+
+    #[test]
     fn lookup_nonexistent() {
         let reg = StdlibRegistry::new();
         assert!(reg.lookup("Array", "nonexistent").is_none());
@@ -296,6 +399,7 @@ mod tests {
         assert!(reg.is_module("Math"));
         assert!(reg.is_module("JSON"));
         assert!(reg.is_module("Pipe"));
+        assert!(reg.is_module("Map"));
         assert!(!reg.is_module("Foo"));
     }
 
@@ -310,6 +414,7 @@ mod tests {
         assert!(reg.module_functions("Console").len() >= 5);
         assert!(reg.module_functions("Math").len() >= 14);
         assert!(reg.module_functions("JSON").len() >= 2);
+        assert!(reg.module_functions("Map").len() >= 12);
     }
 
     #[test]

--- a/src/type_names.rs
+++ b/src/type_names.rs
@@ -18,3 +18,4 @@ pub const MOD_STRING: &str = "String";
 pub const MOD_NUMBER: &str = "Number";
 pub const MOD_OPTION: &str = "Option";
 pub const MOD_RESULT: &str = "Result";
+pub const MOD_MAP: &str = "Map";


### PR DESCRIPTION
closes #262

## Summary
- Adds `Map` stdlib module with 12 immutable key-value operations: `empty`, `fromArray`, `get`, `set`, `remove`, `has`, `keys`, `values`, `entries`, `size`, `isEmpty`, `merge`
- Adds `Map { key, value }` variant to the checker `Type` enum with full support for type compatibility, generic inference, and generic substitution
- Adds `Map` to type-directed pipe resolution in both checker and codegen
- Adds LSP hover support for the Map module and its functions
- Updates docs: `design.md`, `docs/site/reference/stdlib.md`, and `docs/llms.txt`

## Test plan
- [x] All 12 Map stdlib functions have unit tests verifying codegen templates
- [x] `is_module("Map")` test added
- [x] `module_functions("Map")` count test added
- [x] LSP hover test for Map module added
- [x] `cargo fmt` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `RUSTFLAGS="-D warnings" cargo test` passes (all 207 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)