### PR TITLE
fix: correct ignoreDeprecations value to 6.0 for TypeScript 7

### DIFF
--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -8,7 +8,7 @@
     "rootDir": "src",
     "strict": true,
     "moduleResolution": "node10",
-    "ignoreDeprecations": "5.0",
+    "ignoreDeprecations": "6.0",
     "skipLibCheck": true
   },
   "exclude": ["node_modules", "out"]


### PR DESCRIPTION
## Summary
- Fix `ignoreDeprecations` from `"5.0"` to `"6.0"` in VS Code extension tsconfig
- This was causing the Open VSX publish to fail in the release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)