### PR TITLE
fix: [#491] Support JSX comments {/* ... */}

### DIFF
--- a/src/cst.rs
+++ b/src/cst.rs
@@ -1990,8 +1990,12 @@ impl<'src> CstParser<'src> {
                     self.builder.start_node(SyntaxKind::JSX_EXPR_CHILD.into());
                     self.bump();
                     self.eat_trivia();
-                    self.parse_expr();
-                    self.eat_trivia();
+                    // {/* comment */} — block comment already eaten as trivia,
+                    // so if the next token is `}` there's no expr to parse.
+                    if !self.at(TokenKind::RightBrace) {
+                        self.parse_expr();
+                        self.eat_trivia();
+                    }
                     self.expect(TokenKind::RightBrace);
                     self.builder.finish_node();
                 }
@@ -2784,6 +2788,21 @@ mod tests {
     #[test]
     fn jsx_with_props() {
         assert_no_errors("<Button onClick={handler} />");
+    }
+
+    #[test]
+    fn jsx_comment() {
+        assert_no_errors("<div>{/* comment */}</div>");
+    }
+
+    #[test]
+    fn jsx_comment_among_children() {
+        assert_no_errors("<div>{/* comment */}<span>hello</span></div>");
+    }
+
+    #[test]
+    fn lossless_jsx_comment() {
+        assert_lossless("<div>{/* comment */}</div>");
     }
 
     // ── Lambda / arrow functions ──────────────────────────────────

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -22,6 +22,7 @@ pub(crate) enum JsxChildInfo {
     Text(String),
     Expr(SyntaxNode),
     Element(SyntaxNode),
+    Comment(String),
 }
 
 pub(crate) enum PipeSegment {

--- a/src/formatter/jsx.rs
+++ b/src/formatter/jsx.rs
@@ -67,9 +67,12 @@ impl Formatter<'_> {
             return;
         }
 
-        // Single text or single expr child → inline
+        // Single text, expr, or comment child → inline
         let inline = children.len() == 1
-            && matches!(&children[0], JsxChildInfo::Text(_) | JsxChildInfo::Expr(_));
+            && matches!(
+                &children[0],
+                JsxChildInfo::Text(_) | JsxChildInfo::Expr(_) | JsxChildInfo::Comment(_)
+            );
 
         if inline {
             self.fmt_jsx_children_inline(&children);
@@ -160,6 +163,11 @@ impl Formatter<'_> {
                 JsxChildInfo::Element(node) => {
                     self.fmt_jsx(node);
                 }
+                JsxChildInfo::Comment(text) => {
+                    self.write("{");
+                    self.write(text);
+                    self.write("}");
+                }
             }
         }
     }
@@ -182,6 +190,13 @@ impl Formatter<'_> {
                     self.newline();
                     self.write_indent();
                     self.fmt_jsx(node);
+                }
+                JsxChildInfo::Comment(text) => {
+                    self.newline();
+                    self.write_indent();
+                    self.write("{");
+                    self.write(text);
+                    self.write("}");
                 }
             }
         }
@@ -253,7 +268,11 @@ impl Formatter<'_> {
                     }
                 }
                 SyntaxKind::JSX_EXPR_CHILD => {
-                    children.push(JsxChildInfo::Expr(child));
+                    if let Some(comment) = self.jsx_expr_child_comment(&child) {
+                        children.push(JsxChildInfo::Comment(comment));
+                    } else {
+                        children.push(JsxChildInfo::Expr(child));
+                    }
                 }
                 SyntaxKind::JSX_ELEMENT => {
                     children.push(JsxChildInfo::Element(child));
@@ -262,6 +281,28 @@ impl Formatter<'_> {
             }
         }
         children
+    }
+
+    /// If a `JSX_EXPR_CHILD` contains only a block comment (no real expression),
+    /// return the comment text (e.g. `/* Desktop */`).
+    fn jsx_expr_child_comment(&self, node: &SyntaxNode) -> Option<String> {
+        let mut comment = None;
+        for child_or_tok in node.children_with_tokens() {
+            match child_or_tok {
+                rowan::NodeOrToken::Token(tok) => {
+                    if tok.kind() == SyntaxKind::BLOCK_COMMENT {
+                        comment = Some(tok.text().to_string());
+                    } else if !tok.kind().is_trivia()
+                        && tok.kind() != SyntaxKind::L_BRACE
+                        && tok.kind() != SyntaxKind::R_BRACE
+                    {
+                        return None;
+                    }
+                }
+                rowan::NodeOrToken::Node(_) => return None,
+            }
+        }
+        comment
     }
 
     fn jsx_props_short(&self, props: &[SyntaxNode]) -> bool {

--- a/src/formatter/tests.rs
+++ b/src/formatter/tests.rs
@@ -129,6 +129,19 @@ fn format_jsx_fragment() {
     assert_fmt("<>{x}</>", "<>{x}</>");
 }
 
+#[test]
+fn format_jsx_comment() {
+    assert_fmt(
+        "<div>{/* comment */}<span>hi</span></div>",
+        "<div>\n    {/* comment */}\n    <span>hi</span>\n</div>",
+    );
+}
+
+#[test]
+fn format_jsx_comment_only_child() {
+    assert_fmt("<div>{/* comment */}</div>", "<div>{/* comment */}</div>");
+}
+
 // ── Blank line before final expression ──────────────────────
 
 #[test]

--- a/tests/fixtures/jsx_comment.fl
+++ b/tests/fixtures/jsx_comment.fl
@@ -1,0 +1,12 @@
+import { JSX } from "react"
+
+export fn App() -> JSX.Element {
+    <div>
+        {/* Desktop */}
+        {/* Multi
+            line
+            comment */}
+        <span>Hello</span>
+        {/* Trailing comment */}
+    </div>
+}

--- a/tests/snapshot_codegen.rs
+++ b/tests/snapshot_codegen.rs
@@ -66,6 +66,12 @@ fn snapshot_jsx_component() {
 }
 
 #[test]
+fn snapshot_jsx_comment() {
+    let output = compile_fixture("jsx_comment");
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn snapshot_imports() {
     let output = compile_fixture("imports");
     insta::assert_snapshot!(output);

--- a/tests/snapshots/snapshot_codegen__snapshot_jsx_comment.snap
+++ b/tests/snapshots/snapshot_codegen__snapshot_jsx_comment.snap
@@ -1,0 +1,9 @@
+---
+source: tests/snapshot_codegen.rs
+expression: output
+---
+import { JSX } from "react";
+
+export function App(): JSX.Element {
+  return <div><span>Hello</span></div>;
+}


### PR DESCRIPTION
closes #491

Adds support for JSX comments like `{/* Desktop */}` which are standard in React/JSX.

**Parser** (`cst.rs`): When parsing JSX expression children (`{...}`), after eating trivia (which includes block comments), check if the next token is `}`. If so, there's no expression to parse — it's a comment-only block.

**Formatter** (`formatter/jsx.rs`): Detect comment-only JSX expression children and preserve the block comment text in the output, instead of stripping it as trivia.

**Tests**: CST parser tests, formatter tests, and codegen snapshot test.