### PR TITLE
[#329] Emit async IIFE for collect blocks with await

### DIFF
--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -948,7 +948,17 @@ impl Codegen {
     /// })()
     /// ```
     fn emit_collect_block(&mut self, items: &[Item]) {
-        self.push("(() => {");
+        // Check if any item contains await — if so, emit async IIFE
+        let has_await = items.iter().any(|item| match &item.kind {
+            ItemKind::Expr(e) => expr_contains_await(e),
+            ItemKind::Const(c) => expr_contains_await(&c.value),
+            _ => false,
+        });
+        if has_await {
+            self.push("(async () => {");
+        } else {
+            self.push("(() => {");
+        }
         self.newline();
         self.indent += 1;
 


### PR DESCRIPTION
collect blocks containing await now emit async IIFE. Fixes Vite build error.