### PR TITLE
[#259] Add Http stdlib module

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -90,6 +90,7 @@ All four of TypeScript's `?` uses (`?.`, `??`, `?:`, `? :`) are removed. `?` now
 | Immutable maps | `Map.set`, `Map.remove` return new maps | `new Map([...old, [k, v]])` |
 | Immutable sets | `Set.add`, `Set.remove` return new sets | `new Set([...old, val])` |
 | Strict parse | `Number.parse("123")` returns `Result` | no silent `NaN` or partial parse |
+| Http module | `Http.get(url)`, `Http.post(url, body)` | async IIFE wrapping `fetch` in `Result` |
 | Number separators | `1_000_000`, `3.141_592`, `0xFF_FF` | underscores stripped in output |
 
 ### What's Removed (compile errors)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -306,6 +306,11 @@ const port = Map.get(config, "port")     // Option<string>
 const keys = config |> Map.keys          // Array<string>
 const merged = Map.merge(defaults, config)
 
+// Http — pipe-friendly fetch with Result (no try needed)
+const data = await Http.get("https://api.example.com/users")? |> Http.json?
+const result = await Http.post(url, { name: "Alice" })?
+const body = await Http.get(url)? |> Http.text?
+
 // Set<T> — immutable unique collections
 const tags = Set.fromArray(["urgent", "bug", "frontend"])
 const updated = tags |> Set.add("backend")

--- a/docs/site/src/content/docs/reference/stdlib.md
+++ b/docs/site/src/content/docs/reference/stdlib.md
@@ -416,6 +416,44 @@ const tagList = tags |> Set.toArray
 
 ---
 
+## Http
+
+Pipe-friendly HTTP functions that return `Result` natively. No `try` wrapper needed -- errors are captured automatically.
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `Http.get` | `string -> Result<Response, Error>` | GET request |
+| `Http.post` | `string, unknown -> Result<Response, Error>` | POST request with JSON body |
+| `Http.put` | `string, unknown -> Result<Response, Error>` | PUT request with JSON body |
+| `Http.delete` | `string -> Result<Response, Error>` | DELETE request |
+| `Http.json` | `Response -> Result<unknown, Error>` | Parse response body as JSON |
+| `Http.text` | `Response -> Result<string, Error>` | Read response body as text |
+
+### Examples
+
+```floe
+// Simple GET and parse JSON
+const data = await Http.get("https://api.example.com/users")? |> Http.json?
+
+// POST with a body
+const result = await Http.post("https://api.example.com/users", { name: "Alice" })?
+
+// Full pipeline
+const users = await Http.get(url)?
+  |> Http.json?
+  |> Result.map(|data| Array.filter(data, .active))
+
+// Error handling with match
+match await Http.get(url) {
+  Ok(response) -> Http.json(response),
+  Err(e) -> Console.error(e),
+}
+```
+
+All Http functions are async and return `Result`. Use `await` and `?` for ergonomic error handling in pipelines.
+
+---
+
 ## Pipe
 
 Utility functions for pipeline debugging and control flow.

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -812,6 +812,98 @@ fn stdlib_pipe_tap_with_lambda() {
     assert!(result.contains("return _v"), "output: {result}");
 }
 
+// ── Http Stdlib ─────────────────────────────────────────────
+
+#[test]
+fn stdlib_http_get() {
+    let result = emit(r#"Http.get("https://api.example.com")"#);
+    assert!(
+        result.contains("fetch(\"https://api.example.com\")"),
+        "expected fetch call, got: {result}"
+    );
+    assert!(
+        result.contains("async"),
+        "expected async IIFE, got: {result}"
+    );
+    assert!(
+        result.contains("ok: true as const"),
+        "expected Result ok branch, got: {result}"
+    );
+    assert!(
+        result.contains("ok: false as const"),
+        "expected Result err branch, got: {result}"
+    );
+}
+
+#[test]
+fn stdlib_http_post() {
+    let result = emit(r#"Http.post("https://api.example.com", data)"#);
+    assert!(
+        result.contains("\"POST\""),
+        "expected POST method, got: {result}"
+    );
+    assert!(
+        result.contains("JSON.stringify(data)"),
+        "expected JSON.stringify body, got: {result}"
+    );
+    assert!(
+        result.contains("Content-Type"),
+        "expected Content-Type header, got: {result}"
+    );
+}
+
+#[test]
+fn stdlib_http_put() {
+    let result = emit(r#"Http.put("https://api.example.com", data)"#);
+    assert!(
+        result.contains("\"PUT\""),
+        "expected PUT method, got: {result}"
+    );
+    assert!(
+        result.contains("JSON.stringify(data)"),
+        "expected JSON.stringify body, got: {result}"
+    );
+}
+
+#[test]
+fn stdlib_http_delete() {
+    let result = emit(r#"Http.delete("https://api.example.com")"#);
+    assert!(
+        result.contains("\"DELETE\""),
+        "expected DELETE method, got: {result}"
+    );
+    assert!(
+        result.contains("fetch(\"https://api.example.com\""),
+        "expected fetch call, got: {result}"
+    );
+}
+
+#[test]
+fn stdlib_http_json() {
+    let result = emit("Http.json(response)");
+    assert!(
+        result.contains("response.json()"),
+        "expected .json() call, got: {result}"
+    );
+    assert!(
+        result.contains("async"),
+        "expected async IIFE, got: {result}"
+    );
+}
+
+#[test]
+fn stdlib_http_text() {
+    let result = emit("Http.text(response)");
+    assert!(
+        result.contains("response.text()"),
+        "expected .text() call, got: {result}"
+    );
+    assert!(
+        result.contains("async"),
+        "expected async IIFE, got: {result}"
+    );
+}
+
 // ── Test Blocks ─────────────────────────────────────────────
 
 fn emit_test_mode(input: &str) -> String {

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -231,6 +231,13 @@ fn build_stdlib() -> Vec<StdlibFn> {
         stdlib_fn!("Set", "union", [set_of(t.clone()), set_of(t.clone())], set_of(t.clone()), "new Set([...$0, ...$1])"),
         stdlib_fn!("Set", "intersect", [set_of(t.clone()), set_of(t.clone())], set_of(t.clone()), "new Set([...$0].filter(x => $1.has(x)))"),
         stdlib_fn!("Set", "diff", [set_of(t.clone()), set_of(t.clone())], set_of(t.clone()), "new Set([...$0].filter(x => !$1.has(x)))"),
+        // ── Http ──────────────────────────────────────────────────
+        stdlib_fn!("Http", "get", [Type::String], result_of(Type::Named("Response".to_string()), Type::Named("Error".to_string())), "(async () => { try { const _r = await fetch($0); return { ok: true as const, value: _r }; } catch (_e) { return { ok: false as const, error: _e instanceof Error ? _e : new Error(String(_e)) }; } })()"),
+        stdlib_fn!("Http", "post", [Type::String, Type::Unknown], result_of(Type::Named("Response".to_string()), Type::Named("Error".to_string())), "(async () => { try { const _r = await fetch($0, { method: \"POST\", body: JSON.stringify($1), headers: { \"Content-Type\": \"application/json\" } }); return { ok: true as const, value: _r }; } catch (_e) { return { ok: false as const, error: _e instanceof Error ? _e : new Error(String(_e)) }; } })()"),
+        stdlib_fn!("Http", "put", [Type::String, Type::Unknown], result_of(Type::Named("Response".to_string()), Type::Named("Error".to_string())), "(async () => { try { const _r = await fetch($0, { method: \"PUT\", body: JSON.stringify($1), headers: { \"Content-Type\": \"application/json\" } }); return { ok: true as const, value: _r }; } catch (_e) { return { ok: false as const, error: _e instanceof Error ? _e : new Error(String(_e)) }; } })()"),
+        stdlib_fn!("Http", "delete", [Type::String], result_of(Type::Named("Response".to_string()), Type::Named("Error".to_string())), "(async () => { try { const _r = await fetch($0, { method: \"DELETE\" }); return { ok: true as const, value: _r }; } catch (_e) { return { ok: false as const, error: _e instanceof Error ? _e : new Error(String(_e)) }; } })()"),
+        stdlib_fn!("Http", "json", [Type::Named("Response".to_string())], result_of(Type::Unknown, Type::Named("Error".to_string())), "(async () => { try { const _r = await $0.json(); return { ok: true as const, value: _r }; } catch (_e) { return { ok: false as const, error: _e instanceof Error ? _e : new Error(String(_e)) }; } })()"),
+        stdlib_fn!("Http", "text", [Type::Named("Response".to_string())], result_of(Type::String, Type::Named("Error".to_string())), "(async () => { try { const _r = await $0.text(); return { ok: true as const, value: _r }; } catch (_e) { return { ok: false as const, error: _e instanceof Error ? _e : new Error(String(_e)) }; } })()"),
         // ── Pipe Utilities ────────────────────────────────────────
         stdlib_fn!("Pipe", "tap", [t.clone(), fun(vec![t.clone()], Type::Unit)], t.clone(), "(() => { const _v = $0; ($1)(_v); return _v; })()"),
         // ── JSON ───────────────────────────────────────────────
@@ -477,6 +484,51 @@ mod tests {
     }
 
     #[test]
+    fn lookup_http_get() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Http", "get").unwrap();
+        assert!(f.codegen.contains("fetch($0)"));
+        assert!(f.codegen.contains("async"));
+    }
+
+    #[test]
+    fn lookup_http_post() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Http", "post").unwrap();
+        assert!(f.codegen.contains("POST"));
+        assert!(f.codegen.contains("JSON.stringify($1)"));
+    }
+
+    #[test]
+    fn lookup_http_put() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Http", "put").unwrap();
+        assert!(f.codegen.contains("PUT"));
+        assert!(f.codegen.contains("JSON.stringify($1)"));
+    }
+
+    #[test]
+    fn lookup_http_delete() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Http", "delete").unwrap();
+        assert!(f.codegen.contains("DELETE"));
+    }
+
+    #[test]
+    fn lookup_http_json() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Http", "json").unwrap();
+        assert!(f.codegen.contains("$0.json()"));
+    }
+
+    #[test]
+    fn lookup_http_text() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Http", "text").unwrap();
+        assert!(f.codegen.contains("$0.text()"));
+    }
+
+    #[test]
     fn lookup_nonexistent() {
         let reg = StdlibRegistry::new();
         assert!(reg.lookup("Array", "nonexistent").is_none());
@@ -497,6 +549,7 @@ mod tests {
         assert!(reg.is_module("Pipe"));
         assert!(reg.is_module("Map"));
         assert!(reg.is_module("Set"));
+        assert!(reg.is_module("Http"));
         assert!(!reg.is_module("Foo"));
     }
 
@@ -513,6 +566,7 @@ mod tests {
         assert!(reg.module_functions("JSON").len() >= 2);
         assert!(reg.module_functions("Map").len() >= 12);
         assert!(reg.module_functions("Set").len() >= 11);
+        assert!(reg.module_functions("Http").len() >= 6);
     }
 
     #[test]

--- a/src/type_names.rs
+++ b/src/type_names.rs
@@ -20,3 +20,4 @@ pub const MOD_OPTION: &str = "Option";
 pub const MOD_RESULT: &str = "Result";
 pub const MOD_MAP: &str = "Map";
 pub const MOD_SET: &str = "Set";
+pub const MOD_HTTP: &str = "Http";


### PR DESCRIPTION
closes #259

## Summary

- Add `Http` module to the stdlib with 6 pipe-friendly functions: `get`, `post`, `put`, `delete`, `json`, `text`
- All functions return `Result` natively via async IIFE try/catch codegen - no `try` wrapper needed
- `Http.get` and `Http.delete` take a URL string; `Http.post` and `Http.put` take a URL and body
- `Http.json` and `Http.text` parse a Response into `Result<unknown, Error>` and `Result<string, Error>`
- Add `MOD_HTTP` constant to `type_names.rs`
- Add stdlib registry tests and codegen tests for all 6 functions
- Update `docs/design.md`, `docs/site/src/content/docs/reference/stdlib.md`, and `docs/llms.txt`

## Test plan

- [x] All existing tests pass
- [x] New stdlib registry tests verify lookup and codegen templates for all 6 Http functions
- [x] New codegen tests verify emitted JS contains correct fetch calls, methods, and Result wrapping
- [x] `cargo fmt`, `cargo clippy -- -D warnings`, `RUSTFLAGS="-D warnings" cargo test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)