### PR TITLE
[#322] Fix compiler semantic bugs for store example

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -926,8 +926,9 @@ impl Checker {
             self.imported_names
                 .push((effective_name.to_string(), spec.span));
 
-            // Track untrusted imports (not trusted at module or specifier level)
-            if !decl.trusted && !spec.trusted {
+            // Track untrusted imports (not trusted at module or specifier level).
+            // Floe-to-Floe imports (resolved.is_some()) are always trusted.
+            if !decl.trusted && !spec.trusted && resolved.is_none() {
                 self.untrusted_imports.insert(effective_name.to_string());
             }
         }

--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -1400,12 +1400,42 @@ impl Checker {
 pub(crate) fn simple_resolve_type_expr(type_expr: &crate::parser::ast::TypeExpr) -> Type {
     use crate::parser::ast::TypeExprKind;
     match &type_expr.kind {
-        TypeExprKind::Named { name, .. } => match name.as_str() {
+        TypeExprKind::Named {
+            name, type_args, ..
+        } => match name.as_str() {
             type_names::NUMBER => Type::Number,
             type_names::STRING => Type::String,
             type_names::BOOLEAN => Type::Bool,
             type_names::UNIT => Type::Unit,
             type_names::UNDEFINED => Type::Undefined,
+            type_names::ARRAY => {
+                let inner = type_args
+                    .first()
+                    .map(simple_resolve_type_expr)
+                    .unwrap_or(Type::Unknown);
+                Type::Array(Box::new(inner))
+            }
+            type_names::OPTION => {
+                let inner = type_args
+                    .first()
+                    .map(simple_resolve_type_expr)
+                    .unwrap_or(Type::Unknown);
+                Type::Option(Box::new(inner))
+            }
+            type_names::RESULT => {
+                let ok = type_args
+                    .first()
+                    .map(simple_resolve_type_expr)
+                    .unwrap_or(Type::Unknown);
+                let err = type_args
+                    .get(1)
+                    .map(simple_resolve_type_expr)
+                    .unwrap_or(Type::Unknown);
+                Type::Result {
+                    ok: Box::new(ok),
+                    err: Box::new(err),
+                }
+            }
             _ => Type::Named(name.to_string()),
         },
         TypeExprKind::Array(inner) => Type::Array(Box::new(simple_resolve_type_expr(inner))),

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -1032,6 +1032,10 @@ impl<'src> CstParser<'src> {
                     self.builder.finish_node();
                 }
                 Some(TokenKind::LeftParen) => {
+                    // Don't treat `(` on a new line as a call — it's a new expression
+                    if self.preceded_by_newline() {
+                        break;
+                    }
                     // Check if it's a constructor (uppercase ident) — don't parse as call
                     if self.is_uppercase_ident_at_checkpoint() {
                         break;

--- a/src/lower.rs
+++ b/src/lower.rs
@@ -302,11 +302,18 @@ impl<'src> Lowerer<'src> {
         let idents = self.collect_idents(node);
         let has_lbrace = self.has_token(node, SyntaxKind::L_BRACE);
 
+        let has_lparen = self.has_token(node, SyntaxKind::L_PAREN);
+
         let (name, destructure) = if has_lbrace {
             // Destructured param: { name, age }
             let fields: Vec<String> = idents.clone();
             let synthetic_name = format!("_{}", fields.join("_"));
             (synthetic_name, Some(ParamDestructure::Object(fields)))
+        } else if has_lparen {
+            // Tuple destructured param: (a, b)
+            let fields: Vec<String> = idents.clone();
+            let synthetic_name = format!("_{}", fields.join("_"));
+            (synthetic_name, Some(ParamDestructure::Array(fields)))
         } else {
             (idents.first()?.clone(), None)
         };

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -145,6 +145,7 @@ fn build_stdlib() -> Vec<StdlibFn> {
         stdlib_fn!("Array", "unique", [array_of(t.clone())], array_of(t.clone()), "[...new Set($0)]"),
         stdlib_fn!("Array", "groupBy", [array_of(t.clone()), fun(vec![t.clone()], Type::String)], Type::Named("Record".to_string()), "Object.groupBy($0, $1)"),
         stdlib_fn!("Array", "zip", [array_of(t.clone()), array_of(u.clone())], array_of(Type::Tuple(vec![t.clone(), u.clone()])), "$0.map((_v, _i) => [_v, $1[_i]] as const)"),
+        stdlib_fn!("Array", "from", [t.clone(), fun(vec![t.clone(), Type::Number], u.clone())], array_of(u.clone()), "Array.from($0, $1)"),
         // ── Option ──────────────────────────────────────────────
         stdlib_fn!("Option", "map", [option_of(t.clone()), fun(vec![t.clone()], u.clone())], option_of(u.clone()), "$0 !== undefined ? ($1)($0) : undefined"),
         stdlib_fn!("Option", "flatMap", [option_of(t.clone()), fun(vec![t.clone()], option_of(u.clone()))], option_of(u.clone()), "$0 !== undefined ? ($1)($0) : undefined"),
@@ -176,6 +177,7 @@ fn build_stdlib() -> Vec<StdlibFn> {
         stdlib_fn!("String", "padStart", [Type::String, Type::Number, Type::String], Type::String, "$0.padStart($1, $2)"),
         stdlib_fn!("String", "padEnd", [Type::String, Type::Number, Type::String], Type::String, "$0.padEnd($1, $2)"),
         stdlib_fn!("String", "repeat", [Type::String, Type::Number], Type::String, "$0.repeat($1)"),
+        stdlib_fn!("String", "localeCompare", [Type::String, Type::String], Type::Number, "$0.localeCompare($1)"),
         // ── Number ──────────────────────────────────────────────
         stdlib_fn!("Number", "parse", [Type::String], result_of(Type::Number, Type::Named("ParseError".to_string())), "(() => { const _n = Number($0); return Number.isNaN(_n) || $0.trim() === \"\" ? { ok: false as const, error: { message: `Failed to parse \"${$0}\" as number` } } : { ok: true as const, value: _n }; })()"),
         stdlib_fn!("Number", "clamp", [Type::Number, Type::Number, Type::Number], Type::Number, "Math.min(Math.max($0, $1), $2)"),


### PR DESCRIPTION
closes #322

## Summary

- **Trusted Floe imports**: Floe-to-Floe imports (resolved imports) are now automatically trusted. Only npm/JS imports require `try`/`trusted`. Fixed by checking `resolved.is_some()` before marking imports as untrusted.
- **parse<T> generic preservation**: `simple_resolve_type_expr` now correctly resolves `Array<T>`, `Option<T>`, and `Result<T, E>` type constructors instead of collapsing them to bare `Named("Array")` etc.
- **Tuple destructuring in lambdas**: `|(a, b)| expr` now correctly binds `a` and `b` as variables in the lambda body by detecting `L_PAREN` in param lowering and emitting `ParamDestructure::Array`.
- **Block scoping with tuples**: `(x, y)` on a new line after `const y = 2` was being parsed as a call expression `2(x, y)`. Fixed by adding a `preceded_by_newline()` check before treating `(` as a call in the postfix parser.
- **String.localeCompare**: Added `String.localeCompare(string, string) -> number` to stdlib.
- **Array.from**: Added `Array.from(object, (T, number) -> U) -> Array<U>` to stdlib.

## Test plan

- [x] `cargo fmt && cargo clippy -- -D warnings && RUSTFLAGS="-D warnings" cargo test` all pass
- [x] Cross-file Floe imports no longer produce "untrusted import" errors
- [x] Tuple destructuring in lambda params binds variables correctly
- [x] `const x = 1; const y = 2; (x, y)` in a block now resolves correctly
- [x] Store example files show reduced error counts (remaining errors are pre-existing type system issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)