### PR TITLE
[#300] Fix pipe + ? interaction

### DIFF
--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -1065,22 +1065,11 @@ impl Codegen {
     }
 
     /// Find the inner expression of the outermost `?` in an expression.
-    /// For example, in `input.name |> validateName?`, this returns
-    /// `input.name |> validateName` (the Pipe expression).
+    /// For example, in `input.name |> validateName?`, the parser produces
+    /// `Unwrap(Pipe { ... })`, and this returns the `Pipe` expression.
     fn find_unwrap_in_expr(expr: &Expr) -> Option<&Expr> {
         match &expr.kind {
             ExprKind::Unwrap(inner) => Some(inner),
-            ExprKind::Pipe { right, .. } => {
-                // Check if the right side of the pipe ends with ?
-                if let ExprKind::Unwrap(_) = &right.kind {
-                    // The whole pipe expression has ? at the end
-                    // We need to reconstruct without the ?, but we can't mutate.
-                    // Instead, return None and handle it at the Pipe level.
-                    None
-                } else {
-                    None
-                }
-            }
             _ => None,
         }
     }

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -105,14 +105,32 @@ impl Parser {
             }
 
             let right = self.parse_comparison_expr()?;
-            let span = self.merge_spans(left.span, right.span);
-            left = Expr {
-                kind: ExprKind::Pipe {
-                    left: Box::new(left),
-                    right: Box::new(right),
-                },
-                span,
-            };
+
+            // `a |> f?` parses as `a |> (f?)` due to postfix `?` binding tighter,
+            // but the user means `(a |> f)?`. Restructure: lift the `?` above the pipe.
+            if let ExprKind::Unwrap(inner) = right.kind {
+                let outer_span = self.merge_spans(left.span, right.span);
+                let pipe_span = self.merge_spans(left.span, inner.span);
+                left = Expr {
+                    kind: ExprKind::Unwrap(Box::new(Expr {
+                        kind: ExprKind::Pipe {
+                            left: Box::new(left),
+                            right: inner,
+                        },
+                        span: pipe_span,
+                    })),
+                    span: outer_span,
+                };
+            } else {
+                let span = self.merge_spans(left.span, right.span);
+                left = Expr {
+                    kind: ExprKind::Pipe {
+                        left: Box::new(left),
+                        right: Box::new(right),
+                    },
+                    span,
+                };
+            }
         }
 
         Ok(left)

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -183,6 +183,45 @@ fn unwrap_operator() {
     assert!(matches!(expr, ExprKind::Unwrap(_)));
 }
 
+#[test]
+fn pipe_then_unwrap() {
+    // `x |> f?` should parse as `(x |> f)?`, not `x |> (f?)`
+    let expr = first_expr("x |> f?");
+    match &expr {
+        ExprKind::Unwrap(inner) => {
+            assert!(
+                matches!(inner.kind, ExprKind::Pipe { .. }),
+                "expected Unwrap(Pipe), got Unwrap({:?})",
+                inner.kind
+            );
+        }
+        _ => panic!("expected Unwrap, got {expr:?}"),
+    }
+}
+
+#[test]
+fn pipe_chain_then_unwrap() {
+    // `x |> f |> g?` should parse as `(x |> f |> g)?`
+    let expr = first_expr("x |> f |> g?");
+    match &expr {
+        ExprKind::Unwrap(inner) => {
+            assert!(
+                matches!(inner.kind, ExprKind::Pipe { .. }),
+                "expected Unwrap(Pipe), got Unwrap({:?})",
+                inner.kind
+            );
+            // The inner pipe's left should also be a pipe (x |> f)
+            if let ExprKind::Pipe { left, .. } = &inner.kind {
+                assert!(
+                    matches!(left.kind, ExprKind::Pipe { .. }),
+                    "expected chained pipe"
+                );
+            }
+        }
+        _ => panic!("expected Unwrap, got {expr:?}"),
+    }
+}
+
 // ── Function Calls ───────────────────────────────────────────
 
 #[test]

--- a/tests/fixtures/pipe_unwrap.fl
+++ b/tests/fixtures/pipe_unwrap.fl
@@ -1,0 +1,19 @@
+fn validate(s: string) -> Result<string, string> {
+    Ok(s)
+}
+
+fn format(s: string) -> Result<string, string> {
+    Ok(s)
+}
+
+fn _testPipeUnwrap() -> Result<string, string> {
+    "hello" |> validate?
+}
+
+fn _testPipeChainUnwrap() -> Result<string, string> {
+    "hello" |> validate |> format?
+}
+
+fn _testPipeOptionUnwrap() -> Option<number> {
+    [1, 2, 3] |> Array.head?
+}

--- a/tests/snapshot_codegen.rs
+++ b/tests/snapshot_codegen.rs
@@ -171,3 +171,9 @@ fn snapshot_deriving() {
     let output = compile_fixture("deriving");
     insta::assert_snapshot!(output);
 }
+
+#[test]
+fn snapshot_pipe_unwrap() {
+    let output = compile_fixture("pipe_unwrap");
+    insta::assert_snapshot!(output);
+}

--- a/tests/snapshots/snapshot_codegen__snapshot_pipe_unwrap.snap
+++ b/tests/snapshots/snapshot_codegen__snapshot_pipe_unwrap.snap
@@ -1,0 +1,23 @@
+---
+source: tests/snapshot_codegen.rs
+expression: output
+---
+function validate(s: string): { ok: true; value: string } | { ok: false; error: string } {
+  return { ok: true as const, value: s };
+}
+
+function format(s: string): { ok: true; value: string } | { ok: false; error: string } {
+  return { ok: true as const, value: s };
+}
+
+function _testPipeUnwrap(): { ok: true; value: string } | { ok: false; error: string } {
+  return validate("hello")!;
+}
+
+function _testPipeChainUnwrap(): { ok: true; value: string } | { ok: false; error: string } {
+  return format(validate("hello"))!;
+}
+
+function _testPipeOptionUnwrap(): number | undefined {
+  return [1, 2, 3][0]!;
+}


### PR DESCRIPTION
closes #300

## Summary

- Fixed parser precedence so `a |> f?` parses as `(a |> f)?` instead of `a |> (f?)`
- The postfix `?` was binding tighter than `|>`, causing the checker to see the function type rather than the pipe result type
- When the right side of a pipe is `Unwrap(inner)`, the parser now lifts the `?` above the pipe: `Unwrap(Pipe { left, right: inner })`
- Simplified `find_unwrap_in_expr` in codegen since the old AST shape no longer occurs

## Test plan

- [x] Parser unit tests: `pipe_then_unwrap` and `pipe_chain_then_unwrap` verify AST structure
- [x] Codegen snapshot: `pipe_unwrap.fl` tests `|> validate?`, `|> validate |> format?`, and `|> Array.head?`
- [x] All 860 existing tests pass
- [x] `cargo fmt`, `cargo clippy -- -D warnings`, `RUSTFLAGS="-D warnings" cargo test` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)