### PR TITLE
fix: [#384] Preserve user blank lines between statements in blocks

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -197,6 +197,27 @@ impl<'src> Formatter<'src> {
         }
     }
 
+    /// Check if a node has trailing whitespace containing a blank line (2+ newlines).
+    pub(crate) fn has_trailing_blank_line(&self, node: &SyntaxNode) -> bool {
+        let all_tokens: Vec<_> = node
+            .descendants_with_tokens()
+            .filter_map(|t| t.into_token())
+            .collect();
+
+        for tok in all_tokens.into_iter().rev() {
+            match tok.kind() {
+                SyntaxKind::WHITESPACE => {
+                    if tok.text().chars().filter(|&c| c == '\n').count() >= 2 {
+                        return true;
+                    }
+                }
+                k if k.is_trivia() => continue,
+                _ => break,
+            }
+        }
+        false
+    }
+
     fn fmt_verbatim(&mut self, node: &SyntaxNode) {
         let range = node.text_range();
         let start: usize = range.start().into();

--- a/src/formatter/expr.rs
+++ b/src/formatter/expr.rs
@@ -11,22 +11,47 @@ enum NamedArgValue {
 impl Formatter<'_> {
     pub(crate) fn fmt_block(&mut self, node: &SyntaxNode) {
         self.write("{");
-        let children: Vec<_> = node
-            .children()
-            .filter(|c| c.kind() == SyntaxKind::ITEM || c.kind() == SyntaxKind::EXPR_ITEM)
-            .collect();
 
-        if children.is_empty() {
+        // Collect items with whether a blank line preceded them in the source.
+        // Blank lines can appear either as whitespace tokens between items at the
+        // block level, or as trailing trivia inside the previous item.
+        let mut items: Vec<(SyntaxNode, bool)> = Vec::new();
+        let mut saw_blank = false;
+
+        for child_or_tok in node.children_with_tokens() {
+            match child_or_tok {
+                rowan::NodeOrToken::Token(tok) => {
+                    if tok.kind() == SyntaxKind::WHITESPACE
+                        && tok.text().chars().filter(|&c| c == '\n').count() >= 2
+                    {
+                        saw_blank = true;
+                    }
+                }
+                rowan::NodeOrToken::Node(child)
+                    if child.kind() == SyntaxKind::ITEM
+                        || child.kind() == SyntaxKind::EXPR_ITEM =>
+                {
+                    let trailing_blank = self.has_trailing_blank_line(&child);
+                    items.push((child, saw_blank));
+                    saw_blank = trailing_blank;
+                }
+                _ => {}
+            }
+        }
+
+        if items.is_empty() {
             self.write("}");
             return;
         }
 
-        let child_count = children.len();
+        let item_count = items.len();
         self.indent += 1;
-        for (i, child) in children.iter().enumerate() {
-            // Insert a blank line before the final expression in multi-statement blocks
-            if child_count >= 2 && i == child_count - 1 {
-                self.newline();
+        for (i, (child, had_blank)) in items.iter().enumerate() {
+            if i > 0 {
+                let is_final_expr = item_count >= 2 && i == item_count - 1;
+                if *had_blank || is_final_expr {
+                    self.newline();
+                }
             }
             self.newline();
             self.write_indent();

--- a/src/formatter/tests.rs
+++ b/src/formatter/tests.rs
@@ -400,3 +400,27 @@ fn format_long_call_args_go_multiline() {
 fn format_short_call_args_stay_inline() {
     assert_fmt("f(a, b, c)", "f(a, b, c)");
 }
+
+// ── Blank line preservation ────────────────────────────
+
+#[test]
+fn format_preserves_blank_lines_between_statements() {
+    assert_fmt(
+        "fn f() {\n    const a = 1\n\n    const b = 2\n\n    a + b\n}",
+        "fn f() {\n    const a = 1\n\n    const b = 2\n\n    a + b\n}",
+    );
+}
+
+#[test]
+fn format_no_blank_line_when_source_has_none() {
+    assert_fmt(
+        "fn f() {\n    const a = 1\n    const b = 2\n\n    a + b\n}",
+        "fn f() {\n    const a = 1\n    const b = 2\n\n    a + b\n}",
+    );
+}
+
+#[test]
+fn format_preserves_blank_line_after_match_block() {
+    let src = "fn f() {\n    const url = x |> match {\n        1 -> \"a\",\n    }\n\n    const data = y\n\n    Ok(data)\n}";
+    assert_fmt(src, src);
+}


### PR DESCRIPTION
closes #384

## Summary

- The formatter was eating blank lines between statements in function bodies (e.g., blank line between a match block's `}` and the next `const`)
- Now preserves user-placed blank lines by checking whitespace tokens at both the block level and inside item trailing trivia
- Still always inserts a blank line before the final expression in multi-statement blocks

## Test plan

- [ ] `cargo fmt && cargo clippy -- -D warnings && RUSTFLAGS="-D warnings" cargo test` passes
- [ ] 54 formatter tests pass (3 new for blank line preservation)
- [ ] All 14 example `.fl` files pass idempotency check

🤖 Generated with [Claude Code](https://claude.com/claude-code)