### PR TITLE
fix: trigger release workflow directly from release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,3 +20,9 @@ jobs:
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json
+
+  release:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/release.yml
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Release
 
 on:
-  push:
-    tags: ["v*"]
+  workflow_call:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Changed release workflow trigger from `on: push: tags` to `on: workflow_call`
- Release-please workflow now calls the release workflow directly when `release_created == true`
- Fixes the issue where API-created tags don't trigger `on: push` events, requiring manual tag re-pushes every release

## How it works
Before: release-please creates tag via API -> `on: push: tags` never fires -> manual re-push needed
After: release-please creates release -> calls release workflow directly -> builds and publishes automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)