### PR TITLE
fix: support both tag push and workflow_call triggers for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,12 @@
 name: Release
 
 on:
+  push:
+    tags: ["v*"]
   workflow_call:
     inputs:
       tag_name:
-        required: true
+        required: false
         type: string
 
 permissions:
@@ -41,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag_name }}
+          ref: ${{ inputs.tag_name || github.ref_name }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -89,7 +91,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag_name }}
+          ref: ${{ inputs.tag_name || github.ref_name }}
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -100,7 +102,7 @@ jobs:
       - name: Upload assets to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ inputs.tag_name }}
+          tag_name: ${{ inputs.tag_name || github.ref_name }}
           files: artifacts/*
 
   publish-crate:
@@ -110,7 +112,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag_name }}
+          ref: ${{ inputs.tag_name || github.ref_name }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -127,7 +129,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag_name }}
+          ref: ${{ inputs.tag_name || github.ref_name }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -156,7 +158,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag_name }}
+          ref: ${{ inputs.tag_name || github.ref_name }}
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Added `push: tags: ["v*"]` back alongside `workflow_call` trigger
- Uses `inputs.tag_name || github.ref_name` to resolve the tag for both paths
- This means releases work automatically via release-please AND can be manually triggered by re-pushing a tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)