### PR TITLE
[#331] Inline __floeEq helper in every file that needs it

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -860,7 +860,7 @@ type User = {
 
 This generates the same code as a handwritten `for` block with no runtime cost.
 
-**Note:** `Eq` is not derivable — structural equality is built-in for all types via `==` (emits `__zenEq` deep comparison). Writing `deriving (Eq)` is a compile error.
+**Note:** `Eq` is not derivable — structural equality is built-in for all types via `==` (emits `__floeEq` deep comparison). Writing `deriving (Eq)` is a compile error.
 
 **Derivable traits:**
 

--- a/examples/todo-app/src/pages/home.tsx
+++ b/examples/todo-app/src/pages/home.tsx
@@ -1,11 +1,11 @@
-function __zenEq(a: unknown, b: unknown): boolean {
+function __floeEq(a: unknown, b: unknown): boolean {
   if (a === b) return true;
   if (a == null || b == null) return false;
   if (typeof a !== "object" || typeof b !== "object") return false;
   const ka = Object.keys(a as object);
   const kb = Object.keys(b as object);
   if (ka.length !== kb.length) return false;
-  return ka.every((k) => __zenEq((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]));
+  return ka.every((k) => __floeEq((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]));
 }
 
 import { useState } from "react";
@@ -27,10 +27,10 @@ export function HomePage(): JSX.Element {
     return __validate(input).tag === "Empty" ? setError("Please enter a todo") : __validate(input).tag === "TooShort" ? setError("Todo must be at least 2 characters") : __validate(input).tag === "TooLong" ? setError("Todo must be under 100 characters") : __validate(input).tag === "Valid" ? (() => { const text = __validate(input).text;     setTodos([...todos, { id: v4(), text: text, done: false }]);     setInput("");     setError("");  })() : (() => { throw new Error("non-exhaustive match"); })();
   }
   function handleToggle(id: string) {
-    return setTodos(todos.map((t) => __zenEq(t.id, id) === true ? { ...t, done: !t.done } : __zenEq(t.id, id) === false ? t : (() => { throw new Error("non-exhaustive match"); })()));
+    return setTodos(todos.map((t) => __floeEq(t.id, id) === true ? { ...t, done: !t.done } : __floeEq(t.id, id) === false ? t : (() => { throw new Error("non-exhaustive match"); })()));
   }
   function handleDelete(id: string) {
-    return setTodos(todos.filter((_x) => !__zenEq(_x.id, id)));
+    return setTodos(todos.filter((_x) => !__floeEq(_x.id, id)));
   }
   return <div><h1 className={"text-3xl font-bold mb-6"}>Todos</h1><div className={"flex gap-2 mb-4"}><input type={"text"} value={input} onChange={(e) => setInput(e.target.value)} onKeyDown={(e) => e.key === "Enter" ? handleAdd() : undefined} placeholder={"What needs to be done?"} className={"flex-1 rounded-lg bg-zinc-800 px-4 py-2 text-zinc-100 placeholder-zinc-500 outline-none ring-1 ring-zinc-700 focus:ring-indigo-500"} /><button onClick={handleAdd} className={"rounded-lg bg-indigo-600 px-4 py-2 font-medium text-white hover:bg-indigo-500 transition-colors"}>Add</button></div>{error === "" ? <span /> : <p className={"text-red-400 text-sm mb-4"}>{error}</p>}<div className={"flex gap-2 mb-6"}><button onClick={() => setFilter({ tag: "All" })} className={filter.tag === "All" ? "rounded-full px-3 py-1 text-sm font-medium bg-indigo-600 text-white" : "rounded-full px-3 py-1 text-sm font-medium bg-zinc-800 text-zinc-400 hover:text-zinc-100"}>All</button><button onClick={() => setFilter({ tag: "Active" })} className={filter.tag === "Active" ? "rounded-full px-3 py-1 text-sm font-medium bg-indigo-600 text-white" : "rounded-full px-3 py-1 text-sm font-medium bg-zinc-800 text-zinc-400 hover:text-zinc-100"}>Active</button><button onClick={() => setFilter({ tag: "Completed" })} className={filter.tag === "Completed" ? "rounded-full px-3 py-1 text-sm font-medium bg-indigo-600 text-white" : "rounded-full px-3 py-1 text-sm font-medium bg-zinc-800 text-zinc-400 hover:text-zinc-100"}>Completed</button></div><ul className={"space-y-2"}>{visible.map((item) => <li key={item.id} className={"flex items-center gap-3 rounded-lg bg-zinc-800/50 px-4 py-3"}><button onClick={() => handleToggle(item.id)} className={item.done === true ? "h-5 w-5 rounded-full border-2 border-indigo-500 bg-indigo-500 flex items-center justify-center" : item.done === false ? "h-5 w-5 rounded-full border-2 border-zinc-600" : (() => { throw new Error("non-exhaustive match"); })()}>{item.done === true ? <span className={"text-white text-xs"}>✓</span> : item.done === false ? <span /> : (() => { throw new Error("non-exhaustive match"); })()}</button><span className={item.done === true ? "flex-1 text-zinc-500 line-through" : item.done === false ? "flex-1 text-zinc-100" : (() => { throw new Error("non-exhaustive match"); })()}>{item.text}</span><button onClick={() => handleDelete(item.id)} className={"text-zinc-600 hover:text-red-400 transition-colors"}>✕</button></li>)}</ul><p className={"mt-6 text-sm text-zinc-500"}>{`${remainingCount} item(s) remaining`}</p></div>;
 }

--- a/examples/todo-app/src/todo.ts
+++ b/examples/todo-app/src/todo.ts
@@ -1,11 +1,11 @@
-function __zenEq(a: unknown, b: unknown): boolean {
+function __floeEq(a: unknown, b: unknown): boolean {
   if (a === b) return true;
   if (a == null || b == null) return false;
   if (typeof a !== "object" || typeof b !== "object") return false;
   const ka = Object.keys(a as object);
   const kb = Object.keys(b as object);
   if (ka.length !== kb.length) return false;
-  return ka.every((k) => __zenEq((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]));
+  return ka.every((k) => __floeEq((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]));
 }
 
 import { Todo, Filter, Validation, Display } from "./types";
@@ -21,13 +21,13 @@ export function display(self: Todo): string {
 }
 
 export function filterBy(self: Array<Todo>, f: Filter): Array<Todo> {
-  return f.tag === "All" ? self : f.tag === "Active" ? self.filter((_x) => __zenEq(_x.done, false)) : f.tag === "Completed" ? self.filter((_x) => __zenEq(_x.done, true)) : (() => { throw new Error("non-exhaustive match"); })();
+  return f.tag === "All" ? self : f.tag === "Active" ? self.filter((_x) => __floeEq(_x.done, false)) : f.tag === "Completed" ? self.filter((_x) => __floeEq(_x.done, true)) : (() => { throw new Error("non-exhaustive match"); })();
 }
 export function remaining(self: Array<Todo>): number {
-  return (() => { const _v = self.filter((_x) => __zenEq(_x.done, false)); ((active) => console.log("active todos:"))(_v); return _v; })().length;
+  return (() => { const _v = self.filter((_x) => __floeEq(_x.done, false)); ((active) => console.log("active todos:"))(_v); return _v; })().length;
 }
 export function stats(self: Array<Todo>): readonly [number, number] {
-  return [self.length, self.filter((_x) => __zenEq(_x.done, true)).length] as const;
+  return [self.length, self.filter((_x) => __floeEq(_x.done, true)).length] as const;
 }
 export function search(self: Array<Todo>, _query: string): Array<Todo> {
   return (() => { throw new Error("not implemented"); })();

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -188,14 +188,14 @@ impl Codegen {
         // Prepend structural equality helper if any == or != was used
         if self.needs_deep_equal {
             let helper = concat!(
-                "function __zenEq(a: unknown, b: unknown): boolean {\n",
+                "function __floeEq(a: unknown, b: unknown): boolean {\n",
                 "  if (a === b) return true;\n",
                 "  if (a == null || b == null) return false;\n",
                 "  if (typeof a !== \"object\" || typeof b !== \"object\") return false;\n",
                 "  const ka = Object.keys(a as object);\n",
                 "  const kb = Object.keys(b as object);\n",
                 "  if (ka.length !== kb.length) return false;\n",
-                "  return ka.every((k) => __zenEq((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]));\n",
+                "  return ka.every((k) => __floeEq((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]));\n",
                 "}\n\n",
             );
             self.output = format!("{helper}{}", self.output);

--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -1,7 +1,7 @@
 use super::*;
 use super::{ERROR_FIELD, OK_FIELD, TAG_FIELD, VALUE_FIELD};
 
-const DEEP_EQUAL_FN: &str = "__zenEq";
+const DEEP_EQUAL_FN: &str = "__floeEq";
 const THROW_NOT_IMPLEMENTED: &str = "(() => { throw new Error(\"not implemented\"); })()";
 const THROW_UNREACHABLE: &str = "(() => { throw new Error(\"unreachable\"); })()";
 

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -430,9 +430,49 @@ fn lambda_multi_arg() {
 #[test]
 fn equality_becomes_structural() {
     let result = emit("a == b");
-    assert!(result.contains("__zenEq(a, b)"));
+    assert!(result.contains("__floeEq(a, b)"));
     let result = emit("a != b");
-    assert!(result.contains("!__zenEq(a, b)"));
+    assert!(result.contains("!__floeEq(a, b)"));
+}
+
+#[test]
+fn floe_eq_helper_emitted_when_needed() {
+    // File that uses == should have the __floeEq helper definition
+    let result = emit("a == b");
+    assert!(
+        result.contains("function __floeEq(a: unknown, b: unknown): boolean"),
+        "expected __floeEq helper to be emitted, got:\n{result}"
+    );
+}
+
+#[test]
+fn floe_eq_helper_not_emitted_when_not_needed() {
+    // File that doesn't use == should NOT have the __floeEq helper
+    let result = emit("const x = 1 + 2");
+    assert!(
+        !result.contains("__floeEq"),
+        "expected no __floeEq helper, got:\n{result}"
+    );
+}
+
+#[test]
+fn floe_eq_helper_emitted_for_dot_shorthand_eq() {
+    // Dot shorthand with == should emit the helper
+    let result = emit("const active = todos |> Array.filter(.done == false)");
+    assert!(
+        result.contains("function __floeEq(a: unknown, b: unknown): boolean"),
+        "expected __floeEq helper for dot shorthand ==, got:\n{result}"
+    );
+}
+
+#[test]
+fn floe_eq_helper_emitted_for_stdlib_contains() {
+    // Array.contains uses __floeEq in its template
+    let result = emit("Array.contains([1, 2], 2)");
+    assert!(
+        result.contains("function __floeEq(a: unknown, b: unknown): boolean"),
+        "expected __floeEq helper for Array.contains, got:\n{result}"
+    );
 }
 
 // ── Await ────────────────────────────────────────────────────
@@ -534,7 +574,7 @@ fn stdlib_array_length() {
 #[test]
 fn stdlib_array_contains() {
     let result = emit("Array.contains([1, 2], 2)");
-    assert!(result.contains("__zenEq"));
+    assert!(result.contains("__floeEq"));
     assert!(result.contains(".some("));
 }
 

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -125,7 +125,7 @@ fn build_stdlib() -> Vec<StdlibFn> {
         stdlib_fn!("Array", "findIndex", [array_of(t.clone()), fun(vec![t.clone()], Type::Bool)], option_of(Type::Number), "(() => { const _i = $0.findIndex($1); return _i === -1 ? undefined : _i; })()"),
         stdlib_fn!("Array", "flatMap", [array_of(t.clone()), fun(vec![t.clone()], array_of(u.clone()))], array_of(u.clone()), "$0.flatMap($1)"),
         stdlib_fn!("Array", "at", [array_of(t.clone()), Type::Number], option_of(t.clone()), "$0[$1]"),
-        stdlib_fn!("Array", "contains", [array_of(t.clone()), t.clone()], Type::Bool, "$0.some((_item) => __zenEq(_item, $1))"),
+        stdlib_fn!("Array", "contains", [array_of(t.clone()), t.clone()], Type::Bool, "$0.some((_item) => __floeEq(_item, $1))"),
         stdlib_fn!("Array", "head", [array_of(t.clone())], option_of(t.clone()), "$0[0]"),
         stdlib_fn!("Array", "last", [array_of(t.clone())], option_of(t.clone()), "$0[$0.length - 1]"),
         stdlib_fn!("Array", "take", [array_of(t.clone()), Type::Number], array_of(t.clone()), "$0.slice(0, $1)"),

--- a/tests/snapshots/snapshot_codegen__snapshot_dot_shorthand.snap
+++ b/tests/snapshots/snapshot_codegen__snapshot_dot_shorthand.snap
@@ -2,22 +2,22 @@
 source: tests/snapshot_codegen.rs
 expression: output
 ---
-function __zenEq(a: unknown, b: unknown): boolean {
+function __floeEq(a: unknown, b: unknown): boolean {
   if (a === b) return true;
   if (a == null || b == null) return false;
   if (typeof a !== "object" || typeof b !== "object") return false;
   const ka = Object.keys(a as object);
   const kb = Object.keys(b as object);
   if (ka.length !== kb.length) return false;
-  return ka.every((k) => __zenEq((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]));
+  return ka.every((k) => __floeEq((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]));
 }
 
 const names = todos.map((_x) => _x.text);
 
-const active = todos.filter((_x) => __zenEq(_x.done, false));
+const active = todos.filter((_x) => __floeEq(_x.done, false));
 
 const byName = [...users].sort((a, b) => ((_x) => _x.name)(a) - ((_x) => _x.name)(b));
 
-const found = items.filter((_x) => !__zenEq(_x.id, id));
+const found = items.filter((_x) => !__floeEq(_x.id, id));
 
 const big = items.filter((_x) => _x.size > 100);

--- a/tests/snapshots/snapshot_codegen__snapshot_stdlib.snap
+++ b/tests/snapshots/snapshot_codegen__snapshot_stdlib.snap
@@ -2,14 +2,14 @@
 source: tests/snapshot_codegen.rs
 expression: output
 ---
-function __zenEq(a: unknown, b: unknown): boolean {
+function __floeEq(a: unknown, b: unknown): boolean {
   if (a === b) return true;
   if (a == null || b == null) return false;
   if (typeof a !== "object" || typeof b !== "object") return false;
   const ka = Object.keys(a as object);
   const kb = Object.keys(b as object);
   if (ka.length !== kb.length) return false;
-  return ka.every((k) => __zenEq((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]));
+  return ka.every((k) => __floeEq((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]));
 }
 
 const _sorted = [...[3, 1, 2]].sort((a, b) => a - b);
@@ -20,15 +20,15 @@ const _mapped = [1, 2, 3].map((n) => n * 2);
 
 const _filtered = [1, 2, 3, 4].filter((n) => n > 2);
 
-const _found = [1, 2, 3].find((n) => __zenEq(n, 2));
+const _found = [1, 2, 3].find((n) => __floeEq(n, 2));
 
-const _found_idx = (() => { const _i = [1, 2, 3].findIndex((n) => __zenEq(n, 2)); return _i === -1 ? undefined : _i; })();
+const _found_idx = (() => { const _i = [1, 2, 3].findIndex((n) => __floeEq(n, 2)); return _i === -1 ? undefined : _i; })();
 
 const _flat_mapped = [1, 2].flatMap((n) => [n, n * 10]);
 
 const _at = [1, 2, 3][1];
 
-const _has = [1, 2, 3].some((_item) => __zenEq(_item, 2));
+const _has = [1, 2, 3].some((_item) => __floeEq(_item, 2));
 
 const _first = [1, 2, 3][0];
 

--- a/tests/snapshots/snapshot_codegen__snapshot_structural_equality.snap
+++ b/tests/snapshots/snapshot_codegen__snapshot_structural_equality.snap
@@ -2,18 +2,18 @@
 source: tests/snapshot_codegen.rs
 expression: output
 ---
-function __zenEq(a: unknown, b: unknown): boolean {
+function __floeEq(a: unknown, b: unknown): boolean {
   if (a === b) return true;
   if (a == null || b == null) return false;
   if (typeof a !== "object" || typeof b !== "object") return false;
   const ka = Object.keys(a as object);
   const kb = Object.keys(b as object);
   if (ka.length !== kb.length) return false;
-  return ka.every((k) => __zenEq((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]));
+  return ka.every((k) => __floeEq((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]));
 }
 
-const _a = __zenEq(1, 2);
+const _a = __floeEq(1, 2);
 
-const _b = !__zenEq("hello", "world");
+const _b = !__floeEq("hello", "world");
 
-const _c = __zenEq(1, 1);
+const _c = __floeEq(1, 1);

--- a/tests/snapshots/snapshot_codegen__snapshot_traits.snap
+++ b/tests/snapshots/snapshot_codegen__snapshot_traits.snap
@@ -2,14 +2,14 @@
 source: tests/snapshot_codegen.rs
 expression: output
 ---
-function __zenEq(a: unknown, b: unknown): boolean {
+function __floeEq(a: unknown, b: unknown): boolean {
   if (a === b) return true;
   if (a == null || b == null) return false;
   if (typeof a !== "object" || typeof b !== "object") return false;
   const ka = Object.keys(a as object);
   const kb = Object.keys(b as object);
   if (ka.length !== kb.length) return false;
-  return ka.every((k) => __zenEq((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]));
+  return ka.every((k) => __floeEq((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]));
 }
 
 
@@ -23,7 +23,7 @@ function display(self: User): string {
 }
 
 function eq(self: User, other: string): boolean {
-  return __zenEq(self.name, other);
+  return __floeEq(self.name, other);
 }
 
 function greet(self: User, greeting: string): string {


### PR DESCRIPTION
closes #331

## Summary

- Renamed the structural equality helper from `__zenEq` to `__floeEq` to match the project rename from zenscript to floe
- The codegen already correctly tracks `needs_deep_equal` and prepends the helper when any `==`/`!=` comparison or `Array.contains` is used - verified this works across all code paths
- Added 4 new tests verifying the helper is emitted only in files that need it (equality, dot shorthand, stdlib contains) and omitted when not needed
- Updated all snapshot tests, example output files, and docs

## Test plan

- [x] `cargo fmt && cargo clippy -- -D warnings && RUSTFLAGS="-D warnings" cargo test` passes
- [x] New tests verify helper emission for `==`, `!=`, `.field == value`, and `Array.contains`
- [x] New test verifies helper is NOT emitted for files without equality
- [x] Built todo-app and store examples - files using `==` have `__floeEq`, others don't
- [x] No remaining `__zenEq` references in the codebase