### PR TITLE
chore: gitignore Claude Code local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 node_modules/
 dist/
 *.so
+
+# Claude Code local settings (project rules in .claude/rules/ are intentionally tracked)
+.claude/settings.json
+.claude/settings.local.json


### PR DESCRIPTION
Adds `.claude/settings.json` and `.claude/settings.local.json` to `.gitignore` so local Claude Code configuration doesn't get committed accidentally.

Project rules in `.claude/rules/` remain tracked — those are shared and intentional.