### PR TITLE
[#328] Fix newtype constructor codegen to emit value field

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -94,7 +94,16 @@ impl Codegen {
                         let field_names: Vec<String> = variant
                             .fields
                             .iter()
-                            .filter_map(|f| f.name.clone())
+                            .enumerate()
+                            .map(|(i, f)| {
+                                f.name.clone().unwrap_or_else(|| {
+                                    if variant.fields.len() == 1 {
+                                        "value".to_string()
+                                    } else {
+                                        format!("_{i}")
+                                    }
+                                })
+                            })
                             .collect();
                         if variant.fields.is_empty() {
                             codegen.unit_variants.insert(variant.name.clone());
@@ -120,7 +129,16 @@ impl Codegen {
                             let field_names: Vec<String> = variant
                                 .fields
                                 .iter()
-                                .filter_map(|f| f.name.clone())
+                                .enumerate()
+                                .map(|(i, f)| {
+                                    f.name.clone().unwrap_or_else(|| {
+                                        if variant.fields.len() == 1 {
+                                            "value".to_string()
+                                        } else {
+                                            format!("_{i}")
+                                        }
+                                    })
+                                })
                                 .collect();
                             if variant.fields.is_empty() {
                                 self.unit_variants.insert(variant.name.clone());


### PR DESCRIPTION
closes #328

`OrderId(42)` was emitting `{ tag: "OrderId", 42 }` (invalid JS). Now emits `{ tag: "OrderId", value: 42 }`.