### PR TITLE
[#323] Support tuple index access (pair.0, pair.1)

### DIFF
--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -1357,6 +1357,26 @@ impl Checker {
             return Type::Unknown;
         }
 
+        // Tuple index access: pair.0, pair.1
+        if let Type::Tuple(elements) = &concrete
+            && let Ok(idx) = field.parse::<usize>()
+        {
+            if idx < elements.len() {
+                return elements[idx].clone();
+            }
+            self.diagnostics.push(
+                Diagnostic::error(
+                    format!(
+                        "tuple index `{field}` out of bounds — tuple has {} element(s)",
+                        elements.len()
+                    ),
+                    span,
+                )
+                .with_code("E017"),
+            );
+            return Type::Unknown;
+        }
+
         // Error on member access on primitive types
         match obj_ty {
             Type::Number | Type::String | Type::Bool | Type::Unit => {

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -976,12 +976,13 @@ impl<'src> CstParser<'src> {
                         .start_node_at(checkpoint, SyntaxKind::MEMBER_EXPR.into());
                     self.bump();
                     self.eat_trivia();
-                    // Accept identifiers, banned keywords, and other keywords after `.`
-                    // (e.g., `Array.any(...)`, `Number.parse(...)`)
+                    // Accept identifiers, numbers (tuple .0, .1), banned keywords, and other keywords after `.`
+                    // (e.g., `Array.any(...)`, `Number.parse(...)`, `pair.0`)
                     if self.is_ident()
                         || matches!(
                             self.current_kind(),
-                            Some(TokenKind::Banned(_))
+                            Some(TokenKind::Number(_))
+                                | Some(TokenKind::Banned(_))
                                 | Some(TokenKind::Parse)
                                 | Some(TokenKind::Match)
                                 | Some(TokenKind::For)


### PR DESCRIPTION
closes #323

CST parser now allows numbers after dot. Checker resolves `pair.0` on `(string, number)` to `string`.