### PR TITLE
fix: [#506] LSP resolves tsconfig path aliases instead of reporting false errors

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -233,8 +233,16 @@ impl FloeLsp {
                     let source_dir = source_path.parent().unwrap_or(Path::new("."));
                     let project_dir = find_project_dir(source_dir);
                     let cache = self.dts_cache.read().await.clone();
-                    let (import_diags, new_cache) =
-                        enrich_from_imports(&program, &project_dir, source_dir, &mut index, &cache);
+                    let tsconfig_paths =
+                        crate::resolve::TsconfigPaths::from_project_dir(&project_dir);
+                    let (import_diags, new_cache) = enrich_from_imports(
+                        &program,
+                        &project_dir,
+                        source_dir,
+                        &mut index,
+                        &cache,
+                        &tsconfig_paths,
+                    );
                     import_diags_early = import_diags;
 
                     // Use tsgo for fully-resolved types — no fallback

--- a/src/lsp/resolution.rs
+++ b/src/lsp/resolution.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use crate::diagnostic::{self as floe_diag};
 use crate::interop;
 use crate::parser::ast::*;
+use crate::resolve::TsconfigPaths;
 
 use super::symbols::SymbolIndex;
 
@@ -78,6 +79,7 @@ pub(super) fn enrich_from_imports(
     source_dir: &Path,
     index: &mut SymbolIndex,
     dts_cache: &HashMap<String, Vec<interop::DtsExport>>,
+    tsconfig_paths: &TsconfigPaths,
 ) -> (
     Vec<floe_diag::Diagnostic>,
     HashMap<String, Vec<interop::DtsExport>>,
@@ -106,6 +108,23 @@ pub(super) fn enrich_from_imports(
                     .with_code("E012"),
                 );
             }
+            continue;
+        }
+
+        // Check if this is a tsconfig path alias (e.g. "#/utils")
+        if tsconfig_paths.matches(specifier) {
+            if tsconfig_paths.resolve(specifier).is_none() {
+                import_diags.push(
+                    floe_diag::Diagnostic::error(
+                        format!("cannot find module `\"{specifier}\"`"),
+                        item.span,
+                    )
+                    .with_label("path alias resolved but file not found")
+                    .with_help("check the file path matches a tsconfig paths alias")
+                    .with_code("E012"),
+                );
+            }
+            // Path aliases are resolved as local files, not npm packages
             continue;
         }
 

--- a/src/lsp/tests.rs
+++ b/src/lsp/tests.rs
@@ -753,12 +753,14 @@ fn unresolved_npm_import_diagnostic() {
     // Use a directory that definitely has no node_modules
     let project_dir = Path::new("/tmp/no-such-project-dir");
     let source_dir = project_dir;
+    let tsconfig_paths = crate::resolve::TsconfigPaths::default();
     let (diags, _) = super::resolution::enrich_from_imports(
         &program,
         project_dir,
         source_dir,
         &mut index,
         &cache,
+        &tsconfig_paths,
     );
     assert!(
         !diags.is_empty(),

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -9,6 +9,114 @@ use std::path::{Path, PathBuf};
 use crate::parser::Parser;
 use crate::parser::ast::*;
 
+/// Parsed tsconfig.json path aliases.
+/// Maps alias prefixes (e.g. "#/") to their target directories.
+#[derive(Debug, Clone, Default)]
+pub struct TsconfigPaths {
+    /// Alias prefix -> resolved base directories (e.g. "#/*" -> ["/abs/path/src"])
+    pub mappings: Vec<(String, Vec<PathBuf>)>,
+}
+
+impl TsconfigPaths {
+    /// Parse path aliases from the nearest tsconfig.json.
+    pub fn from_project_dir(project_dir: &Path) -> Self {
+        let tsconfig_path = match find_tsconfig(project_dir) {
+            Some(p) => p,
+            None => return Self::default(),
+        };
+
+        let content = match std::fs::read_to_string(&tsconfig_path) {
+            Ok(c) => c,
+            Err(_) => return Self::default(),
+        };
+
+        let json: serde_json::Value = match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(_) => return Self::default(),
+        };
+
+        let tsconfig_dir = tsconfig_path.parent().unwrap_or(project_dir);
+
+        let base_url = json
+            .pointer("/compilerOptions/baseUrl")
+            .and_then(|v| v.as_str())
+            .map(|b| tsconfig_dir.join(b))
+            .unwrap_or_else(|| tsconfig_dir.to_path_buf());
+
+        let paths = match json.pointer("/compilerOptions/paths") {
+            Some(serde_json::Value::Object(map)) => map,
+            _ => return Self::default(),
+        };
+
+        let mut mappings = Vec::new();
+        for (pattern, targets) in paths {
+            let targets = match targets.as_array() {
+                Some(arr) => arr,
+                None => continue,
+            };
+
+            // Strip trailing "*" from pattern (e.g. "#/*" -> "#/")
+            let prefix = pattern.trim_end_matches('*');
+
+            let resolved_dirs: Vec<PathBuf> = targets
+                .iter()
+                .filter_map(|t| t.as_str())
+                .map(|t| base_url.join(t.trim_end_matches('*')))
+                .collect();
+
+            if !resolved_dirs.is_empty() {
+                mappings.push((prefix.to_string(), resolved_dirs));
+            }
+        }
+
+        Self { mappings }
+    }
+
+    /// Try to resolve a specifier using tsconfig path aliases.
+    /// Returns the resolved file path if found.
+    pub fn resolve(&self, specifier: &str) -> Option<PathBuf> {
+        for (prefix, dirs) in &self.mappings {
+            if let Some(rest) = specifier.strip_prefix(prefix) {
+                for dir in dirs {
+                    let candidate = dir.join(rest);
+                    // Try .fl, .ts, .tsx extensions and /index variants
+                    for ext in &[".fl", ".ts", ".tsx", "/index.fl", "/index.ts", "/index.tsx"] {
+                        let path = PathBuf::from(format!("{}{}", candidate.display(), ext));
+                        if path.exists() {
+                            return Some(path);
+                        }
+                    }
+                    if candidate.exists() && candidate.is_file() {
+                        return Some(candidate);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Check if a specifier matches any path alias.
+    pub fn matches(&self, specifier: &str) -> bool {
+        self.mappings
+            .iter()
+            .any(|(prefix, _)| specifier.starts_with(prefix))
+    }
+}
+
+/// Find the nearest tsconfig.json by walking up from a directory.
+fn find_tsconfig(dir: &Path) -> Option<PathBuf> {
+    let mut current = dir.to_path_buf();
+    loop {
+        let tsconfig = current.join("tsconfig.json");
+        if tsconfig.exists() {
+            return Some(tsconfig);
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
 /// Symbols exported from a resolved module.
 #[derive(Debug, Clone, Default)]
 pub struct ResolvedImports {


### PR DESCRIPTION
closes #506

## Summary
- Added `TsconfigPaths` struct to `resolve.rs` that parses `compilerOptions.paths` and `baseUrl` from `tsconfig.json`
- LSP's `enrich_from_imports` now checks path aliases before falling through to npm resolution, preventing false "cannot find module" errors for aliases like `#/`
- Path aliases that match but point to nonexistent files still report errors with a helpful message

## Test plan
- [x] `cargo fmt && cargo clippy -- -D warnings && RUSTFLAGS="-D warnings" cargo test` - all pass
- [x] All 215 LSP tests pass (0 failures)
- [x] `floe fmt/check/build` on both example apps - all pass
- [ ] Manual: open a file with `#/` path alias imports in VSCode - no false E013 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)