### PR TITLE
[#263] Add Set stdlib module

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -88,6 +88,7 @@ All four of TypeScript's `?` uses (`?.`, `??`, `?:`, `? :`) are removed. `?` now
 | tap | `x \|> tap(Console.log)` | IIFE: calls fn, returns value unchanged |
 | Immutable sort | `Array.sort` returns new array | sorted copy, no mutation |
 | Immutable maps | `Map.set`, `Map.remove` return new maps | `new Map([...old, [k, v]])` |
+| Immutable sets | `Set.add`, `Set.remove` return new sets | `new Set([...old, val])` |
 | Strict parse | `Number.parse("123")` returns `Result` | no silent `NaN` or partial parse |
 | Number separators | `1_000_000`, `3.141_592`, `0xFF_FF` | underscores stripped in output |
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -293,6 +293,14 @@ const updated = config |> Map.set("port", "3000")
 const port = Map.get(config, "port")     // Option<string>
 const keys = config |> Map.keys          // Array<string>
 const merged = Map.merge(defaults, config)
+
+// Set<T> — immutable unique collections
+const tags = Set.fromArray(["urgent", "bug", "frontend"])
+const updated = tags |> Set.add("backend")
+const isUrgent = tags |> Set.has("urgent")    // boolean
+const teamAll = Set.union(teamA, teamB)
+const overlap = Set.intersect(teamA, teamB)
+const diff = Set.diff(teamA, teamB)
 ```
 
 ## Imports

--- a/docs/site/src/content/docs/reference/stdlib.md
+++ b/docs/site/src/content/docs/reference/stdlib.md
@@ -370,6 +370,52 @@ const merged = Map.merge(defaults, config)
 
 ---
 
+## Set
+
+Immutable unique collection operations. All functions return new sets -- they never mutate the original.
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `Set.empty` | `() -> Set<T>` | Create an empty set |
+| `Set.fromArray` | `Array<T> -> Set<T>` | Create a set from an array |
+| `Set.toArray` | `Set<T> -> Array<T>` | Convert a set to an array |
+| `Set.add` | `Set<T>, T -> Set<T>` | Add an element |
+| `Set.remove` | `Set<T>, T -> Set<T>` | Remove an element |
+| `Set.has` | `Set<T>, T -> boolean` | Check if an element exists |
+| `Set.size` | `Set<T> -> number` | Number of elements |
+| `Set.isEmpty` | `Set<T> -> boolean` | True if set has no elements |
+| `Set.union` | `Set<T>, Set<T> -> Set<T>` | Union of two sets |
+| `Set.intersect` | `Set<T>, Set<T> -> Set<T>` | Intersection of two sets |
+| `Set.diff` | `Set<T>, Set<T> -> Set<T>` | Difference (elements in first but not second) |
+
+### Examples
+
+```floe
+// Create a set from an array
+const tags = Set.fromArray(["urgent", "bug", "frontend"])
+
+// All operations are immutable
+const updated = tags
+  |> Set.add("backend")
+  |> Set.remove("frontend")
+
+// Check membership
+const isUrgent = tags |> Set.has("urgent")   // true
+
+// Set operations
+const teamA = Set.fromArray(["alice", "bob", "carol"])
+const teamB = Set.fromArray(["bob", "carol", "dave"])
+
+const everyone = Set.union(teamA, teamB)       // {"alice", "bob", "carol", "dave"}
+const overlap = Set.intersect(teamA, teamB)    // {"bob", "carol"}
+const onlyA = Set.diff(teamA, teamB)           // {"alice"}
+
+// Convert back to array
+const tagList = tags |> Set.toArray
+```
+
+---
+
 ## Pipe
 
 Utility functions for pipeline debugging and control flow.

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1676,6 +1676,7 @@ impl Checker {
             (Type::Map { key: k1, value: v1 }, Type::Map { key: k2, value: v2 }) => {
                 self.types_compatible(k1, k2) && self.types_compatible(v1, v2)
             }
+            (Type::Set { element: e1 }, Type::Set { element: e2 }) => self.types_compatible(e1, e2),
             (Type::Tuple(a), Type::Tuple(b)) => {
                 a.len() == b.len()
                     && a.iter()

--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -926,8 +926,8 @@ impl Checker {
                 self.used_names.insert(name.to_string());
                 let display = format!("{m}.{name}");
                 return self.validate_stdlib_pipe_call(&stdlib_fn, &display, left_ty, right);
-            } else if !fallback_matches.is_empty() {
-                // Found via name-based fallback
+            } else if !fallback_matches.is_empty() && self.env.lookup(name).is_none() {
+                // Found via name-based fallback (only if not locally defined)
                 let stdlib_fn = fallback_matches[0].clone();
                 self.used_names.insert(name.to_string());
                 return self.validate_stdlib_pipe_call(&stdlib_fn, name, left_ty, right);
@@ -1087,6 +1087,9 @@ impl Checker {
                 Self::collect_generic_params_from_type(key, names, seen);
                 Self::collect_generic_params_from_type(value, names, seen);
             }
+            Type::Set { element } => {
+                Self::collect_generic_params_from_type(element, names, seen);
+            }
             _ => {}
         }
     }
@@ -1125,6 +1128,9 @@ impl Checker {
                 Self::unify_for_inference(pk, ak, generics, subs);
                 Self::unify_for_inference(pv, av, generics, subs);
             }
+            (Type::Set { element: pe }, Type::Set { element: ae }) => {
+                Self::unify_for_inference(pe, ae, generics, subs);
+            }
             (Type::Option(p), Type::Option(a)) => {
                 Self::unify_for_inference(p, a, generics, subs);
             }
@@ -1149,6 +1155,9 @@ impl Checker {
             Type::Map { key, value } => Type::Map {
                 key: Box::new(Self::substitute_generics(key, subs)),
                 value: Box::new(Self::substitute_generics(value, subs)),
+            },
+            Type::Set { element } => Type::Set {
+                element: Box::new(Self::substitute_generics(element, subs)),
             },
             Type::Option(inner) => Type::Option(Box::new(Self::substitute_generics(inner, subs))),
             Type::Tuple(types) => Type::Tuple(
@@ -1179,6 +1188,7 @@ impl Checker {
         match ty {
             Type::Array(_) => Some(type_names::MOD_ARRAY),
             Type::Map { .. } => Some(type_names::MOD_MAP),
+            Type::Set { .. } => Some(type_names::MOD_SET),
             Type::String => Some(type_names::MOD_STRING),
             Type::Number => Some(type_names::MOD_NUMBER),
             Type::Option(_) => Some(type_names::MOD_OPTION),

--- a/src/checker/types.rs
+++ b/src/checker/types.rs
@@ -44,6 +44,10 @@ pub enum Type {
         key: Box<Type>,
         value: Box<Type>,
     },
+    /// Set type: Set<T>
+    Set {
+        element: Box<Type>,
+    },
     /// Tuple type
     Tuple(Vec<Type>),
     /// Record/struct type
@@ -105,6 +109,7 @@ impl Type {
             Type::Map { key, value } => {
                 format!("Map<{}, {}>", key.display_name(), value.display_name())
             }
+            Type::Set { element } => format!("Set<{}>", element.display_name()),
             Type::Tuple(types) => {
                 let t: Vec<_> = types.iter().map(|t| t.display_name()).collect();
                 format!("({})", t.join(", "))

--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -492,6 +492,7 @@ impl Codegen {
         match ty {
             Type::Array(_) => Some("Array"),
             Type::Map { .. } => Some("Map"),
+            Type::Set { .. } => Some("Set"),
             Type::String => Some("String"),
             Type::Number => Some("Number"),
             Type::Option(_) => Some("Option"),

--- a/src/lsp/stdlib_hover.rs
+++ b/src/lsp/stdlib_hover.rs
@@ -31,6 +31,7 @@ fn format_type(ty: &crate::checker::Type) -> String {
         Type::Var(id) => type_var_name(*id).to_string(),
         Type::Array(inner) => format!("Array<{}>", format_type(inner)),
         Type::Map { key, value } => format!("Map<{}, {}>", format_type(key), format_type(value)),
+        Type::Set { element } => format!("Set<{}>", format_type(element)),
         Type::Option(inner) => format!("Option<{}>", format_type(inner)),
         Type::Result { ok, err } => {
             format!("Result<{}, {}>", format_type(ok), format_type(err))
@@ -218,6 +219,17 @@ mod tests {
         assert!(text.contains("set"));
         assert!(text.contains("keys"));
         assert!(text.contains("merge"));
+    }
+
+    #[test]
+    fn hover_set_module() {
+        let result = hover_stdlib_module("Set");
+        assert!(result.is_some());
+        let text = result.unwrap();
+        assert!(text.contains("module Set"));
+        assert!(text.contains("add"));
+        assert!(text.contains("union"));
+        assert!(text.contains("intersect"));
     }
 
     #[test]

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -85,6 +85,11 @@ fn map_of(k: Type, v: Type) -> Type {
         value: Box::new(v),
     }
 }
+fn set_of(t: Type) -> Type {
+    Type::Set {
+        element: Box::new(t),
+    }
+}
 fn fun(params: Vec<Type>, ret: Type) -> Type {
     Type::Function {
         params,
@@ -214,6 +219,18 @@ fn build_stdlib() -> Vec<StdlibFn> {
         stdlib_fn!("Map", "size", [map_of(t.clone(), u.clone())], Type::Number, "$0.size"),
         stdlib_fn!("Map", "isEmpty", [map_of(t.clone(), u.clone())], Type::Bool, "$0.size === 0"),
         stdlib_fn!("Map", "merge", [map_of(t.clone(), u.clone()), map_of(t.clone(), u.clone())], map_of(t.clone(), u.clone()), "new Map([...$0, ...$1])"),
+        // ── Set ────────────────────────────────────────────────────
+        stdlib_fn!("Set", "empty", [], set_of(t.clone()), "new Set()"),
+        stdlib_fn!("Set", "fromArray", [array_of(t.clone())], set_of(t.clone()), "new Set($0)"),
+        stdlib_fn!("Set", "toArray", [set_of(t.clone())], array_of(t.clone()), "[...$0]"),
+        stdlib_fn!("Set", "add", [set_of(t.clone()), t.clone()], set_of(t.clone()), "new Set([...$0, $1])"),
+        stdlib_fn!("Set", "remove", [set_of(t.clone()), t.clone()], set_of(t.clone()), "new Set([...$0].filter(x => x !== $1))"),
+        stdlib_fn!("Set", "has", [set_of(t.clone()), t.clone()], Type::Bool, "$0.has($1)"),
+        stdlib_fn!("Set", "size", [set_of(t.clone())], Type::Number, "$0.size"),
+        stdlib_fn!("Set", "isEmpty", [set_of(t.clone())], Type::Bool, "$0.size === 0"),
+        stdlib_fn!("Set", "union", [set_of(t.clone()), set_of(t.clone())], set_of(t.clone()), "new Set([...$0, ...$1])"),
+        stdlib_fn!("Set", "intersect", [set_of(t.clone()), set_of(t.clone())], set_of(t.clone()), "new Set([...$0].filter(x => $1.has(x)))"),
+        stdlib_fn!("Set", "diff", [set_of(t.clone()), set_of(t.clone())], set_of(t.clone()), "new Set([...$0].filter(x => !$1.has(x)))"),
         // ── Pipe Utilities ────────────────────────────────────────
         stdlib_fn!("Pipe", "tap", [t.clone(), fun(vec![t.clone()], Type::Unit)], t.clone(), "(() => { const _v = $0; ($1)(_v); return _v; })()"),
         // ── JSON ───────────────────────────────────────────────
@@ -381,6 +398,85 @@ mod tests {
     }
 
     #[test]
+    fn lookup_set_empty() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Set", "empty").unwrap();
+        assert_eq!(f.codegen, "new Set()");
+    }
+
+    #[test]
+    fn lookup_set_from_array() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Set", "fromArray").unwrap();
+        assert_eq!(f.codegen, "new Set($0)");
+    }
+
+    #[test]
+    fn lookup_set_to_array() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Set", "toArray").unwrap();
+        assert_eq!(f.codegen, "[...$0]");
+    }
+
+    #[test]
+    fn lookup_set_add() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Set", "add").unwrap();
+        assert_eq!(f.codegen, "new Set([...$0, $1])");
+    }
+
+    #[test]
+    fn lookup_set_remove() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Set", "remove").unwrap();
+        assert!(f.codegen.contains("filter"));
+    }
+
+    #[test]
+    fn lookup_set_has() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Set", "has").unwrap();
+        assert_eq!(f.codegen, "$0.has($1)");
+    }
+
+    #[test]
+    fn lookup_set_size() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Set", "size").unwrap();
+        assert_eq!(f.codegen, "$0.size");
+    }
+
+    #[test]
+    fn lookup_set_is_empty() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Set", "isEmpty").unwrap();
+        assert_eq!(f.codegen, "$0.size === 0");
+    }
+
+    #[test]
+    fn lookup_set_union() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Set", "union").unwrap();
+        assert_eq!(f.codegen, "new Set([...$0, ...$1])");
+    }
+
+    #[test]
+    fn lookup_set_intersect() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Set", "intersect").unwrap();
+        assert!(f.codegen.contains("filter"));
+        assert!(f.codegen.contains("has"));
+    }
+
+    #[test]
+    fn lookup_set_diff() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Set", "diff").unwrap();
+        assert!(f.codegen.contains("filter"));
+        assert!(f.codegen.contains("!$1.has"));
+    }
+
+    #[test]
     fn lookup_nonexistent() {
         let reg = StdlibRegistry::new();
         assert!(reg.lookup("Array", "nonexistent").is_none());
@@ -400,6 +496,7 @@ mod tests {
         assert!(reg.is_module("JSON"));
         assert!(reg.is_module("Pipe"));
         assert!(reg.is_module("Map"));
+        assert!(reg.is_module("Set"));
         assert!(!reg.is_module("Foo"));
     }
 
@@ -415,6 +512,7 @@ mod tests {
         assert!(reg.module_functions("Math").len() >= 14);
         assert!(reg.module_functions("JSON").len() >= 2);
         assert!(reg.module_functions("Map").len() >= 12);
+        assert!(reg.module_functions("Set").len() >= 11);
     }
 
     #[test]

--- a/src/type_names.rs
+++ b/src/type_names.rs
@@ -19,3 +19,4 @@ pub const MOD_NUMBER: &str = "Number";
 pub const MOD_OPTION: &str = "Option";
 pub const MOD_RESULT: &str = "Result";
 pub const MOD_MAP: &str = "Map";
+pub const MOD_SET: &str = "Set";

--- a/tests/fixtures/stdlib.fl
+++ b/tests/fixtures/stdlib.fl
@@ -88,6 +88,19 @@ const _tangent = Math.tan(0)
 const _json_str = JSON.stringify([1, 2, 3])
 const _json_parsed = JSON.parse("{}")
 
+// ── Set ────────────────────────────────────────────────────
+const _set = Set.fromArray([1, 2, 3])
+const _set_arr = Set.toArray(_set)
+const _set_added = Set.add(_set, 4)
+const _set_removed = Set.remove(_set, 2)
+const _set_has = Set.has(_set, 1)
+const _set_size = Set.size(_set)
+const _set_empty = Set.isEmpty(_set)
+const _set2 = Set.fromArray([2, 3, 4])
+const _set_union = Set.union(_set, _set2)
+const _set_inter = Set.intersect(_set, _set2)
+const _set_diff = Set.diff(_set, _set2)
+
 // ── Pipes with stdlib ───────────────────────────────────────
 const _piped = [3, 1, 2] |> Array.sort
 const _pipe_chain = [1, 2, 3, 4, 5]

--- a/tests/snapshots/snapshot_codegen__snapshot_stdlib.snap
+++ b/tests/snapshots/snapshot_codegen__snapshot_stdlib.snap
@@ -160,6 +160,28 @@ const _json_str = JSON.stringify([1, 2, 3]);
 
 const _json_parsed = (() => { try { return { ok: true as const, value: JSON.parse("{}") }; } catch (e) { return { ok: false as const, error: { message: String(e) } }; } })();
 
+const _set = new Set([1, 2, 3]);
+
+const _set_arr = [..._set];
+
+const _set_added = new Set([..._set, 4]);
+
+const _set_removed = new Set([..._set].filter(x => x !== 2));
+
+const _set_has = _set.has(1);
+
+const _set_size = _set.size;
+
+const _set_empty = _set.size === 0;
+
+const _set2 = new Set([2, 3, 4]);
+
+const _set_union = new Set([..._set, ..._set2]);
+
+const _set_inter = new Set([..._set].filter(x => _set2.has(x)));
+
+const _set_diff = new Set([..._set].filter(x => !_set2.has(x)));
+
 const _piped = [...[3, 1, 2]].sort((a, b) => a - b);
 
 const _pipe_chain = [...[1, 2, 3, 4, 5].filter((n) => n > 2).map((n) => n * 10)].reverse();


### PR DESCRIPTION
closes #263

## Summary

- Adds `Set<T>` type variant to the type system (checker, codegen, LSP)
- Adds 11 immutable Set stdlib functions: `empty`, `fromArray`, `toArray`, `add`, `remove`, `has`, `size`, `isEmpty`, `union`, `intersect`, `diff`
- All operations return new sets, never mutate
- Fixes a pipe resolution bug where locally-defined functions with names matching stdlib functions (e.g. `add`) would incorrectly fall through to the stdlib name-based fallback

## Files changed

- `src/stdlib.rs` - Set function definitions and tests
- `src/checker/types.rs` - `Set { element }` variant on `Type` enum
- `src/checker/expr.rs` - Set support in generic inference, substitution, type-directed pipe resolution; pipe fallback fix
- `src/checker.rs` - `types_compatible` for Set
- `src/codegen/expr.rs` - Set in `type_to_stdlib_module`
- `src/lsp/stdlib_hover.rs` - Set in `format_type` + hover test
- `src/type_names.rs` - `MOD_SET` constant
- `tests/fixtures/stdlib.fl` - Set test cases
- `docs/design.md`, `docs/llms.txt`, `docs/site/.../stdlib.md` - documentation

## Test plan

- [x] All 11 Set stdlib functions have unit tests in `src/stdlib.rs`
- [x] Snapshot codegen test updated with Set output
- [x] LSP hover test for Set module
- [x] Existing pipe resolution test passes (regression fix)
- [x] `cargo fmt`, `cargo clippy -- -D warnings`, `RUSTFLAGS="-D warnings" cargo test` all pass