### PR TITLE
[#299] Implement default parameter values in checker

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -75,6 +75,9 @@ pub struct Checker {
     trait_defs: HashMap<String, Vec<TraitMethodSig>>,
     /// Tracks which (type, trait) pairs have been implemented.
     trait_impls: HashSet<(String, String)>,
+    /// Maps function names to their required (non-default) parameter count.
+    /// Functions not in this map require all parameters.
+    fn_required_params: HashMap<String, usize>,
 }
 
 /// Signature of a trait method (for checking implementations).
@@ -250,6 +253,7 @@ impl Checker {
             defined_sources: HashMap::new(),
             trait_defs: HashMap::new(),
             trait_impls: HashSet::new(),
+            fn_required_params: HashMap::new(),
         }
     }
 
@@ -340,6 +344,13 @@ impl Checker {
                 self.env.define(&func.name, fn_type);
                 self.defined_sources
                     .insert(func.name.clone(), format!("function from \"{}\"", source));
+
+                // Track required (non-default) parameter count
+                let required_params = func.params.iter().filter(|p| p.default.is_none()).count();
+                if required_params < func.params.len() {
+                    self.fn_required_params
+                        .insert(func.name.clone(), required_params);
+                }
             }
         }
 
@@ -1034,6 +1045,13 @@ impl Checker {
                 func.name.clone(),
                 format!("for-block function from \"{}\"", source),
             );
+
+            // Track required (non-default) parameter count
+            let required_params = func.params.iter().filter(|p| p.default.is_none()).count();
+            if required_params < func.params.len() {
+                self.fn_required_params
+                    .insert(func.name.clone(), required_params);
+            }
         }
     }
 
@@ -1288,6 +1306,14 @@ impl Checker {
         self.env.define(&decl.name, fn_type);
         self.defined_sources
             .insert(decl.name.clone(), "function".to_string());
+
+        // Track required (non-default) parameter count
+        let required_params = decl.params.iter().filter(|p| p.default.is_none()).count();
+        if required_params < decl.params.len() {
+            self.fn_required_params
+                .insert(decl.name.clone(), required_params);
+        }
+
         if decl.exported {
             self.used_names.insert(decl.name.clone());
         }
@@ -1305,6 +1331,28 @@ impl Checker {
                 self.check_no_redefinition(&param.name, span);
             }
             self.env.define(&param.name, ty.clone());
+        }
+
+        // Type-check default parameter values
+        for (param, ty) in decl.params.iter().zip(param_types.iter()) {
+            if let Some(default_expr) = &param.default {
+                let default_ty = self.check_expr(default_expr);
+                if !self.types_compatible(ty, &default_ty) {
+                    self.diagnostics.push(
+                        Diagnostic::error(
+                            format!(
+                                "default value for `{}`: expected `{}`, found `{}`",
+                                param.name,
+                                ty.display_name(),
+                                default_ty.display_name()
+                            ),
+                            param.span,
+                        )
+                        .with_label(format!("expected `{}`", ty.display_name()))
+                        .with_code("E001"),
+                    );
+                }
+            }
         }
 
         // Check body
@@ -1408,6 +1456,14 @@ impl Checker {
             self.env.define(&func.name, fn_type);
             self.defined_sources
                 .insert(func.name.clone(), "for-block function".to_string());
+
+            // Track required (non-default) parameter count
+            let required_params = func.params.iter().filter(|p| p.default.is_none()).count();
+            if required_params < func.params.len() {
+                self.fn_required_params
+                    .insert(func.name.clone(), required_params);
+            }
+
             if func.exported {
                 self.used_names.insert(func.name.clone());
             }
@@ -1421,6 +1477,28 @@ impl Checker {
 
             for (param, ty) in func.params.iter().zip(param_types.iter()) {
                 self.env.define(&param.name, ty.clone());
+            }
+
+            // Type-check default parameter values
+            for (param, ty) in func.params.iter().zip(param_types.iter()) {
+                if let Some(default_expr) = &param.default {
+                    let default_ty = self.check_expr(default_expr);
+                    if !self.types_compatible(ty, &default_ty) {
+                        self.diagnostics.push(
+                            Diagnostic::error(
+                                format!(
+                                    "default value for `{}`: expected `{}`, found `{}`",
+                                    param.name,
+                                    ty.display_name(),
+                                    default_ty.display_name()
+                                ),
+                                param.span,
+                            )
+                            .with_label(format!("expected `{}`", ty.display_name()))
+                            .with_code("E001"),
+                        );
+                    }
+                }
             }
 
             let body_type = self.check_expr(&func.body);

--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -210,14 +210,26 @@ impl Checker {
                             _ => "<anonymous>",
                         };
 
-                        // Check argument count
-                        if arg_types.len() != params.len() {
+                        // Check argument count, accounting for default parameters
+                        let required_params = self
+                            .fn_required_params
+                            .get(callee_name)
+                            .copied()
+                            .unwrap_or(params.len());
+                        if arg_types.len() < required_params || arg_types.len() > params.len() {
+                            let expected_msg = if required_params == params.len() {
+                                format!(
+                                    "{} argument{}",
+                                    params.len(),
+                                    if params.len() == 1 { "" } else { "s" }
+                                )
+                            } else {
+                                format!("{} to {} arguments", required_params, params.len())
+                            };
                             self.diagnostics.push(
                                 Diagnostic::error(
                                     format!(
-                                        "`{callee_name}` expects {} argument{}, found {}",
-                                        params.len(),
-                                        if params.len() == 1 { "" } else { "s" },
+                                        "`{callee_name}` expects {expected_msg}, found {}",
                                         arg_types.len()
                                     ),
                                     expr.span,

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -2629,3 +2629,124 @@ fn type_alias_still_works() {
         diags.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+// ── Default parameter values ────────────────────────────────
+
+#[test]
+fn default_params_all_defaults_omitted() {
+    let diags = check(
+        r#"
+fn greet(name: string, greeting: string = "Hello") -> string {
+    `${greeting}, ${name}!`
+}
+const x = greet("Ryan")
+"#,
+    );
+    assert!(
+        diags.iter().all(|d| d.severity != Severity::Error),
+        "calling with defaults omitted should work, got errors: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn default_params_some_defaults_omitted() {
+    let diags = check(
+        r#"
+fn make(a: string, b: string = "x", c: number = 0) -> string {
+    `${a}${b}`
+}
+const x = make("hello", "world")
+"#,
+    );
+    assert!(
+        diags.iter().all(|d| d.severity != Severity::Error),
+        "calling with some defaults omitted should work, got errors: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn default_params_all_explicit() {
+    let diags = check(
+        r#"
+fn make(a: string, b: string = "x", c: number = 0) -> string {
+    `${a}${b}`
+}
+const x = make("hello", "world", 42)
+"#,
+    );
+    assert!(
+        diags.iter().all(|d| d.severity != Severity::Error),
+        "calling with all args explicit should work, got errors: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn default_params_too_few_args_error() {
+    let diags = check(
+        r#"
+fn make(a: string, b: string = "x", c: number = 0) -> string {
+    `${a}${b}`
+}
+const x = make()
+"#,
+    );
+    assert!(
+        has_error_containing(&diags, "expects"),
+        "missing required param should error, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn default_params_too_many_args_error() {
+    let diags = check(
+        r#"
+fn make(a: string, b: string = "x") -> string {
+    `${a}${b}`
+}
+const x = make("a", "b", "c")
+"#,
+    );
+    assert!(
+        has_error_containing(&diags, "expects"),
+        "too many args should error, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn default_params_type_mismatch_error() {
+    let diags = check(
+        r#"
+fn greet(name: string, count: number = "oops") -> string {
+    name
+}
+"#,
+    );
+    assert!(
+        has_error_containing(&diags, "default value for `count`"),
+        "default value type mismatch should error, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn default_params_only_required_param() {
+    let diags = check(
+        r#"
+fn greet(name: string, greeting: string = "Hello") -> string {
+    `${greeting}, ${name}!`
+}
+const x = greet("Ryan")
+"#,
+    );
+    // Verify the error message format says "1 to 2 arguments" not just "2 arguments"
+    assert!(
+        !has_error_containing(&diags, "expects"),
+        "should not produce argument count error, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
closes #299

## Summary

- The checker now tracks required (non-default) parameter counts for all function declarations (regular functions, for-block functions, and imported functions)
- Function call validation allows fewer arguments than total parameters when the missing parameters have default values
- Default value expressions are type-checked against their parameter's declared type
- Error messages show the valid range (e.g., "expects 1 to 3 arguments") when defaults are present

## Test plan

- [x] Call with all defaults omitted - valid
- [x] Call with some defaults omitted - valid  
- [x] Call with all args explicit - valid
- [x] Call with too few args (missing required param) - error
- [x] Call with too many args - error
- [x] Default value type mismatch - error
- [x] All existing tests pass