### PR TITLE
[#398] feat: docs and syntax highlighting for generic functions

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -41,7 +41,7 @@ All four of TypeScript's `?` uses (`?.`, `??`, `?:`, `? :`) are removed. `?` now
 - Closures `(x) => expr` for inline/anonymous functions
 - Dot shorthand `.field` for implicit field-access closures
 - JSX / TSX (full support)
-- Generics, template literals
+- Generics (types and functions), template literals
 - `async`/`await`
 - Destructuring, spread, rest params
 - `||` (boolean OR), `&&`, `!` (boolean operators)
@@ -79,6 +79,7 @@ All four of TypeScript's `?` uses (`?.`, `??`, `?:`, `? :`) are removed. `?` now
 | Dot shorthand (predicate) | `.id != id` in callback position | `(x) => x.id != id` |
 | Qualified variant | `Type.Variant` for disambiguation | `{ tag: "Variant" }` (same as bare) |
 | Variant as function | `Validation` (bare, non-unit) | `(errors) => ({ tag: "Validation", errors })` |
+| Generic functions | `fn identity<T>(x: T) -> T { x }` | `function identity<T>(x: T): T { return x; }` |
 | Default values | `fn f(x: number = 10)` | caller can omit, compiler fills in |
 | Structural equality | `==` on objects compares by value | deep equality check |
 | Unit type | `()` as return type, usable in generics | `undefined` / `void` in TS |
@@ -1232,8 +1233,19 @@ enum Expr {
 }
 
 // Top-level items include ForBlock, TraitDecl, and TestBlock
+// FunctionDecl includes optional type parameters for generic functions
+// fn identity<T>(x: T) -> T { x } → type_params: vec!["T"]
+// fn pair<A, B>(a: A, b: B) -> (A, B) { (a, b) } → type_params: vec!["A", "B"]
+struct FunctionDecl {
+    name: String,
+    type_params: Vec<String>,  // <T, U> — empty for non-generic functions
+    params: Vec<Param>,
+    return_type: Option<TypeExpr>,
+    body: Vec<Item>,
+}
+
 enum ItemKind {
-    Import, Const, Function, TypeDecl,
+    Import, Const, Function(FunctionDecl), TypeDecl,
     ForBlock {                 // for Type { fn f(self) ... }
         type_name: TypeExpr,
         trait_name: Option<String>,  // for Type: Trait { ... }
@@ -1400,6 +1412,7 @@ Emits clean, readable `.tsx`. Zero runtime imports.
 | `.id != id` (in callback) | `(x) => x.id != id` |
 | `Type.Variant` (qualified) | `{ tag: "Variant" }` (same as bare) |
 | `fn f(x: T) -> U { ... }` | `function f(x: T): U { ... }` |
+| `fn f<T>(x: T) -> T { ... }` | `function f<T>(x: T): T { ... }` |
 | `try expr` | `(() => { try { return { ok: true, value: expr }; } catch (_e) { return { ok: false, error: _e instanceof Error ? _e : new Error(String(_e)) }; } })()` |
 | `match x { A -> ..., B -> ... }` | `x.tag === "A" ? ... : x.tag === "B" ? ... : absurd(x)` |
 | `match x { A(v) when v > 0 -> ... }` | `x.tag === "A" ? (() => { const v = x.value; if (v > 0) { return ...; } ... })()` |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -10,6 +10,10 @@ fn add(a: number, b: number) -> number {
     a + b
 }
 
+// Generic functions — type parameters after the function name
+fn identity<T>(x: T) -> T { x }
+fn pair<A, B>(a: A, b: B) -> (A, B) { (a, b) }
+
 // Exported function
 export fn greet(name: string) -> string {
     `Hello, ${name}!`
@@ -562,6 +566,7 @@ match key {
 | Floe | TypeScript Output |
 |------|-------------------|
 | `fn f(x: number) -> number { x }` | `function f(x: number): number { return x; }` |
+| `fn f<T>(x: T) -> T { x }` | `function f<T>(x: T): T { return x; }` |
 | `a \|> f(b)` | `f(a, b)` |
 | `a \|> f(b, _, c)` | `f(b, a, c)` |
 | `a \|> match { 1 -> "one", _ -> "other" }` | `match a { ... }` (desugared) |

--- a/docs/site/src/content/docs/guide/functions.md
+++ b/docs/site/src/content/docs/guide/functions.md
@@ -56,6 +56,30 @@ export fn greet(name: string) -> string {
 }
 ```
 
+### Generic Functions
+
+Functions can declare type parameters using angle brackets after the function name:
+
+```floe
+fn identity<T>(x: T) -> T { x }
+
+fn pair<A, B>(a: A, b: B) -> (A, B) { (a, b) }
+
+fn mapResult<T, U, E>(r: Result<T, E>, f: (T) => U) -> Result<U, E> {
+    match r {
+        Ok(value) -> Ok(f(value)),
+        Err(e) -> Err(e),
+    }
+}
+```
+
+Generic functions compile directly to TypeScript generics:
+
+```typescript
+function identity<T>(x: T): T { return x; }
+function pair<A, B>(a: A, b: B): readonly [A, B] { return [a, b] as const; }
+```
+
 ### Default Parameters
 
 ```floe

--- a/docs/site/src/content/docs/guide/tour.md
+++ b/docs/site/src/content/docs/guide/tour.md
@@ -22,6 +22,10 @@ fn double(n: number) -> number {
     n * 2
 }
 
+// Generic functions
+fn identity<T>(x: T) -> T { x }
+fn pair<A, B>(a: A, b: B) -> (A, B) { (a, b) }
+
 // Closures use arrow syntax
 const add = (a, b) => a + b
 const log = () => Console.log("clicked")

--- a/docs/site/src/content/docs/reference/syntax.md
+++ b/docs/site/src/content/docs/reference/syntax.md
@@ -31,6 +31,15 @@ fn name(param: Type) -> ReturnType {
   body
 }
 
+// Generic function — type parameters after the name
+fn name<T>(param: T) -> T {
+  body
+}
+
+fn name<A, B>(a: A, b: B) -> (A, B) {
+  body
+}
+
 export fn name(param: Type) -> ReturnType {
   body
 }

--- a/editors/neovim/queries/floe/highlights.scm
+++ b/editors/neovim/queries/floe/highlights.scm
@@ -56,6 +56,11 @@
 (function_declaration
   name: (type_identifier) @function)
 
+; Generic function type parameters: fn identity<T>(...)
+(function_declaration
+  type_parameters: (type_parameters
+    (type_identifier) @type.parameter))
+
 (call_expression
   function: (primary_expression
     (identifier) @function.call))

--- a/editors/tree-sitter-floe/grammar.js
+++ b/editors/tree-sitter-floe/grammar.js
@@ -109,6 +109,7 @@ module.exports = grammar({
       seq(
         "fn",
         field("name", $.identifier),
+        optional(field("type_parameters", $.type_parameters)),
         field("parameters", $.parameter_list),
         optional(seq("->", field("return_type", $._type_expression))),
         optional(field("body", $.block)),
@@ -142,6 +143,7 @@ module.exports = grammar({
         optional("async"),
         "fn",
         field("name", choice($.identifier, $.type_identifier)),
+        optional(field("type_parameters", $.type_parameters)),
         field("parameters", $.parameter_list),
         optional(seq("->", field("return_type", $._type_expression))),
         field("body", $.block),

--- a/editors/tree-sitter-floe/queries/highlights.scm
+++ b/editors/tree-sitter-floe/queries/highlights.scm
@@ -56,6 +56,11 @@
 (function_declaration
   name: (type_identifier) @function)
 
+; Generic function type parameters: fn identity<T>(...)
+(function_declaration
+  type_parameters: (type_parameters
+    (type_identifier) @type.parameter))
+
 (call_expression
   function: (primary_expression
     (identifier) @function.call))

--- a/editors/tree-sitter-floe/test/corpus/declarations.txt
+++ b/editors/tree-sitter-floe/test/corpus/declarations.txt
@@ -116,6 +116,60 @@ async fn fetchData() -> string {
             (string_content)))))))
 
 ===
+Generic function declaration
+===
+
+fn identity<T>(x: T) -> T {
+    x
+}
+
+---
+
+(source_file
+  (function_declaration
+    name: (identifier)
+    type_parameters: (type_parameters
+      (type_identifier))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (type_identifier)))
+    return_type: (type_identifier)
+    body: (block
+      (expression_statement
+        (primary_expression
+          (identifier))))))
+
+===
+Generic function with multiple type parameters
+===
+
+fn pair<A, B>(a: A, b: B) -> A {
+    a
+}
+
+---
+
+(source_file
+  (function_declaration
+    name: (identifier)
+    type_parameters: (type_parameters
+      (type_identifier)
+      (type_identifier))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (type_identifier))
+      (parameter
+        name: (identifier)
+        type: (type_identifier)))
+    return_type: (type_identifier)
+    body: (block
+      (expression_statement
+        (primary_expression
+          (identifier))))))
+
+===
 Const declaration
 ===
 

--- a/editors/vscode/syntaxes/floe.tmLanguage.json
+++ b/editors/vscode/syntaxes/floe.tmLanguage.json
@@ -211,11 +211,12 @@
     "functions": {
       "patterns": [
         {
-          "comment": "fn declarations",
-          "match": "\\b(fn)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+          "comment": "fn declarations (with optional generic type parameters)",
+          "match": "\\b(fn)\\s+([a-zA-Z_][a-zA-Z0-9_]*)(?:<([A-Z][a-zA-Z0-9]*(?:\\s*,\\s*[A-Z][a-zA-Z0-9]*)*)>)?",
           "captures": {
             "1": { "name": "storage.type.function.floe" },
-            "2": { "name": "entity.name.function.floe" }
+            "2": { "name": "entity.name.function.floe" },
+            "3": { "name": "entity.name.type.parameter.floe" }
           }
         },
         {


### PR DESCRIPTION
closes #398

## Summary
- Updated design.md (AST, codegen table), llms.txt, site docs (functions guide, tour, syntax reference)
- Tree-sitter grammar: type_parameters rule for fn declarations
- TextMate grammar: updated function pattern for `<T, U>`
- Neovim highlights: type parameter highlighting
- Tree-sitter test corpus for generic function declarations

## Test plan
- [x] `cargo fmt` + `cargo clippy` - clean
- [x] `RUSTFLAGS="-D warnings" cargo test` - 929 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)