### PR TITLE
chore: [#475] Move default field expansion from codegen to desugar pass

### DIFF
--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -141,8 +141,8 @@ impl Codegen {
                 // If all args are positional (no named args) and it's not a known Floe type,
                 // emit as `new Name(args)`
                 let has_named_args = args.iter().any(|a| matches!(a, Arg::Named { .. }));
-                let known_type_def = self.type_defs.get(type_name).cloned();
-                if !is_variant && !has_named_args && known_type_def.is_none() && spread.is_none() {
+                let is_known_type = self.type_defs.contains_key(type_name.as_str());
+                if !is_variant && !has_named_args && !is_known_type && spread.is_none() {
                     self.push("new ");
                     self.push(type_name);
                     self.push("(");
@@ -179,34 +179,6 @@ impl Codegen {
                     self.emit_construct_fields(args, field_names);
                 } else {
                     self.emit_named_fields(args);
-                    // Fill in default values for omitted record fields.
-                    // Skip when spread is present — the spread already provides all fields.
-                    if spread.is_none()
-                        && let Some(ref type_def) = known_type_def
-                    {
-                        let provided: HashSet<&str> = args
-                            .iter()
-                            .filter_map(|a| match a {
-                                Arg::Named { label, .. } => Some(label.as_str()),
-                                _ => None,
-                            })
-                            .collect();
-                        let has_prior = !args.is_empty();
-                        let mut added = false;
-                        for field in type_def.record_fields() {
-                            if !provided.contains(field.name.as_str())
-                                && let Some(ref default_expr) = field.default
-                            {
-                                if has_prior || added {
-                                    self.push(", ");
-                                }
-                                self.push(&field.name);
-                                self.push(": ");
-                                self.emit_expr(default_expr);
-                                added = true;
-                            }
-                        }
-                    }
                 }
                 self.push(" }");
             }

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -1,8 +1,9 @@
 use super::*;
+use crate::desugar;
 use crate::parser::Parser;
 
 fn emit(input: &str) -> String {
-    let program = Parser::new(input).parse_program().unwrap_or_else(|errs| {
+    let mut program = Parser::new(input).parse_program().unwrap_or_else(|errs| {
         panic!(
             "parse failed:\n{}",
             errs.iter()
@@ -11,6 +12,7 @@ fn emit(input: &str) -> String {
                 .join("\n")
         )
     });
+    desugar::desugar_program(&mut program, &std::collections::HashMap::new());
     let output = Codegen::new().generate(&program);
     output.code.trim().to_string()
 }

--- a/src/desugar.rs
+++ b/src/desugar.rs
@@ -7,13 +7,35 @@
 //! Current transforms:
 //! - `Some(x)` → `x` (identity — Option is `T | undefined`)
 //! - `None`   → `Identifier("undefined")`
+//! - Record constructors with omitted default fields → args filled in
+
+use std::collections::{HashMap, HashSet};
 
 use crate::parser::ast::*;
+use crate::resolve::ResolvedImports;
 use crate::walk;
 
 /// Run the desugar pass over a program, transforming it in place.
-pub fn desugar_program(program: &mut Program) {
-    walk::walk_program_mut(program, &mut desugar_expr);
+pub fn desugar_program(program: &mut Program, resolved: &HashMap<String, ResolvedImports>) {
+    // Collect type definitions for default field expansion
+    let mut type_defs: HashMap<String, TypeDef> = HashMap::new();
+    // Local types
+    for item in &program.items {
+        if let ItemKind::TypeDecl(decl) = &item.kind {
+            type_defs.insert(decl.name.clone(), decl.def.clone());
+        }
+    }
+    // Imported types
+    for imports in resolved.values() {
+        for decl in &imports.type_decls {
+            type_defs.insert(decl.name.clone(), decl.def.clone());
+        }
+    }
+
+    walk::walk_program_mut(program, &mut |expr| {
+        desugar_expr(expr);
+        expand_construct_defaults(expr, &type_defs);
+    });
 }
 
 /// Desugar is post-order: we need children desugared before transforming
@@ -37,4 +59,46 @@ fn desugar_expr(expr: &mut Expr) {
         // annotations needed for TypeScript discriminated union narrowing.
         _ => {}
     }
+}
+
+/// For record constructors with omitted fields that have defaults,
+/// splice the default expressions into the arg list so codegen emits them.
+/// Skipped when a spread is present — the spread provides all fields.
+fn expand_construct_defaults(expr: &mut Expr, type_defs: &HashMap<String, TypeDef>) {
+    let ExprKind::Construct {
+        type_name,
+        spread,
+        args,
+    } = &mut expr.kind
+    else {
+        return;
+    };
+
+    if spread.is_some() {
+        return;
+    }
+
+    let Some(type_def) = type_defs.get(type_name.as_str()) else {
+        return;
+    };
+
+    let provided: HashSet<String> = args
+        .iter()
+        .filter_map(|a| match a {
+            Arg::Named { label, .. } => Some(label.clone()),
+            _ => None,
+        })
+        .collect();
+
+    let defaults: Vec<Arg> = type_def
+        .record_fields()
+        .iter()
+        .filter(|f| !provided.contains(&f.name) && f.default.is_some())
+        .map(|f| Arg::Named {
+            label: f.name.clone(),
+            value: f.default.clone().unwrap(),
+        })
+        .collect();
+
+    args.extend(defaults);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,7 +144,7 @@ fn compile_source(file_path: &Path, filename: &str, source: &str) -> Result<Comp
 
     let mut program = program;
     checker::annotate_types(&mut program, &expr_types);
-    desugar::desugar_program(&mut program);
+    desugar::desugar_program(&mut program, &resolved);
 
     Ok(CompileResult { program, resolved })
 }
@@ -374,7 +374,7 @@ fn cmd_test(path: &Path) -> Result<()> {
         }
 
         checker::annotate_types(program, &expr_types);
-        desugar::desugar_program(program);
+        desugar::desugar_program(program, &resolved);
         let output = Codegen::with_imports(&resolved)
             .with_test_mode()
             .generate(program);


### PR DESCRIPTION
## Summary

- Moves record constructor default field expansion from codegen to the desugar pass, aligning with the compiler architecture (codegen should not carry semantic state)
- Desugar now splices default `Arg::Named` entries directly into `Construct` nodes, so codegen just emits what it sees
- Codegen no longer needs `.cloned()` TypeDef lookups or ad-hoc comma separator logic for defaults
- Skips default expansion when spread is present (spread provides all fields)
- `desugar_program` now takes resolved imports so imported type defaults work too

This was part of #475 but was pushed after the PR was merged.

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `RUSTFLAGS="-D warnings" cargo test` — 966 tests pass
- [x] Example apps pass `floe fmt`, `floe check`, `floe build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)