### PR TITLE
[#291] Remove Eq from derivable traits - structural equality is built-in

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -854,40 +854,32 @@ type User = {
   id: string,
   name: string,
   email: string,
-} deriving (Eq, Display)
+} deriving (Display)
 ```
 
 This generates the same code as a handwritten `for` block with no runtime cost.
+
+**Note:** `Eq` is not derivable — structural equality is built-in for all types via `==` (emits `__zenEq` deep comparison). Writing `deriving (Eq)` is a compile error.
 
 **Derivable traits:**
 
 | Trait | Generated implementation |
 |---|---|
-| `Eq` | Field-by-field `===` comparison: `fn eq(self, other: T) -> boolean` |
 | `Display` | String representation: `fn display(self) -> string` producing `TypeName(field1: val1, field2: val2)` |
-
-**Codegen output** for `deriving (Eq)` on `type User = { id: string, name: string }`:
-
-```typescript
-function eq(self: User, other: User): boolean {
-  return self.id === other.id && self.name === other.name;
-}
-```
 
 **Codegen output** for `deriving (Display)`:
 
 ```typescript
 function display(self: User): string {
-  return `User(id: ${self.id}, name: ${self.name})`;
+  return `User(id: ${self.id}, name: ${self.name}, email: ${self.email})`;
 }
 ```
 
 Deriving rules:
 
 1. `deriving` only works on record types — compile error on unions, aliases, or string literal unions
-2. You can derive multiple traits: `deriving (Eq, Display)`
-3. A handwritten `for` block overrides a derived implementation
-4. Only `Eq` and `Display` are derivable — attempting to derive anything else is a compile error
+2. A handwritten `for` block overrides a derived implementation
+3. Only `Display` is derivable — attempting to derive anything else (including `Eq`) is a compile error
 
 ### Inline Test Blocks
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -397,12 +397,12 @@ for User: Display {
     }
 }
 
-// Auto-derive traits for record types
+// Auto-derive traits for record types (only Display — Eq is built-in via ==)
 type Point = {
     x: number,
     y: number,
-} deriving (Eq, Display)
-// Generates eq(self, other: Point) -> boolean and display(self) -> string
+} deriving (Display)
+// Generates display(self) -> string
 ```
 
 ## JSX / React Components

--- a/docs/site/src/content/docs/guide/traits.md
+++ b/docs/site/src/content/docs/guide/traits.md
@@ -91,42 +91,43 @@ type User = {
   id: string,
   name: string,
   email: string,
-} deriving (Eq, Display)
+} deriving (Display)
 ```
 
 This generates:
 
-- `eq(self, other: User) -> boolean` - field-by-field `===` comparison
 - `display(self) -> string` - string representation like `User(id: abc, name: Ryan, email: r@t.com)`
+
+:::note
+`Eq` is not derivable — structural equality is built-in for all types via `==`. You do not need to derive or implement equality.
+:::
 
 ### Derivable traits
 
 | Trait | Generated implementation |
 |---|---|
-| `Eq` | Field-by-field `===` comparison |
 | `Display` | `TypeName(field1: val1, field2: val2)` format |
 
 ### Compiled output
 
 ```floe
-type Point = { x: number, y: number } deriving (Eq)
+type User = { name: string, age: number } deriving (Display)
 ```
 
 ```typescript
 // Generated TypeScript
-type Point = { x: number; y: number };
+type User = { name: string; age: number };
 
-function eq(self: Point, other: Point): boolean {
-  return self.x === other.x && self.y === other.y;
+function display(self: User): string {
+  return `User(name: ${self.name}, age: ${self.age})`;
 }
 ```
 
 ### Deriving rules
 
 1. `deriving` only works on record types (not unions)
-2. You can derive multiple traits: `deriving (Eq, Display)`
-3. A handwritten `for` block overrides a derived implementation
-4. Only `Eq` and `Display` are derivable
+2. A handwritten `for` block overrides a derived implementation
+3. Only `Display` is derivable — `Eq` is built-in via `==`
 
 ## Rules
 

--- a/docs/site/src/content/docs/reference/syntax.md
+++ b/docs/site/src/content/docs/reference/syntax.md
@@ -70,7 +70,7 @@ opaque type Email = string
 type Point = {
   x: number,
   y: number,
-} deriving (Eq, Display)
+} deriving (Display)
 ```
 
 ### For Block

--- a/editors/vscode/snippets/floe.json
+++ b/editors/vscode/snippets/floe.json
@@ -199,7 +199,7 @@
     "body": [
       "type ${1:Name} = {",
       "\t${2:field}: ${3:Type},",
-      "} deriving (${4:Eq})"
+      "} deriving (${4:Display})"
     ],
     "description": "Record type with deriving clause"
   },

--- a/examples/todo-app/src/types.fl
+++ b/examples/todo-app/src/types.fl
@@ -2,7 +2,7 @@ export type Todo = {
     id: string,
     text: string,
     done: boolean,
-} deriving (Eq)
+}
 
 export type Filter =
     | All

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -698,19 +698,15 @@ impl Checker {
         for trait_name in &decl.deriving {
             match trait_name.as_str() {
                 "Eq" => {
-                    // Register eq function: fn eq(self, other: TypeName) -> boolean
-                    let fn_name = "eq".to_string();
-                    let self_type = Type::Named(type_name.clone());
-                    let fn_type = Type::Function {
-                        params: vec![self_type.clone(), self_type],
-                        return_type: Box::new(Type::Bool),
-                    };
-                    self.env.define(&fn_name, fn_type);
-                    self.defined_sources
-                        .insert(fn_name.clone(), format!("derived Eq for {type_name}"));
-                    self.used_names.insert(fn_name.clone());
-                    self.trait_impls
-                        .insert((type_name.clone(), "Eq".to_string()));
+                    self.diagnostics.push(
+                        Diagnostic::error(
+                            "`Eq` cannot be derived — structural equality is built-in for all types via `==`".to_string(),
+                            span,
+                        )
+                        .with_label("not needed")
+                        .with_help("remove `Eq` from the deriving clause — use `==` for equality comparison")
+                        .with_code("E019"),
+                    );
                 }
                 "Display" => {
                     // Register display function: fn display(self) -> string
@@ -731,7 +727,7 @@ impl Checker {
                     self.diagnostics.push(
                         Diagnostic::error(format!("trait `{trait_name}` cannot be derived"), span)
                             .with_label("not a derivable trait")
-                            .with_help("only `Eq` and `Display` can be derived")
+                            .with_help("only `Display` can be derived")
                             .with_code("E019"),
                     );
                 }

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -2479,7 +2479,7 @@ fn f() -> Result<number, Array<string>> {
 // ── Deriving ────────────────────────────────────────────────
 
 #[test]
-fn deriving_eq_on_record_type() {
+fn deriving_eq_is_error() {
     let diags = check(
         r#"
 type Point = {
@@ -2489,8 +2489,8 @@ type Point = {
 "#,
     );
     assert!(
-        diags.iter().all(|d| d.severity != Severity::Error),
-        "deriving Eq on record should not error: {:?}",
+        has_error_containing(&diags, "structural equality is built-in"),
+        "deriving Eq should error: {:?}",
         diags.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
@@ -2513,7 +2513,7 @@ type User = {
 }
 
 #[test]
-fn deriving_both_eq_and_display() {
+fn deriving_eq_and_display_errors_on_eq() {
     let diags = check(
         r#"
 type User = {
@@ -2523,8 +2523,8 @@ type User = {
 "#,
     );
     assert!(
-        diags.iter().all(|d| d.severity != Severity::Error),
-        "deriving both Eq and Display should not error: {:?}",
+        has_error_containing(&diags, "structural equality is built-in"),
+        "deriving Eq should error even when combined with Display: {:?}",
         diags.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
@@ -2533,7 +2533,7 @@ type User = {
 fn deriving_on_union_type_is_error() {
     let diags = check(
         r#"
-type Shape = | Circle(radius: number) | Square(side: number) deriving (Eq)
+type Shape = | Circle(radius: number) | Square(side: number) deriving (Display)
 "#,
     );
     assert!(

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -131,14 +131,8 @@ impl Codegen {
                     }
                     // Register derived function names as local names
                     for trait_name in &decl.deriving {
-                        match trait_name.as_str() {
-                            "Eq" => {
-                                self.local_names.insert("eq".to_string());
-                            }
-                            "Display" => {
-                                self.local_names.insert("display".to_string());
-                            }
-                            _ => {}
+                        if trait_name.as_str() == "Display" {
+                            self.local_names.insert("display".to_string());
                         }
                     }
                 }
@@ -571,39 +565,11 @@ impl Codegen {
             for trait_name in &decl.deriving {
                 self.newline();
                 self.newline();
-                match trait_name.as_str() {
-                    "Eq" => self.emit_derived_eq(&decl.name, &fields),
-                    "Display" => self.emit_derived_display(&decl.name, &fields),
-                    _ => {} // Unknown derivable traits are caught by the checker
+                if trait_name.as_str() == "Display" {
+                    self.emit_derived_display(&decl.name, &fields);
                 }
             }
         }
-    }
-
-    fn emit_derived_eq(&mut self, type_name: &str, fields: &[&RecordField]) {
-        self.emit_indent();
-        self.push(&format!(
-            "function eq(self: {type_name}, other: {type_name}): boolean {{"
-        ));
-        self.newline();
-        self.indent += 1;
-        self.emit_indent();
-        self.push("return ");
-        if fields.is_empty() {
-            self.push("true");
-        } else {
-            for (i, field) in fields.iter().enumerate() {
-                if i > 0 {
-                    self.push(" && ");
-                }
-                self.push(&format!("self.{name} === other.{name}", name = field.name));
-            }
-        }
-        self.push(";");
-        self.newline();
-        self.indent -= 1;
-        self.emit_indent();
-        self.push("}");
     }
 
     fn emit_derived_display(&mut self, type_name: &str, fields: &[&RecordField]) {

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -1150,26 +1150,6 @@ fn f() -> Result<number, Array<string>> {
 // ── Deriving ────────────────────────────────────────────────
 
 #[test]
-fn deriving_eq_generates_equality() {
-    let result = emit(
-        r#"
-type Point = {
-  x: number,
-  y: number,
-} deriving (Eq)
-"#,
-    );
-    assert!(
-        result.contains("function eq(self: Point, other: Point): boolean"),
-        "should generate eq function, got: {result}"
-    );
-    assert!(
-        result.contains("self.x === other.x && self.y === other.y"),
-        "should compare all fields, got: {result}"
-    );
-}
-
-#[test]
 fn deriving_display_generates_string() {
     let result = emit(
         r#"
@@ -1186,25 +1166,5 @@ type User = {
     assert!(
         result.contains("User(name: ${self.name}, age: ${self.age})"),
         "should format all fields, got: {result}"
-    );
-}
-
-#[test]
-fn deriving_both_eq_and_display() {
-    let result = emit(
-        r#"
-type User = {
-  id: string,
-  name: string,
-} deriving (Eq, Display)
-"#,
-    );
-    assert!(
-        result.contains("function eq(self: User, other: User): boolean"),
-        "should generate eq function, got: {result}"
-    );
-    assert!(
-        result.contains("function display(self: User): string"),
-        "should generate display function, got: {result}"
     );
 }

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -326,7 +326,7 @@ impl<'src> CstParser<'src> {
 
         self.parse_type_def();
 
-        // Optional deriving clause: `deriving (Eq, Display)`
+        // Optional deriving clause: `deriving (Display)`
         self.eat_trivia();
         if self.at(TokenKind::Deriving) {
             self.builder.start_node(SyntaxKind::DERIVING_CLAUSE.into());

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -498,7 +498,7 @@ impl Parser {
 
         let def = self.parse_type_def()?;
 
-        // Optional deriving clause: `deriving (Eq, Display)`
+        // Optional deriving clause: `deriving (Display)`
         let deriving = if self.check(&TokenKind::Deriving) {
             self.advance();
             self.expect(&TokenKind::LeftParen)?;

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -126,7 +126,7 @@ pub struct TypeDecl {
     pub name: String,
     pub type_params: Vec<String>,
     pub def: TypeDef,
-    /// `deriving (Eq, Display)` — auto-derive trait implementations for record types.
+    /// `deriving (Display)` — auto-derive trait implementations for record types.
     pub deriving: Vec<String>,
 }
 

--- a/tests/fixtures/deriving.fl
+++ b/tests/fixtures/deriving.fl
@@ -1,9 +1,3 @@
-// Record type with deriving Eq
-type Point = {
-  x: number,
-  y: number,
-} deriving (Eq)
-
 // Record type with deriving Display
 type Color = {
   r: number,
@@ -11,9 +5,9 @@ type Color = {
   b: number,
 } deriving (Display)
 
-// Record type with both Eq and Display
+// Record type with Display only (Eq is built-in via ==)
 type User = {
   id: string,
   name: string,
   email: string,
-} deriving (Eq, Display)
+} deriving (Display)

--- a/tests/snapshots/snapshot_codegen__snapshot_deriving.snap
+++ b/tests/snapshots/snapshot_codegen__snapshot_deriving.snap
@@ -2,12 +2,6 @@
 source: tests/snapshot_codegen.rs
 expression: output
 ---
-type Point = { x: number; y: number };
-
-function eq(self: Point, other: Point): boolean {
-  return self.x === other.x && self.y === other.y;
-}
-
 type Color = { r: number; g: number; b: number };
 
 function display(self: Color): string {
@@ -15,10 +9,6 @@ function display(self: Color): string {
 }
 
 type User = { id: string; name: string; email: string };
-
-function eq(self: User, other: User): boolean {
-  return self.id === other.id && self.name === other.name && self.email === other.email;
-}
 
 function display(self: User): string {
   return `User(id: ${self.id}, name: ${self.name}, email: ${self.email})`;


### PR DESCRIPTION
closes #291

## Summary

- **Checker**: `deriving (Eq)` now produces a compile error: "structural equality is built-in for all types via `==`" with a helpful suggestion to remove the Eq clause
- **Codegen**: Removed `emit_derived_eq` function and Eq codegen paths; simplified remaining single-arm matches to `if` statements per clippy
- **Docs**: Updated `docs/design.md`, `docs/llms.txt`, site guide (`traits.md`), and syntax reference to only mention Display as derivable
- **Example app**: Removed `deriving (Eq)` from `examples/todo-app/src/types.fl`
- **Tests**: Updated checker and codegen tests; updated fixture and snapshot

## Test plan

- [x] `cargo fmt` - clean
- [x] `cargo clippy -- -D warnings` - no warnings
- [x] `RUSTFLAGS="-D warnings" cargo test` - all tests pass