### PR TITLE
fix: [#486] Widen vite-plugin peer dependency to support Vite 7 and 8

### DIFF
--- a/integrations/vite-plugin-floe/package.json
+++ b/integrations/vite-plugin-floe/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/milkyskies/floe",
   "peerDependencies": {
-    "vite": "^5.0.0 || ^6.0.0"
+    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
closes #486

## Summary
- Widens `peerDependencies.vite` from `^5.0.0 || ^6.0.0` to `^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0`
- The plugin only uses stable Vite plugin APIs (`transform`, `handleHotUpdate`) that are unchanged across all these versions

## Test plan
- [ ] Verify `npm install -D @floeorg/vite-plugin` works in a project with Vite 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)