### PR TITLE
[#265] Add array pattern matching in match expressions

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -84,6 +84,7 @@ All four of TypeScript's `?` uses (`?.`, `??`, `?:`, `? :`) are removed. `?` now
 | Tuple types | `(number, string)`, `(1, "a")` | `readonly [number, string]`, `[1, "a"] as const` |
 | Tuple destructuring | `const (x, y) = pair` | `const [x, y] = pair` |
 | Tuple match patterns | `(0, _) -> ...` | index-based match conditions |
+| Array match patterns | `[first, ..rest] -> ...` | length check + index/slice access |
 | tap | `x \|> tap(Console.log)` | IIFE: calls fn, returns value unchanged |
 | Immutable sort | `Array.sort` returns new array | sorted copy, no mutation |
 | Strict parse | `Number.parse("123")` returns `Result` | no silent `NaN` or partial parse |
@@ -235,6 +236,51 @@ match url {
 ```
 
 Match uses `->` for arms (not `|x|`), so it's visually distinct from lambdas.
+
+### Array Pattern Matching
+
+Match on array structure with head/tail destructuring:
+
+```floe
+match items {
+    [] -> "empty",
+    [only] -> `just one: ${only}`,
+    [first, second] -> "exactly two",
+    [first, ..rest] -> `first is ${first}, ${rest |> Array.length} more`,
+}
+```
+
+| Pattern | Matches | Binds |
+|---|---|---|
+| `[]` | Empty array | Nothing |
+| `[a]` | Exactly 1 element | `a` |
+| `[a, b]` | Exactly 2 elements | `a`, `b` |
+| `[first, ..rest]` | 1 or more elements | `first` (head), `rest` (tail array) |
+| `[first, second, ..rest]` | 2 or more elements | `first`, `second`, `rest` |
+| `[_, ..rest]` | 1 or more, ignore head | `rest` |
+
+**Exhaustiveness:** `[]` + `[_, ..rest]` covers all cases (empty + non-empty). `[a]` alone is not exhaustive.
+
+**Codegen:**
+
+```floe
+match items {
+    [] -> "empty",
+    [first, ..rest] -> first,
+}
+```
+
+Emits:
+
+```typescript
+items.length === 0 ? "empty" : items.length >= 1 ? (() => { const first = items[0]; const rest = items.slice(1); return first; })() : (() => { throw new Error("non-exhaustive match"); })()
+```
+
+- Empty pattern `[]` checks `subject.length === 0`
+- Exact patterns `[a, b]` check `subject.length === N`
+- Rest patterns `[a, ..rest]` check `subject.length >= N` where N is the count of fixed elements
+- Element bindings use index access: `subject[0]`, `subject[1]`
+- Rest bindings use slice: `subject.slice(N)`
 
 ### Match Arm Guards
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -225,6 +225,20 @@ match appError {
     _ -> showGenericError(appError),
 }
 
+// Array pattern matching
+match items {
+    [] -> "empty",
+    [only] -> `just ${only}`,
+    [first, second] -> "exactly two",
+    [first, ..rest] -> `first is ${first}, rest has ${rest |> Array.length}`,
+}
+
+// Exhaustive array matching ([] + [_, ..rest] covers all cases)
+match items {
+    [] -> "empty",
+    [head, ..tail] -> `head: ${head}`,
+}
+
 // Inline match in JSX
 <div className={match active { true -> "bold", false -> "dim" }}>
     {match error {

--- a/docs/site/src/content/docs/guide/pattern-matching.md
+++ b/docs/site/src/content/docs/guide/pattern-matching.md
@@ -105,6 +105,43 @@ Captured variables (`id`, `postId`) are bound as `string` in the match arm body.
 
 This is useful for URL routing, string parsing, and any case where you need to extract structured data from strings.
 
+## Array Patterns
+
+Match on array structure with head/tail destructuring:
+
+```floe
+match items {
+    [] -> "empty",
+    [only] -> `just one: ${only}`,
+    [first, second] -> "exactly two",
+    [first, ..rest] -> `first is ${first}, rest has ${rest |> Array.length}`,
+}
+```
+
+### Supported patterns
+
+| Pattern | Matches | Binds |
+|---|---|---|
+| `[]` | Empty array | Nothing |
+| `[a]` | Exactly 1 element | `a` |
+| `[a, b]` | Exactly 2 elements | `a`, `b` |
+| `[first, ..rest]` | 1 or more elements | `first` (head), `rest` (tail array) |
+| `[first, second, ..rest]` | 2 or more elements | `first`, `second`, `rest` |
+| `[_, ..rest]` | 1 or more, ignore head | `rest` |
+
+### Exhaustiveness
+
+`[]` combined with `[_, ..rest]` covers all cases (empty + non-empty):
+
+```floe
+match items {
+    [] -> "nothing here",
+    [head, ..tail] -> `starts with ${head}`,
+}
+```
+
+A pattern like `[a]` alone is NOT exhaustive - it only matches arrays of exactly one element.
+
 ## Wildcard
 
 The `_` pattern matches anything. Place it last as a default:
@@ -196,3 +233,4 @@ This applies to:
 - **Result** - must handle `Ok` and `Err`
 - **Option** - must handle `Some` and `None`
 - **Unions** - must handle every variant (or use `_`)
+- **Arrays** - `[]` + `[_, ..rest]` covers all cases (empty + non-empty)

--- a/src/checker/match_check.rs
+++ b/src/checker/match_check.rs
@@ -168,6 +168,50 @@ impl Checker {
             }
         }
 
+        // For array types, check if empty + non-empty are covered
+        if matches!(subject_ty, Type::Array(_)) {
+            let mut has_empty = false;
+            let mut has_nonempty_rest = false;
+
+            for arm in arms {
+                if arm.guard.is_some() {
+                    continue;
+                }
+                if let PatternKind::Array { elements, rest } = &arm.pattern.kind {
+                    if elements.is_empty() && rest.is_none() {
+                        has_empty = true;
+                    }
+                    if rest.is_some() {
+                        has_nonempty_rest = true;
+                    }
+                }
+            }
+
+            // If there are array patterns but they don't cover all cases
+            let has_any_array_pattern = arms
+                .iter()
+                .any(|a| matches!(a.pattern.kind, PatternKind::Array { .. }));
+            if has_any_array_pattern && !(has_empty && has_nonempty_rest) {
+                let missing = match (has_empty, has_nonempty_rest) {
+                    (false, false) => "empty array `[]` and non-empty array `[_, .._]`",
+                    (false, true) => "empty array `[]`",
+                    (true, false) => "non-empty array `[_, .._]`",
+                    _ => unreachable!(),
+                };
+                self.diagnostics.push(
+                    Diagnostic::error(
+                        format!("non-exhaustive match on array: missing {missing}"),
+                        span,
+                    )
+                    .with_label("not all cases covered")
+                    .with_help(
+                        "add match arms for both `[]` and `[_, ..rest]`, or add a `_ ->` catch-all",
+                    )
+                    .with_code("E004"),
+                );
+            }
+        }
+
         // For bool, check true/false covered
         if matches!(subject_ty, Type::Bool) {
             let mut has_true = false;
@@ -296,6 +340,32 @@ impl Checker {
                     for pat in patterns {
                         self.check_pattern(pat, &Type::Unknown);
                     }
+                }
+            }
+            PatternKind::Array { elements, rest } => {
+                // Determine element type from subject
+                let elem_ty = if let Type::Array(inner) = subject_ty {
+                    inner.as_ref().clone()
+                } else {
+                    Type::Unknown
+                };
+
+                // Bind each element pattern
+                for pat in elements {
+                    self.check_pattern(pat, &elem_ty);
+                }
+
+                // Bind rest as array of same element type
+                if let Some(name) = rest
+                    && name != "_"
+                {
+                    let rest_ty = if let Type::Array(_) = subject_ty {
+                        subject_ty.clone()
+                    } else {
+                        Type::Array(Box::new(Type::Unknown))
+                    };
+                    self.env.define(name, rest_ty.clone());
+                    self.name_types.insert(name.clone(), rest_ty.display_name());
                 }
             }
         }

--- a/src/codegen/match_emit.rs
+++ b/src/codegen/match_emit.rs
@@ -210,6 +210,41 @@ impl Codegen {
                 }
                 self.push("$/)")
             }
+            PatternKind::Array { elements, rest } => {
+                let subj_str = self.expr_to_string(subject);
+                if elements.is_empty() && rest.is_none() {
+                    // Empty array: `[]` → subject.length === 0
+                    self.push(&format!("{subj_str}.length === 0"));
+                } else if rest.is_some() {
+                    // With rest: `[a, b, ..rest]` → subject.length >= elements.len()
+                    self.push(&format!("{subj_str}.length >= {}", elements.len()));
+                    // Add conditions for non-trivial element patterns
+                    for (i, pat) in elements.iter().enumerate() {
+                        if !matches!(pat.kind, PatternKind::Wildcard | PatternKind::Binding(_)) {
+                            self.push(" && ");
+                            let elem_expr = Expr {
+                                kind: ExprKind::Identifier(format!("{subj_str}[{i}]")),
+                                span: subject.span,
+                            };
+                            self.emit_pattern_condition(&elem_expr, pat);
+                        }
+                    }
+                } else {
+                    // Exact length: `[a, b]` → subject.length === elements.len()
+                    self.push(&format!("{subj_str}.length === {}", elements.len()));
+                    // Add conditions for non-trivial element patterns
+                    for (i, pat) in elements.iter().enumerate() {
+                        if !matches!(pat.kind, PatternKind::Wildcard | PatternKind::Binding(_)) {
+                            self.push(" && ");
+                            let elem_expr = Expr {
+                                kind: ExprKind::Identifier(format!("{subj_str}[{i}]")),
+                                span: subject.span,
+                            };
+                            self.emit_pattern_condition(&elem_expr, pat);
+                        }
+                    }
+                }
+            }
             PatternKind::Binding(_) | PatternKind::Wildcard => {
                 self.push("true");
             }
@@ -369,6 +404,22 @@ fn collect_bindings_inner(
                     span: subject.span,
                 };
                 collect_bindings_inner(&elem_expr, pat, expr_to_str, variant_info, bindings);
+            }
+        }
+        PatternKind::Array { elements, rest } => {
+            for (i, pat) in elements.iter().enumerate() {
+                let elem_access = format!("{}[{}]", expr_to_str(subject), i);
+                let elem_expr = Expr {
+                    kind: ExprKind::Identifier(elem_access),
+                    span: subject.span,
+                };
+                collect_bindings_inner(&elem_expr, pat, expr_to_str, variant_info, bindings);
+            }
+            if let Some(name) = rest
+                && name != "_"
+            {
+                let rest_access = format!("{}.slice({})", expr_to_str(subject), elements.len());
+                bindings.push((name.clone(), rest_access));
             }
         }
         PatternKind::StringPattern { .. } => {

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -988,3 +988,112 @@ fn string_literal_union_exported() {
     assert!(result.starts_with("export type Direction = "));
     assert!(result.contains(r#""north" | "south" | "east" | "west""#));
 }
+
+// ── Array Pattern Matching ──────────────────────────────────
+
+#[test]
+fn match_array_empty() {
+    let result = emit(r#"match items { [] -> "empty", _ -> "other" }"#);
+    assert!(
+        result.contains(".length === 0"),
+        "expected empty array check, got: {result}"
+    );
+    assert!(
+        result.contains("\"empty\""),
+        "expected empty branch, got: {result}"
+    );
+}
+
+#[test]
+fn match_array_single() {
+    let result = emit(r#"match items { [a] -> a, _ -> "none" }"#);
+    assert!(
+        result.contains(".length === 1"),
+        "expected single element check, got: {result}"
+    );
+    assert!(
+        result.contains("[0]"),
+        "expected index access for binding, got: {result}"
+    );
+}
+
+#[test]
+fn match_array_two_elements() {
+    let result = emit(r#"match items { [a, b] -> a, _ -> "none" }"#);
+    assert!(
+        result.contains(".length === 2"),
+        "expected two element check, got: {result}"
+    );
+}
+
+#[test]
+fn match_array_rest() {
+    let result = emit("match items { [first, ..rest] -> first, _ -> 0 }");
+    assert!(
+        result.contains(".length >= 1"),
+        "expected length >= 1 check, got: {result}"
+    );
+    assert!(
+        result.contains("[0]"),
+        "expected index access for first, got: {result}"
+    );
+    assert!(
+        result.contains(".slice(1)"),
+        "expected slice for rest, got: {result}"
+    );
+}
+
+#[test]
+fn match_array_two_plus_rest() {
+    let result = emit("match items { [a, b, ..rest] -> a, _ -> 0 }");
+    assert!(
+        result.contains(".length >= 2"),
+        "expected length >= 2 check, got: {result}"
+    );
+    assert!(
+        result.contains(".slice(2)"),
+        "expected slice(2) for rest, got: {result}"
+    );
+}
+
+#[test]
+fn match_array_empty_and_rest_exhaustive() {
+    // [] + [_, ..rest] covers all cases — should not add non-exhaustive throw
+    let result = emit(r#"match items { [] -> "empty", [first, ..rest] -> first }"#);
+    assert!(
+        result.contains(".length === 0"),
+        "expected empty check, got: {result}"
+    );
+    assert!(
+        result.contains(".length >= 1"),
+        "expected non-empty check, got: {result}"
+    );
+}
+
+#[test]
+fn match_array_wildcard_rest() {
+    // [_, ..rest] with underscore as first element
+    let result = emit("match items { [_, ..rest] -> rest, _ -> items }");
+    assert!(
+        result.contains(".length >= 1"),
+        "expected length >= 1, got: {result}"
+    );
+    assert!(
+        result.contains(".slice(1)"),
+        "expected slice(1) for rest, got: {result}"
+    );
+}
+
+#[test]
+fn match_array_literal_element() {
+    // Pattern with literal sub-pattern
+    let result = emit(r#"match items { [1] -> "one", _ -> "other" }"#);
+    assert!(
+        result.contains(".length === 1"),
+        "expected length check, got: {result}"
+    );
+    assert!(
+        result.contains("[0] === 1"),
+        "expected literal element check, got: {result}"
+    );
+}

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -1323,6 +1323,43 @@ impl<'src> CstParser<'src> {
                 self.parse_comma_separated(Self::parse_record_pattern_field, TokenKind::RightBrace);
                 self.expect(TokenKind::RightBrace);
             }
+            Some(TokenKind::LeftBracket) => {
+                // Array pattern: [], [a, b], [first, ..rest]
+                self.bump(); // [
+                self.eat_trivia();
+                // Parse elements and optional rest pattern
+                while !self.at(TokenKind::RightBracket) && !self.at_end() {
+                    // Check for rest pattern: ..name
+                    if self.at(TokenKind::DotDot) {
+                        self.bump(); // ..
+                        self.eat_trivia();
+                        // Expect identifier or _ after ..
+                        if matches!(
+                            self.current_kind(),
+                            Some(TokenKind::Identifier(_)) | Some(TokenKind::Underscore)
+                        ) {
+                            self.bump();
+                        } else {
+                            self.error("expected identifier after '..' in array pattern");
+                        }
+                        self.eat_trivia();
+                        if self.at(TokenKind::Comma) {
+                            self.bump();
+                            self.eat_trivia();
+                        }
+                        break;
+                    }
+                    self.parse_pattern();
+                    self.eat_trivia();
+                    if self.at(TokenKind::Comma) {
+                        self.bump();
+                        self.eat_trivia();
+                    } else {
+                        break;
+                    }
+                }
+                self.expect(TokenKind::RightBracket);
+            }
             Some(TokenKind::LeftParen) => {
                 // Tuple pattern: (x, y)
                 self.bump(); // (

--- a/src/lower/pattern.rs
+++ b/src/lower/pattern.rs
@@ -188,6 +188,52 @@ impl<'src> Lowerer<'src> {
                             span,
                         });
                     }
+                    SyntaxKind::L_BRACKET => {
+                        // Array pattern: [], [a, b], [first, ..rest]
+                        let child_patterns: Vec<Pattern> = node
+                            .children()
+                            .filter(|c| c.kind() == SyntaxKind::PATTERN)
+                            .filter_map(|c| self.lower_pattern(&c))
+                            .collect();
+
+                        // Check for rest pattern (..name) by looking for DOT_DOT token
+                        let rest = if self.has_token(node, SyntaxKind::DOT_DOT) {
+                            // Find the identifier after ..
+                            let mut found_dotdot = false;
+                            let mut rest_name = None;
+                            for child_or_token in node.children_with_tokens() {
+                                if let Some(token) = child_or_token.as_token() {
+                                    if token.kind() == SyntaxKind::DOT_DOT {
+                                        found_dotdot = true;
+                                        continue;
+                                    }
+                                    if found_dotdot && !token.kind().is_trivia() {
+                                        match token.kind() {
+                                            SyntaxKind::IDENT => {
+                                                rest_name = Some(token.text().to_string());
+                                            }
+                                            SyntaxKind::UNDERSCORE => {
+                                                rest_name = Some("_".to_string());
+                                            }
+                                            _ => {}
+                                        }
+                                        break;
+                                    }
+                                }
+                            }
+                            rest_name
+                        } else {
+                            None
+                        };
+
+                        return Some(Pattern {
+                            kind: PatternKind::Array {
+                                elements: child_patterns,
+                                rest,
+                            },
+                            span,
+                        });
+                    }
                     SyntaxKind::L_PAREN => {
                         // Tuple pattern: (x, y)
                         let patterns: Vec<Pattern> = node

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -514,6 +514,13 @@ pub enum PatternKind {
     Wildcard,
     /// Tuple pattern: `(x, y)`, `(_, 0)`
     Tuple(Vec<Pattern>),
+    /// Array pattern: `[]`, `[a]`, `[a, b]`, `[first, ..rest]`
+    Array {
+        /// Fixed element patterns (before any rest pattern)
+        elements: Vec<Pattern>,
+        /// Optional rest binding: `..rest` captures the remaining tail
+        rest: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/parser/pattern.rs
+++ b/src/parser/pattern.rs
@@ -213,6 +213,56 @@ impl Parser {
                 })
             }
 
+            // Array pattern: `[]`, `[a, b]`, `[first, ..rest]`
+            TokenKind::LeftBracket => {
+                self.advance(); // [
+                let mut elements = Vec::new();
+                let mut rest = None;
+
+                while !self.check(&TokenKind::RightBracket) && !self.is_at_end() {
+                    // Check for rest pattern: `..name`
+                    if self.check(&TokenKind::DotDot) {
+                        self.advance(); // ..
+                        // The rest binding name
+                        match self.current_kind() {
+                            TokenKind::Identifier(name) => {
+                                rest = Some(name.clone());
+                                self.advance();
+                            }
+                            TokenKind::Underscore => {
+                                rest = Some("_".to_string());
+                                self.advance();
+                            }
+                            _ => {
+                                return Err(
+                                    self.error("expected identifier after '..' in array pattern")
+                                );
+                            }
+                        }
+                        // After rest, only comma and ] are allowed
+                        if self.check(&TokenKind::Comma) {
+                            self.advance();
+                        }
+                        break;
+                    }
+
+                    elements.push(self.parse_pattern()?);
+
+                    if self.check(&TokenKind::Comma) {
+                        self.advance();
+                    } else {
+                        break;
+                    }
+                }
+
+                self.expect(&TokenKind::RightBracket)?;
+                let end_span = self.previous_span();
+                Ok(Pattern {
+                    kind: PatternKind::Array { elements, rest },
+                    span: self.merge_spans(start_span, end_span),
+                })
+            }
+
             // Tuple pattern: `(x, y)` or `(_, 0)`
             TokenKind::LeftParen => {
                 self.advance(); // (

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -446,6 +446,92 @@ fn match_guard_no_guard() {
     }
 }
 
+// ── Array Pattern Matching ───────────────────────────────────
+
+#[test]
+fn match_array_empty() {
+    let expr = first_expr(r#"match items { [] -> "empty", _ -> "other" }"#);
+    match expr {
+        ExprKind::Match { arms, .. } => {
+            assert!(matches!(
+                arms[0].pattern.kind,
+                PatternKind::Array {
+                    ref elements,
+                    ref rest
+                } if elements.is_empty() && rest.is_none()
+            ));
+        }
+        _ => panic!("expected match"),
+    }
+}
+
+#[test]
+fn match_array_single_binding() {
+    let expr = first_expr("match items { [a] -> a, _ -> 0 }");
+    match expr {
+        ExprKind::Match { arms, .. } => {
+            if let PatternKind::Array { elements, rest } = &arms[0].pattern.kind {
+                assert_eq!(elements.len(), 1);
+                assert!(matches!(elements[0].kind, PatternKind::Binding(ref n) if n == "a"));
+                assert!(rest.is_none());
+            } else {
+                panic!("expected array pattern");
+            }
+        }
+        _ => panic!("expected match"),
+    }
+}
+
+#[test]
+fn match_array_rest_pattern() {
+    let expr = first_expr("match items { [first, ..rest] -> first, _ -> 0 }");
+    match expr {
+        ExprKind::Match { arms, .. } => {
+            if let PatternKind::Array { elements, rest } = &arms[0].pattern.kind {
+                assert_eq!(elements.len(), 1);
+                assert!(matches!(elements[0].kind, PatternKind::Binding(ref n) if n == "first"));
+                assert_eq!(rest.as_deref(), Some("rest"));
+            } else {
+                panic!("expected array pattern");
+            }
+        }
+        _ => panic!("expected match"),
+    }
+}
+
+#[test]
+fn match_array_two_plus_rest() {
+    let expr = first_expr("match items { [a, b, ..rest] -> a, _ -> 0 }");
+    match expr {
+        ExprKind::Match { arms, .. } => {
+            if let PatternKind::Array { elements, rest } = &arms[0].pattern.kind {
+                assert_eq!(elements.len(), 2);
+                assert_eq!(rest.as_deref(), Some("rest"));
+            } else {
+                panic!("expected array pattern");
+            }
+        }
+        _ => panic!("expected match"),
+    }
+}
+
+#[test]
+fn match_array_wildcard_rest() {
+    let expr = first_expr("match items { [_, .._] -> 1, _ -> 0 }");
+    match expr {
+        ExprKind::Match { arms, .. } => {
+            if let PatternKind::Array { elements, rest } = &arms[0].pattern.kind {
+                assert_eq!(elements.len(), 1);
+                assert!(matches!(elements[0].kind, PatternKind::Wildcard));
+                assert_eq!(rest.as_deref(), Some("_"));
+            } else {
+                panic!("expected array pattern");
+            }
+        }
+        _ => panic!("expected match"),
+    }
+}
+
 // ── Const Declaration ────────────────────────────────────────
 
 #[test]

--- a/tests/fixtures/array_patterns.fl
+++ b/tests/fixtures/array_patterns.fl
@@ -1,0 +1,20 @@
+const items = [1, 2, 3]
+
+const _result = match items {
+    [] -> "empty",
+    [only] -> only,
+    [first, ..rest] -> first,
+}
+
+// Two-element exact match
+const pair = [10, 20]
+const _sum = match pair {
+    [a, b] -> a + b,
+    _ -> 0,
+}
+
+// Rest pattern with multiple leading elements
+const _head = match items {
+    [a, b, ..rest] -> a + b,
+    _ -> 0,
+}

--- a/tests/snapshot_codegen.rs
+++ b/tests/snapshot_codegen.rs
@@ -153,3 +153,9 @@ fn snapshot_record_spread() {
     let output = compile_fixture("record_spread");
     insta::assert_snapshot!(output);
 }
+
+#[test]
+fn snapshot_array_patterns() {
+    let output = compile_fixture("array_patterns");
+    insta::assert_snapshot!(output);
+}

--- a/tests/snapshots/snapshot_codegen__snapshot_array_patterns.snap
+++ b/tests/snapshots/snapshot_codegen__snapshot_array_patterns.snap
@@ -1,0 +1,13 @@
+---
+source: tests/snapshot_codegen.rs
+expression: output
+---
+const items = [1, 2, 3];
+
+const _result = items.length === 0 ? "empty" : items.length === 1 ? (() => { const only = items[0]; return only; })() : items.length >= 1 ? (() => { const first = items[0]; const rest = items.slice(1); return first; })() : (() => { throw new Error("non-exhaustive match"); })();
+
+const pair = [10, 20];
+
+const _sum = pair.length === 2 ? (() => { const a = pair[0]; const b = pair[1]; return a + b; })() : 0;
+
+const _head = items.length >= 2 ? (() => { const a = items[0]; const b = items[1]; const rest = items.slice(2); return a + b; })() : 0;


### PR DESCRIPTION
closes #265

## Summary

- Add `PatternKind::Array` AST variant with fixed elements and optional rest binding
- Parse `[a, b, ..rest]` syntax in both the old parser and CST parser
- Lower CST array patterns to AST in the lowering pass
- Type-check array patterns: bind elements to the array's element type, bind rest to the full array type
- Exhaustiveness checking: `[]` + `[_, ..rest]` covers all cases; partial array patterns emit a diagnostic
- Codegen: empty `[]` emits `length === 0`, exact `[a, b]` emits `length === N`, rest `[a, ..r]` emits `length >= N` with `slice()` for the rest binding

## Test plan

- [x] Parser tests: empty, single, rest, two+rest, wildcard rest patterns
- [x] Codegen tests: empty, single, two elements, rest, two+rest, exhaustive, wildcard rest, literal element
- [x] Snapshot test with `array_patterns.fl` fixture
- [x] All 741 existing unit tests pass
- [x] All 23 snapshot codegen tests pass
- [x] All 16 snapshot error tests pass
- [x] `cargo fmt` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `RUSTFLAGS="-D warnings" cargo test` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)