### PR TITLE
fix: [#501] Tell Vite that compiled .fl output is TypeScript

### DIFF
--- a/integrations/vite-plugin-floe/src/index.ts
+++ b/integrations/vite-plugin-floe/src/index.ts
@@ -45,6 +45,7 @@ export default function floe(options: FloeOptions = {}): Plugin {
         return {
           code: result.code,
           map: result.map,
+          moduleType: "tsx",
         };
       } catch (error) {
         const message =


### PR DESCRIPTION
closes #501

## Summary

- Add `moduleType: "tsx"` to the Vite plugin's `transform` return value so Rolldown/OXC (Vite 7+/8+) parses the compiled output as TypeScript instead of JavaScript
- Fixes `[PARSE_ERROR] Expected ',' or '}' but found 'Identifier'` errors caused by OXC seeing `import { type Foo }` and parsing it as JS

## Why this works

- **Vite 7+/8+** use Rolldown, which supports `moduleType` to tell OXC the correct language. Without it, OXC infers JS from the `.fl` extension and chokes on TS-only syntax like inline type specifiers.
- **Vite 5/6** use esbuild for dev transforms, which handles TS natively. The `moduleType` field is silently ignored on these versions (it's a Rolldown concept), so no breakage.
- `tsx` is used instead of `ts` because it's a superset and the compiler may emit JSX.

## Test plan

- [ ] Verify `.fl` files with type-only imports compile without parse errors in Vite 8 dev mode
- [ ] Verify JSX-containing `.fl` files still work
- [ ] Verify Vite 5/6 compatibility (plugin should still work, `moduleType` ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)