### PR TITLE
fix: add id-token permission for npm trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release-please:


### PR DESCRIPTION
## Summary
- Added `id-token: write` to release-please workflow permissions
- `workflow_call` inherits permissions from the caller, so the release workflow's npm `--provenance` flag needs this from release-please

🤖 Generated with [Claude Code](https://claude.com/claude-code)