### PR TITLE
docs: fix Floe syntax examples and add package links

### DIFF
--- a/docs/site/src/content/docs/guide/tour.md
+++ b/docs/site/src/content/docs/guide/tour.md
@@ -26,9 +26,9 @@ fn double(n: number) -> number {
 fn identity<T>(x: T) -> T { x }
 fn pair<A, B>(a: A, b: B) -> (A, B) { (a, b) }
 
-// Closures use arrow syntax
-const add = (a, b) => a + b
-const log = () => Console.log("clicked")
+// Closures use arrow syntax (always inline, never assigned to const)
+scores |> filter((n: number) => n > 50)
+scores |> map((n: number) => n * 2)
 ```
 
 ## Pipes

--- a/docs/site/src/content/docs/reference/syntax.md
+++ b/docs/site/src/content/docs/reference/syntax.md
@@ -228,8 +228,8 @@ Color.Blue(hex: "#00f") // variant with data
 ### Anonymous Functions (Closures)
 
 ```floe
-(a, b) => a + b
-(x) => x * 2
+(a: number, b: number) => a + b
+(x: number) => x * 2
 () => doSomething()
 ```
 

--- a/docs/site/src/content/docs/tooling/neovim.md
+++ b/docs/site/src/content/docs/tooling/neovim.md
@@ -27,7 +27,7 @@ vim.api.nvim_create_autocmd("FileType", {
 })
 ```
 
-### With nvim-lspconfig
+### With [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig)
 
 ```lua
 local lspconfig = require("lspconfig")

--- a/docs/site/src/content/docs/tooling/vite.md
+++ b/docs/site/src/content/docs/tooling/vite.md
@@ -2,7 +2,7 @@
 title: Vite Plugin
 ---
 
-The `@floeorg/vite-plugin` package lets Vite transform `.fl` files during development and production builds.
+The [`@floeorg/vite-plugin`](https://www.npmjs.com/package/@floeorg/vite-plugin) package lets Vite transform `.fl` files during development and production builds.
 
 ## Installation
 

--- a/docs/site/src/content/docs/tooling/vscode.md
+++ b/docs/site/src/content/docs/tooling/vscode.md
@@ -6,9 +6,9 @@ The Floe VS Code extension provides syntax highlighting, LSP integration, and co
 
 ## Installation
 
-### From Marketplace
+### From Open VSX
 
-Search for "Floe" in the VS Code extensions panel.
+Install from [Open VSX](https://open-vsx.org/extension/milkyskies/floe), or search for "Floe" in the VS Code extensions panel.
 
 ### From Source
 


### PR DESCRIPTION
## Summary
- Fix `tour.md`: removed invalid `const add = (a, b) => ...` (compile error in Floe), replaced with typed inline closure examples
- Fix `syntax.md`: added type annotations to closure parameter examples
- Added npm package link to `vite.md`
- Added Open VSX link to `vscode.md`
- Added nvim-lspconfig repo link to `neovim.md`

These were lost in the squash merge of #441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)