### PR TITLE
[#370] Enforce naming conventions for types and variants

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -310,7 +310,8 @@ impl Checker {
         self.registering_types = true;
         for resolved in self.resolved_imports.values().cloned().collect::<Vec<_>>() {
             for decl in &resolved.type_decls {
-                self.register_type_decl(decl);
+                // Skip naming checks for imported types (already validated in source)
+                self.register_type_decl(decl, Span::new(0, 0, 0, 0));
             }
             for decl in &resolved.trait_decls {
                 self.register_trait_decl(decl);
@@ -363,7 +364,7 @@ impl Checker {
         for item in &program.items {
             match &item.kind {
                 ItemKind::TypeDecl(decl) => {
-                    self.register_type_decl(decl);
+                    self.register_type_decl(decl, item.span);
                 }
                 ItemKind::TraitDecl(decl) => {
                     self.register_trait_decl(decl);
@@ -482,7 +483,57 @@ impl Checker {
 
     // ── Type Registration ────────────────────────────────────────
 
-    fn register_type_decl(&mut self, decl: &TypeDecl) {
+    fn register_type_decl(&mut self, decl: &TypeDecl, span: Span) {
+        // Enforce naming conventions
+        if span.start != 0 || span.end != 0 {
+            // Only check local declarations (not imports with dummy spans)
+            if decl.name.starts_with(char::is_lowercase) {
+                self.diagnostics.push(
+                    Diagnostic::error(
+                        format!(
+                            "type name `{}` must start with an uppercase letter",
+                            decl.name
+                        ),
+                        span,
+                    )
+                    .with_label("must be uppercase")
+                    .with_help(format!(
+                        "rename to `{}{}`",
+                        decl.name[..1].to_uppercase(),
+                        &decl.name[1..]
+                    ))
+                    .with_code("E024"),
+                );
+            }
+            match &decl.def {
+                TypeDef::Union(variants) => {
+                    for variant in variants {
+                        if variant.name.starts_with(char::is_lowercase) {
+                            self.diagnostics.push(
+                                Diagnostic::error(
+                                    format!(
+                                        "variant name `{}` must start with an uppercase letter",
+                                        variant.name
+                                    ),
+                                    variant.span,
+                                )
+                                .with_help(format!(
+                                    "rename to `{}{}`",
+                                    variant.name[..1].to_uppercase(),
+                                    &variant.name[1..]
+                                ))
+                                .with_code("E024"),
+                            );
+                        }
+                    }
+                }
+                // Record field names: uppercase fields are already rejected by the parser
+                // (uppercase identifiers are parsed as types/variants, not field names)
+                TypeDef::Record(_) => {}
+                _ => {}
+            }
+        }
+
         // Flatten record spreads into a flat record definition
         let flattened_def = self.flatten_record_spreads(&decl.def, &decl.name);
 

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -3036,3 +3036,40 @@ const _result = apply(Validation)
     );
     assert!(has_error(&diags, "E001"));
 }
+
+// ── Naming convention enforcement ───────────────────────────
+
+#[test]
+fn lowercase_type_name_error() {
+    let diags = check("type color { | Red | Green }");
+    assert!(has_error(&diags, "E024"));
+    assert!(has_error_containing(
+        &diags,
+        "type name `color` must start with an uppercase letter"
+    ));
+}
+
+#[test]
+fn uppercase_type_name_ok() {
+    let diags = check("type Color { | Red | Green }");
+    assert!(!has_error(&diags, "E024"));
+}
+
+#[test]
+fn lowercase_variant_name_error() {
+    let diags = check("type Color { | red | Green }");
+    assert!(has_error(&diags, "E024"));
+    assert!(has_error_containing(
+        &diags,
+        "variant name `red` must start with an uppercase letter"
+    ));
+}
+
+#[test]
+fn uppercase_variant_name_ok() {
+    let diags = check("type Color { | Red | Green }");
+    assert!(!has_error(&diags, "E024"));
+}
+
+// Note: uppercase field names are already rejected by the parser
+// (uppercase identifiers are parsed as types/variants, not field names)


### PR DESCRIPTION
closes #370

## Summary

- Type names must start with uppercase: `type color` → error with suggestion to rename to `Color`
- Variant names must start with uppercase: `| red` → error with suggestion to rename to `Red`
- Record field names: already enforced by the parser (uppercase identifiers are parsed as types/variants)
- New error code E024
- Imported types skip the check (already validated in their source file)

## Test plan

- [x] `type color { ... }` → E024 error
- [x] `type Color { | red }` → E024 error
- [x] `type Color { | Red }` → no error
- [x] All 933 existing tests pass (0 regressions)
- [x] Example apps pass (non-npm files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)