### PR TITLE
[#336] Fix destructured param codegen

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -412,15 +412,43 @@ impl Codegen {
             if i > 0 {
                 self.push(", ");
             }
-            self.push(&param.name);
-            if let Some(type_ann) = &param.type_ann {
-                self.push(": ");
-                self.emit_type_expr(type_ann);
+            self.emit_param(param);
+        }
+    }
+
+    fn emit_param(&mut self, param: &Param) {
+        match &param.destructure {
+            Some(ParamDestructure::Object(fields)) => {
+                self.push("{ ");
+                for (i, field) in fields.iter().enumerate() {
+                    if i > 0 {
+                        self.push(", ");
+                    }
+                    self.push(field);
+                }
+                self.push(" }");
             }
-            if let Some(default) = &param.default {
-                self.push(" = ");
-                self.emit_expr(default);
+            Some(ParamDestructure::Array(fields)) => {
+                self.push("[");
+                for (i, field) in fields.iter().enumerate() {
+                    if i > 0 {
+                        self.push(", ");
+                    }
+                    self.push(field);
+                }
+                self.push("]");
             }
+            None => {
+                self.push(&param.name);
+            }
+        }
+        if let Some(type_ann) = &param.type_ann {
+            self.push(": ");
+            self.emit_type_expr(type_ann);
+        }
+        if let Some(default) = &param.default {
+            self.push(" = ");
+            self.emit_expr(default);
         }
     }
 

--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -199,7 +199,7 @@ impl Codegen {
                 }
                 if params.len() == 1 && params[0].type_ann.is_none() {
                     self.push("(");
-                    self.push(&params[0].name);
+                    self.emit_param(&params[0]);
                     self.push(")");
                 } else {
                     self.push("(");


### PR DESCRIPTION
Object and array destructuring in lambda params now emit correct JS. |{ reset }| emits ({ reset }) =>, not (_reset) =>.