### PR TITLE
fix: VS Code extension publisher and engine version for Open VSX

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -4,14 +4,14 @@
   "description": "Language support for Floe (.fl) - syntax highlighting, diagnostics, and LSP integration",
   "version": "0.1.0",
   "license": "MIT",
-  "publisher": "floeorg",
+  "publisher": "milkyskies",
   "icon": "icons/floe-icon.png",
   "repository": {
     "type": "git",
     "url": "https://github.com/milkyskies/floe"
   },
   "engines": {
-    "vscode": "^1.75.0"
+    "vscode": "^1.110.0"
   },
   "categories": [
     "Programming Languages"


### PR DESCRIPTION
## Summary
- Set publisher to `milkyskies` (was still `floeorg` from squash merge loss)
- Bumped `engines.vscode` from `^1.75.0` to `^1.110.0` to match `@types/vscode`
- Fixes Open VSX publish error: `@types/vscode ^1.110.0 greater than engines.vscode ^1.75.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)