### PR TITLE
[#298] Support single-variant union newtypes with primitive types

### DIFF
--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -2559,3 +2559,73 @@ type Point = {
         diags.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+// ── Single-variant union newtypes ───────────────────────────
+
+#[test]
+fn newtype_with_number() {
+    let diags = check("type ProductId = ProductId(number)");
+    assert!(
+        !has_error_containing(&diags, "is not defined"),
+        "ProductId(number) should parse as a newtype, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn newtype_with_string() {
+    let diags = check("type Email = Email(string)");
+    assert!(
+        !has_error_containing(&diags, "is not defined"),
+        "Email(string) should parse as a newtype, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn newtype_with_boolean() {
+    let diags = check("type Flag = Flag(boolean)");
+    assert!(
+        !has_error_containing(&diags, "is not defined"),
+        "Flag(boolean) should parse as a newtype, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn newtype_with_named_field() {
+    let diags = check("type UserId = UserId(value: number)");
+    assert!(
+        !has_error_containing(&diags, "is not defined"),
+        "UserId(value: number) should parse as a newtype, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn newtype_coexists_with_regular_unions() {
+    let diags = check(
+        r#"
+type ProductId = ProductId(number)
+type Route =
+  | Home
+  | Profile(id: string)
+  | NotFound
+"#,
+    );
+    assert!(
+        diags.iter().all(|d| d.severity != Severity::Error),
+        "newtypes and regular unions should coexist, got errors: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn type_alias_still_works() {
+    let diags = check("type Name = string");
+    assert!(
+        diags.iter().all(|d| d.severity != Severity::Error),
+        "type aliases should still work, got errors: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -538,6 +538,23 @@ impl Parser {
             return Ok(TypeDef::Record(entries));
         }
 
+        // Check if this is a single-variant union (newtype pattern): `Name(fields)`
+        // An uppercase identifier followed by `(` is a constructor, not a type alias.
+        if self.is_newtype_constructor() {
+            let start_span = self.current_span();
+            let name = self.expect_identifier()?;
+            self.advance(); // consume '('
+            let fields = self.parse_comma_separated(|p| p.parse_variant_field())?;
+            self.expect(&TokenKind::RightParen)?;
+            let end_span = self.previous_span();
+            let variant = Variant {
+                name,
+                fields,
+                span: self.merge_spans(start_span, end_span),
+            };
+            return Ok(TypeDef::Union(vec![variant]));
+        }
+
         // Otherwise it's a type alias
         let type_expr = self.parse_type_expr()?;
         Ok(TypeDef::Alias(type_expr))
@@ -1200,6 +1217,17 @@ impl Parser {
 
     fn is_identifier(&self) -> bool {
         matches!(self.tokens[self.pos].kind, TokenKind::Identifier(_))
+    }
+
+    /// Check if we're at a single-variant union (newtype) pattern: `Name(...)`.
+    /// An uppercase identifier followed by `(` is a constructor, not a type alias.
+    fn is_newtype_constructor(&self) -> bool {
+        if let TokenKind::Identifier(name) = &self.tokens[self.pos].kind {
+            name.starts_with(|c: char| c.is_uppercase())
+                && self.peek_kind() == Some(&TokenKind::LeftParen)
+        } else {
+            false
+        }
     }
 
     /// Check if the current token is `|` used in union type declarations.

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1839,3 +1839,59 @@ fn collect_block_with_const() {
         other => panic!("expected Collect, got {other:?}"),
     }
 }
+
+// ── Single-variant union newtypes ───────────────────────────
+
+#[test]
+fn newtype_parses_as_single_variant_union() {
+    let item = first_item("type ProductId = ProductId(number)");
+    match item {
+        ItemKind::TypeDecl(decl) => {
+            assert_eq!(decl.name, "ProductId");
+            match &decl.def {
+                TypeDef::Union(variants) => {
+                    assert_eq!(variants.len(), 1);
+                    assert_eq!(variants[0].name, "ProductId");
+                    assert_eq!(variants[0].fields.len(), 1);
+                    assert!(variants[0].fields[0].name.is_none());
+                    match &variants[0].fields[0].type_ann.kind {
+                        TypeExprKind::Named { name, .. } => assert_eq!(name, "number"),
+                        other => panic!("expected Named type, got {other:?}"),
+                    }
+                }
+                other => panic!("expected Union, got {other:?}"),
+            }
+        }
+        other => panic!("expected TypeDecl, got {other:?}"),
+    }
+}
+
+#[test]
+fn newtype_with_named_field_parses() {
+    let item = first_item("type UserId = UserId(value: number)");
+    match item {
+        ItemKind::TypeDecl(decl) => {
+            assert_eq!(decl.name, "UserId");
+            match &decl.def {
+                TypeDef::Union(variants) => {
+                    assert_eq!(variants.len(), 1);
+                    assert_eq!(variants[0].fields[0].name.as_deref(), Some("value"));
+                }
+                other => panic!("expected Union, got {other:?}"),
+            }
+        }
+        other => panic!("expected TypeDecl, got {other:?}"),
+    }
+}
+
+#[test]
+fn type_alias_still_parses_as_alias() {
+    let item = first_item("type Name = string");
+    match item {
+        ItemKind::TypeDecl(decl) => {
+            assert_eq!(decl.name, "Name");
+            assert!(matches!(&decl.def, TypeDef::Alias(_)));
+        }
+        other => panic!("expected TypeDecl, got {other:?}"),
+    }
+}


### PR DESCRIPTION
closes #298

## Summary

- Add newtype constructor detection in the parser's `parse_type_def` method
- When an uppercase identifier is followed by `(`, it's parsed as a single-variant union (newtype pattern) instead of a type alias
- `type ProductId = ProductId(number)` now correctly resolves primitive types in variant fields

## Test plan

- [x] `type ProductId = ProductId(number)` passes check
- [x] `type Email = Email(string)` passes check
- [x] `type Flag = Flag(boolean)` passes check
- [x] `type UserId = UserId(value: number)` (named field) passes check
- [x] Regular union types with `|` prefix still work
- [x] Type aliases (`type Name = string`) still work
- [x] All existing tests pass
- [x] `cargo fmt && cargo clippy -- -D warnings && RUSTFLAGS="-D warnings" cargo test` passes