### PR TITLE
chore: switch to squash merges to fix duplicate changelog entries

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -127,25 +127,26 @@ If either is wrong, stop and fix it before proceeding.
 glb update <num> --claim
 ```
 
-Commit semi-frequently - don't save everything for one giant commit. Use **conventional commits** (`feat:`, `fix:`, `chore:`, `docs:`, `ci:`, `refactor:`, `test:`). Append `!` for breaking changes (e.g. `feat!:`). These prefixes drive automatic version bumps and changelog generation via release-please.
+Commit semi-frequently - don't save everything for one giant commit. Individual commit messages inside PRs don't need conventional commit prefixes - use whatever messages are descriptive.
 
 **Before every commit**, run `cargo fmt` (and `floe fmt` if you touched `.fl` files). Never commit unformatted code.
 
-**Use conventional commits.** All commit messages must be prefixed:
+**PR titles use conventional commit prefixes.** The repo uses squash merges, so the PR title becomes the single commit on main. Only the PR title matters for versioning and changelog generation.
+
+Prefixes:
 - `feat:` — new feature or language syntax
 - `fix:` — bug fix
 - `chore:` — maintenance, deps, CI, docs, refactoring
 - `test:` — adding or updating tests only
 
+Append `!` for breaking changes (e.g. `feat!:`).
+
 Examples:
 ```
-feat: add use keyword for callback flattening
-fix: checker resolves pipe expressions to unknown type
-chore: remove Brand type in favor of newtypes
-test: add codegen snapshot tests for tuples
+feat: [#260] Add use keyword for callback flattening
+fix: [#384] Checker resolves pipe expressions to unknown type
+chore: [#257] Remove Brand type in favor of newtypes
 ```
-
-PR titles follow the same convention: `feat: [#260] Add use keyword`
 
 ### 4. Quality Gate
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,18 +26,20 @@ This project uses **conventional commits** + **release-please** for automated ve
 
 ### How it works
 
-1. **You write commits with prefixes:**
+1. **PR titles use conventional commit prefixes:**
 
    | Prefix | Version bump | Example |
    |---|---|---|
-   | `fix:` | patch (0.1.0 -> 0.1.1) | `fix: crash on nested match` |
-   | `feat:` | minor (0.1.0 -> 0.2.0) | `feat: add pipe lambdas` |
-   | `feat!:` | major (0.1.0 -> 1.0.0) | `feat!: remove arrow functions` |
+   | `fix:` | patch (0.1.0 -> 0.1.1) | `fix: [#123] crash on nested match` |
+   | `feat:` | minor (0.1.0 -> 0.2.0) | `feat: [#456] add pipe lambdas` |
+   | `feat!:` | major (0.1.0 -> 1.0.0) | `feat!: [#789] remove arrow functions` |
    | `chore:`, `docs:`, `ci:`, `refactor:`, `test:` | no bump | `docs: update README` |
 
+   The repo uses **squash merges only**. Each PR becomes a single commit on main, and the PR title becomes the commit message. This means only the PR title matters for versioning - individual commits inside PRs can use any message format.
+
 2. **release-please watches main** and auto-opens a "Release PR" that:
-   - Bumps the version in `Cargo.toml` based on commit prefixes
-   - Updates `CHANGELOG.md` with entries generated from commit messages
+   - Bumps the version in `Cargo.toml` based on squash commit messages (PR titles)
+   - Updates `CHANGELOG.md` with entries generated from PR titles
    - Title looks like `chore(main): release 0.2.0`
 
 3. **Merging the Release PR** creates a git tag (`v0.2.0`) and a GitHub Release.
@@ -59,7 +61,8 @@ This project uses **conventional commits** + **release-please** for automated ve
 
 ### What you need to do
 
-- Write meaningful conventional commit messages (the CHANGELOG is generated from them)
+- Write meaningful PR titles with conventional commit prefixes (the CHANGELOG is generated from them)
+- Individual commits inside PRs don't need prefixes - only the PR title matters
 - Periodically merge the Release PR that release-please opens
 - That's it - everything else is automated
 


### PR DESCRIPTION
## Summary
- Set repo to squash-merge only (disabled merge commits and rebase) via GitHub API
- Updated CLAUDE.md and workflow rules to reflect that only PR titles need conventional commit prefixes
- Fixes duplicate entries in release-please changelogs caused by release-please seeing both merge commits and individual commits inside PRs

## Test plan
- [x] Repo settings updated (squash only, PR title as commit message)
- [ ] Verify next release PR has no duplicate entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)