### PR TITLE
[#272] Allow variant constructors as functions (cleaner mapErr)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -78,6 +78,7 @@ All four of TypeScript's `?` uses (`?.`, `??`, `?:`, `? :`) are removed. `?` now
 | Dot shorthand | `.name` in callback position | `(x) => x.name` |
 | Dot shorthand (predicate) | `.id != id` in callback position | `(x) => x.id != id` |
 | Qualified variant | `Type.Variant` for disambiguation | `{ tag: "Variant" }` (same as bare) |
+| Variant as function | `Validation` (bare, non-unit) | `(errors) => ({ tag: "Validation", errors })` |
 | Default values | `fn f(x: number = 10)` | caller can omit, compiler fills in |
 | Structural equality | `==` on objects compares by value | deep equality check |
 | Unit type | `()` as return type, usable in generics | `undefined` / `void` in TS |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -141,6 +141,13 @@ const err = ApiError.Network(NetworkError.Timeout(ms: 3000))
 // const c = Red        // Error: ambiguous
 const c = Color.Red     // OK — qualified
 // Bare variants work when unambiguous or in match arms
+
+// Non-unit variants as functions (constructor-as-function):
+// A non-unit variant name used without args becomes an arrow function
+const toValidation = Validation  // (errors) => ({ tag: "Validation", errors })
+const toApi = SaveError.Api      // (message) => ({ tag: "Api", message })
+// Useful with mapErr:
+result |> Result.mapErr(Validation)  // instead of Result.mapErr(fn(e) Validation(e))
 ```
 
 ## Pipe Operator

--- a/docs/site/src/content/docs/guide/error-handling.md
+++ b/docs/site/src/content/docs/guide/error-handling.md
@@ -74,6 +74,25 @@ The return type of a `collect` block is always `Result<T, Array<E>>`.
 
 This is useful for form validation, batch processing, and anywhere you want to report all errors at once instead of stopping at the first one.
 
+## Mapping Error Types
+
+When composing functions with different error types, use `Result.mapErr` to convert errors into a domain type. Variant constructors can be passed directly as functions:
+
+```floe
+type AppError {
+    | Validation { errors: Array<string> }
+    | Api { message: string }
+}
+
+fn saveTodo(text: string, id: string) -> Result<Todo, AppError> {
+    const todo = validateTodo(text, id) |> Result.mapErr(Validation)?
+    const saved = apiSave(todo) |> Result.mapErr(Api)?
+    Ok(saved)
+}
+```
+
+`Validation` here is used as a function — equivalent to `fn(e) Validation(errors: e)`. This works for any non-unit variant.
+
 ## Option
 
 ```floe

--- a/docs/site/src/content/docs/guide/types.md
+++ b/docs/site/src/content/docs/guide/types.md
@@ -112,6 +112,30 @@ match filter {
 }
 ```
 
+## Variant Constructors as Functions
+
+Non-unit variants (variants with fields) can be used as function values by referencing them without arguments:
+
+```floe
+type SaveError {
+    | Validation { errors: Array<string> }
+    | Api { message: string }
+}
+
+// Bare variant name becomes an arrow function
+const toValidation = Validation
+// Equivalent to: fn(errors) Validation(errors: errors)
+
+// Qualified syntax works too
+const toApi = SaveError.Api
+
+// Most useful with higher-order functions like mapErr:
+result |> Result.mapErr(Validation)
+// Instead of: result |> Result.mapErr(fn(e) Validation(e))
+```
+
+Unit variants (no fields) are values, not functions — `All` produces `{ tag: "All" }` directly.
+
 ## String Literal Unions
 
 For npm interop with TypeScript libraries that use string literal unions:

--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -49,6 +49,16 @@ impl Checker {
                     );
                 }
                 if let Some(ty) = self.env.lookup(name).cloned() {
+                    // Non-unit variant as bare identifier → constructor function
+                    if let Type::Union { ref variants, .. } = ty
+                        && let Some((_, field_types)) = variants.iter().find(|(v, _)| v == name)
+                        && !field_types.is_empty()
+                    {
+                        return Type::Function {
+                            params: field_types.clone(),
+                            return_type: Box::new(ty),
+                        };
+                    }
                     ty
                 } else if self.stdlib.is_module(name) {
                     // Stdlib module names (Array, String, etc.) are valid identifiers
@@ -475,6 +485,21 @@ impl Checker {
                                 .with_code("E002"),
                         );
                     }
+                }
+
+                // Zero-arg reference to non-unit variant → constructor function
+                // Must check early, before field validation would flag missing fields
+                if args.is_empty()
+                    && spread.is_none()
+                    && let Some(ty) = self.env.lookup(type_name).cloned()
+                    && let Type::Union { variants, .. } = &ty
+                    && let Some((_, field_types)) = variants.iter().find(|(v, _)| v == type_name)
+                    && !field_types.is_empty()
+                {
+                    return Type::Function {
+                        params: field_types.clone(),
+                        return_type: Box::new(ty),
+                    };
                 }
 
                 // Rule 3: Opaque enforcement

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -2997,3 +2997,59 @@ const _result = "hello" |> add(3, _)
         "expected `number`, found `string`"
     ));
 }
+
+// ── Variant constructors as functions ───────────────────────
+
+#[test]
+fn variant_constructor_as_function_no_error() {
+    let diags = check(
+        r#"
+type SaveError {
+    | Validation { errors: Array<string> }
+    | Api { message: string }
+}
+
+fn apply(f: fn(Array<string>) -> SaveError) -> SaveError {
+    f(["error"])
+}
+
+const _result = apply(Validation)
+"#,
+    );
+    assert!(diags.is_empty(), "expected no errors, got: {diags:?}");
+}
+
+#[test]
+fn unit_variant_not_treated_as_function() {
+    let diags = check(
+        r#"
+type Filter {
+    | All
+    | Active
+    | Completed
+}
+
+const _f: Filter = All
+"#,
+    );
+    assert!(diags.is_empty(), "expected no errors, got: {diags:?}");
+}
+
+#[test]
+fn variant_constructor_type_mismatch() {
+    let diags = check(
+        r#"
+type MyError {
+    | Validation { errors: Array<string> }
+    | Api { message: string }
+}
+
+fn apply(f: fn(number) -> MyError) -> MyError {
+    f(42)
+}
+
+const _result = apply(Validation)
+"#,
+    );
+    assert!(has_error(&diags, "E001"));
+}

--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -33,6 +33,15 @@ impl Codegen {
                     self.push(&format!("{{ {TAG_FIELD}: \""));
                     self.push(name);
                     self.push("\" }");
+                } else if let Some(field_names) = self
+                    .variant_info
+                    .get(name.as_str())
+                    .filter(|(_, f)| !f.is_empty())
+                    .map(|(_, f)| f.clone())
+                {
+                    // Non-unit variant as function value:
+                    // `Validation` → `(value) => ({ tag: "Validation", value })`
+                    self.emit_variant_constructor_fn(name, &field_names);
                 } else {
                     self.push(name);
                 }
@@ -108,6 +117,20 @@ impl Codegen {
                 spread,
                 args,
             } => {
+                // Qualified non-unit variant with no args → function value
+                // `SaveError.Validation` → `(value) => ({ tag: "Validation", value })`
+                if args.is_empty()
+                    && spread.is_none()
+                    && let Some(field_names) = self
+                        .variant_info
+                        .get(type_name.as_str())
+                        .filter(|(_, f)| !f.is_empty())
+                        .map(|(_, f)| f.clone())
+                {
+                    self.emit_variant_constructor_fn(type_name, &field_names);
+                    return;
+                }
+
                 let variant_field_names = self
                     .variant_info
                     .get(type_name.as_str())
@@ -657,6 +680,26 @@ impl Codegen {
     }
 
     // ── Constructor → Object Literal ─────────────────────────────
+
+    /// Emit a variant constructor as an arrow function.
+    /// `Validation` → `(value) => ({ tag: "Validation", value })`
+    fn emit_variant_constructor_fn(&mut self, variant_name: &str, field_names: &[String]) {
+        self.push("(");
+        for (i, fname) in field_names.iter().enumerate() {
+            if i > 0 {
+                self.push(", ");
+            }
+            self.push(fname);
+        }
+        self.push(&format!(") => ({{ {TAG_FIELD}: \""));
+        self.push(variant_name);
+        self.push("\"");
+        for fname in field_names {
+            self.push(", ");
+            self.push(fname);
+        }
+        self.push(" })");
+    }
 
     /// Emit construct fields, mapping positional args to field names from the type definition.
     fn emit_construct_fields(&mut self, args: &[Arg], field_names: &[String]) {

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -815,6 +815,95 @@ fn union_variant_dot_access_non_union_passthrough() {
     assert!(result.contains("foo.bar"));
 }
 
+// ── Variant constructors as functions ──────────────────────
+
+#[test]
+fn non_unit_variant_as_function() {
+    let result = emit(
+        r#"
+type SaveError {
+    | Validation { errors: Array<string> }
+    | Api { message: string }
+}
+
+const _f = Validation
+"#,
+    );
+    assert!(
+        result.contains(r#"(errors) => ({ tag: "Validation", errors })"#),
+        "got: {result}"
+    );
+}
+
+#[test]
+fn unit_variant_unchanged_as_value() {
+    let result = emit(
+        r#"
+type Filter { | All | Active | Completed }
+const _f = All
+"#,
+    );
+    assert!(result.contains(r#"{ tag: "All" }"#), "got: {result}");
+    assert!(
+        !result.contains("=>"),
+        "should not emit arrow function, got: {result}"
+    );
+}
+
+#[test]
+fn qualified_non_unit_variant_as_function() {
+    let result = emit(
+        r#"
+type SaveError {
+    | Validation { errors: Array<string> }
+    | Api { message: string }
+}
+
+const _f = SaveError.Validation
+"#,
+    );
+    assert!(
+        result.contains(r#"(errors) => ({ tag: "Validation", errors })"#),
+        "got: {result}"
+    );
+}
+
+#[test]
+fn variant_construct_with_args_unchanged() {
+    let result = emit(
+        r#"
+type MyError {
+    | Validation { message: string }
+    | NotFound
+}
+
+const _e = Validation(message: "bad")
+"#,
+    );
+    assert!(
+        result.contains(r#"{ tag: "Validation", message: "bad" }"#),
+        "got: {result}"
+    );
+}
+
+#[test]
+fn multi_field_variant_as_function() {
+    let result = emit(
+        r#"
+type Shape {
+    | Circle { radius: number }
+    | Rect { width: number, height: number }
+}
+
+const _f = Rect
+"#,
+    );
+    assert!(
+        result.contains(r#"(width, height) => ({ tag: "Rect", width, height })"#),
+        "got: {result}"
+    );
+}
+
 // ── Tuples ─────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
closes #272

## Summary

- Non-unit variant constructors can now be used as function values by referencing them without arguments
- `result |> Result.mapErr(Validation)` instead of `result |> Result.mapErr(fn(e) Validation(e))`
- Works for both bare identifiers (`Validation`) and qualified syntax (`SaveError.Validation`)
- Unit variants are unchanged - they remain values, not functions

## How it works

**Checker:** When a non-unit variant name appears as a bare identifier or a zero-arg qualified construct, the checker returns `Type::Function { params: field_types, return_type: union_type }` instead of the raw union type.

**Codegen:** Emits an arrow function for non-unit variant references:
```
Validation → (errors) => ({ tag: "Validation", errors })
Rect → (width, height) => ({ tag: "Rect", width, height })
```

## Test plan

- [x] Checker: non-unit variant as bare identifier produces no type error
- [x] Checker: variant passed to function expecting callback is compatible
- [x] Checker: type mismatch when variant fields don't match expected params
- [x] Checker: unit variants unchanged (still work as values)
- [x] Codegen: non-unit variant emits arrow function
- [x] Codegen: unit variant unchanged (`{ tag: "All" }`)
- [x] Codegen: qualified non-unit variant emits arrow function
- [x] Codegen: construct with args unchanged
- [x] Codegen: multi-field variant emits correct arrow
- [x] All 906 existing tests pass (0 regressions)
- [x] `floe check` passes on example app files (non-npm imports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)