### PR TITLE
[#378][#379] Add Node.js/pnpm setup to CI for example type resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,19 @@ jobs:
       - name: Build release for LSP tests
         run: cargo build
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install example dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Floe check examples
         run: |
           ./target/debug/floe check examples/todo-app/src/


### PR DESCRIPTION
closes #378
closes #379

## Summary
- The checker is **not broken** — it correctly resolves npm import types via tsgo/.d.ts files
- CI was missing `node_modules`, so tsgo had nothing to resolve, making all npm imports `unknown`
- Adds Node.js 22 + pnpm 10 setup and `pnpm install --frozen-lockfile` before `floe check` in CI

## Root cause
`floe check` uses tsgo (or `npx @typescript/native-preview`) to resolve types from npm packages. Without `node_modules` installed, tsgo produces empty output and all trusted imports fall back to `Type::Unknown`, cascading through pipes and member access.

## Test plan
- [ ] CI passes with the new Node.js/pnpm steps
- [ ] `floe check examples/todo-app/src/` passes (0 errors)
- [ ] `floe check examples/store/src/` passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)