### PR TITLE
[#375] Add LSP document formatting support for format-on-save in VSCode

### DIFF
--- a/src/lsp/handlers.rs
+++ b/src/lsp/handlers.rs
@@ -37,6 +37,7 @@ impl LanguageServer for FloeLsp {
                 references_provider: Some(OneOf::Left(true)),
                 document_symbol_provider: Some(OneOf::Left(true)),
                 code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
+                document_formatting_provider: Some(OneOf::Left(true)),
                 ..Default::default()
             },
             server_info: Some(ServerInfo {
@@ -715,6 +716,34 @@ impl LanguageServer for FloeLsp {
         } else {
             Ok(Some(actions))
         }
+    }
+
+    // ── Formatting ───────────────────────────────────────────────
+
+    async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {
+        let uri = params.text_document.uri;
+
+        let docs = self.documents.read().await;
+        let Some(doc) = docs.get(&uri) else {
+            return Ok(None);
+        };
+
+        let formatted = crate::formatter::format(&doc.content);
+
+        if formatted == doc.content {
+            return Ok(None);
+        }
+
+        let last_line = doc.content.lines().count().saturating_sub(1) as u32;
+        let last_char = doc.content.lines().last().map_or(0, |l| l.len()) as u32;
+
+        Ok(Some(vec![TextEdit {
+            range: Range {
+                start: Position::new(0, 0),
+                end: Position::new(last_line, last_char),
+            },
+            new_text: formatted,
+        }]))
     }
 }
 


### PR DESCRIPTION
closes #375

## Summary
- Registers `document_formatting_provider` in LSP server capabilities
- Adds `textDocument/formatting` handler that delegates to the existing `formatter::format()` function
- Returns a full-document `TextEdit` when formatting changes the content, or `None` when already formatted

## Test plan
- [ ] Open a `.fl` file in VSCode, trigger "Format Document" — verify it formats correctly
- [ ] Enable `editor.formatOnSave` in VSCode settings — verify it formats on save
- [ ] Open an already-formatted file — verify no edits are applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)