### PR TITLE
chore: add badges, quickstart, and links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://github.com/milkyskies/floe/releases"><img src="https://img.shields.io/github/release/milkyskies/floe" alt="GitHub release"></a>
   <a href="https://crates.io/crates/floe"><img src="https://img.shields.io/crates/v/floe" alt="crates.io"></a>
   <a href="https://www.npmjs.com/package/@floeorg/vite-plugin"><img src="https://img.shields.io/npm/v/@floeorg/vite-plugin" alt="npm"></a>
-  <a href="https://open-vsx.org/extension/floeorg/floe"><img src="https://img.shields.io/open-vsx/v/floeorg/floe" alt="Open VSX"></a>
+  <a href="https://open-vsx.org/extension/milkyskies/floe"><img src="https://img.shields.io/open-vsx/v/milkyskies/floe" alt="Open VSX"></a>
 </p>
 
 <!-- A spacer -->


### PR DESCRIPTION
## Summary
- Added badges for GitHub release, crates.io, npm, and Open VSX
- Added a React code sample showing what Floe looks like
- Added quickstart (install, init, build)
- Added editor support links (VS Code, Neovim)
- Added Vite integration snippet
- Added links to docs, tour, CLI reference, and changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)