### PR TITLE
[#314] Fix Bang and punctuation in JSX text content

### DIFF
--- a/src/cst.rs
+++ b/src/cst.rs
@@ -2045,6 +2045,13 @@ impl<'src> CstParser<'src> {
                 | Some(TokenKind::Number(_))
                 | Some(TokenKind::String(_))
                 | Some(TokenKind::Whitespace)
+                | Some(TokenKind::Bang)
+                | Some(TokenKind::BangEqual)
+                | Some(TokenKind::Dot)
+                | Some(TokenKind::Comma)
+                | Some(TokenKind::Colon)
+                | Some(TokenKind::Semicolon)
+                | Some(TokenKind::Question)
         )
     }
 


### PR DESCRIPTION
closes #314

## Summary

- Added `!`, `.`, `,`, `:`, `;`, `?`, `!=` as valid JSX text tokens in the CST parser
- `<p>Hello!</p>` inside match arms now parses correctly
- Fixes cascading parse errors in store example pages (cart.fl, catalog.fl, product-detail.fl)

## Test plan

- [x] All 873 tests pass
- [x] `<p>Hello!</p>` in match arms works
- [x] `cargo fmt && cargo clippy -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)