### PR TITLE
feat: [#509] Add Date module to stdlib

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -92,6 +92,7 @@ All four of TypeScript's `?` uses (`?.`, `??`, `?:`, `? :`) are removed. `?` now
 | Immutable sort | `Array.sort` returns new array | sorted copy, no mutation |
 | Immutable maps | `Map.set`, `Map.remove` return new maps | `new Map([...old, [k, v]])` |
 | Immutable sets | `Set.add`, `Set.remove` return new sets | `new Set([...old, val])` |
+| Date construction | `Date.now()`, `Date.from("...")` | `new Date()`, `new Date("...")` |
 | Strict parse | `Number.parse("123")` returns `Result` | no silent `NaN` or partial parse |
 | Http module | `Http.get(url)`, `Http.post(url, body)` | async IIFE wrapping `fetch` in `Result` |
 | Number separators | `1_000_000`, `3.141_592`, `0xFF_FF` | underscores stripped in output |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -375,6 +375,16 @@ const isUrgent = tags |> Set.has("urgent")    // boolean
 const teamAll = Set.union(teamA, teamB)
 const overlap = Set.intersect(teamA, teamB)
 const diff = Set.diff(teamA, teamB)
+
+// Date — construction and accessors (no `new` keyword in Floe)
+const now = Date.now()                        // new Date()
+const d = Date.from("2024-01-15")             // new Date("2024-01-15")
+const d2 = Date.fromMillis(1705276800000)     // new Date(1705276800000)
+const year = d |> Date.year                   // d.getFullYear()
+const month = d |> Date.month                 // d.getMonth() + 1 (1-indexed!)
+const day = d |> Date.day                     // d.getDate()
+const ms = d |> Date.millis                   // d.getTime()
+const iso = d |> Date.toIso                   // d.toISOString()
 ```
 
 ## Imports

--- a/docs/site/src/content/docs/reference/stdlib.md
+++ b/docs/site/src/content/docs/reference/stdlib.md
@@ -417,6 +417,48 @@ const tagList = tags |> Set.toArray
 
 ---
 
+## Date
+
+Date construction and accessors. Floe has no `new` keyword, so the `Date` module bridges the gap for creating JS `Date` objects and reading their fields.
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `Date.now` | `() -> Date` | Current date and time |
+| `Date.from` | `string -> Date` | Parse a date string |
+| `Date.fromMillis` | `number -> Date` | Create from Unix milliseconds |
+| `Date.year` | `Date -> number` | Full year (e.g. 2024) |
+| `Date.month` | `Date -> number` | Month (1-12, 1-indexed!) |
+| `Date.day` | `Date -> number` | Day of month (1-31) |
+| `Date.hour` | `Date -> number` | Hour (0-23) |
+| `Date.minute` | `Date -> number` | Minute (0-59) |
+| `Date.second` | `Date -> number` | Second (0-59) |
+| `Date.millis` | `Date -> number` | Unix timestamp in milliseconds |
+| `Date.toIso` | `Date -> string` | ISO 8601 string |
+
+### Examples
+
+```floe
+// Create dates
+const now = Date.now()
+const release = Date.from("2024-06-15")
+const epoch = Date.fromMillis(0)
+
+// Read fields with pipes
+const year = release |> Date.year         // 2024
+const month = release |> Date.month       // 6 (1-indexed, not 0!)
+const day = release |> Date.day           // 15
+
+// Convert to string or timestamp
+const iso = now |> Date.toIso             // "2024-..."
+const timestamp = now |> Date.millis      // 1718...
+```
+
+`Date.month` returns 1-12 (January = 1), unlike JavaScript's `getMonth()` which returns 0-11. This fixes a common JS footgun.
+
+For date arithmetic, formatting, and timezone handling, use npm libraries like `date-fns` via interop -- the stdlib only covers construction and basic access.
+
+---
+
 ## Http
 
 Pipe-friendly HTTP functions that return `Result` natively. No `try` wrapper needed -- errors are captured automatically.

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -239,6 +239,18 @@ fn build_stdlib() -> Vec<StdlibFn> {
         stdlib_fn!("Set", "union", [set_of(t.clone()), set_of(t.clone())], set_of(t.clone()), "new Set([...$0, ...$1])"),
         stdlib_fn!("Set", "intersect", [set_of(t.clone()), set_of(t.clone())], set_of(t.clone()), "new Set([...$0].filter(x => $1.has(x)))"),
         stdlib_fn!("Set", "diff", [set_of(t.clone()), set_of(t.clone())], set_of(t.clone()), "new Set([...$0].filter(x => !$1.has(x)))"),
+        // ── Date ───────────────────────────────────────────────────
+        stdlib_fn!("Date", "now", [], Type::Named("Date".to_string()), "new Date()"),
+        stdlib_fn!("Date", "from", [Type::String], Type::Named("Date".to_string()), "new Date($0)"),
+        stdlib_fn!("Date", "fromMillis", [Type::Number], Type::Named("Date".to_string()), "new Date($0)"),
+        stdlib_fn!("Date", "year", [Type::Named("Date".to_string())], Type::Number, "$0.getFullYear()"),
+        stdlib_fn!("Date", "month", [Type::Named("Date".to_string())], Type::Number, "($0.getMonth() + 1)"),
+        stdlib_fn!("Date", "day", [Type::Named("Date".to_string())], Type::Number, "$0.getDate()"),
+        stdlib_fn!("Date", "hour", [Type::Named("Date".to_string())], Type::Number, "$0.getHours()"),
+        stdlib_fn!("Date", "minute", [Type::Named("Date".to_string())], Type::Number, "$0.getMinutes()"),
+        stdlib_fn!("Date", "second", [Type::Named("Date".to_string())], Type::Number, "$0.getSeconds()"),
+        stdlib_fn!("Date", "millis", [Type::Named("Date".to_string())], Type::Number, "$0.getTime()"),
+        stdlib_fn!("Date", "toIso", [Type::Named("Date".to_string())], Type::String, "$0.toISOString()"),
         // ── Http ──────────────────────────────────────────────────
         stdlib_fn!("Http", "get", [Type::String], result_of(Type::Named("Response".to_string()), Type::Named("Error".to_string())), "(async () => { try { const _r = await fetch($0); return { ok: true as const, value: _r }; } catch (_e) { return { ok: false as const, error: _e instanceof Error ? _e : new Error(String(_e)) }; } })()"),
         stdlib_fn!("Http", "post", [Type::String, Type::Unknown], result_of(Type::Named("Response".to_string()), Type::Named("Error".to_string())), "(async () => { try { const _r = await fetch($0, { method: \"POST\", body: JSON.stringify($1), headers: { \"Content-Type\": \"application/json\" } }); return { ok: true as const, value: _r }; } catch (_e) { return { ok: false as const, error: _e instanceof Error ? _e : new Error(String(_e)) }; } })()"),
@@ -558,6 +570,7 @@ mod tests {
         assert!(reg.is_module("Map"));
         assert!(reg.is_module("Set"));
         assert!(reg.is_module("Http"));
+        assert!(reg.is_module("Date"));
         assert!(!reg.is_module("Foo"));
     }
 
@@ -575,6 +588,57 @@ mod tests {
         assert!(reg.module_functions("Map").len() >= 12);
         assert!(reg.module_functions("Set").len() >= 11);
         assert!(reg.module_functions("Http").len() >= 6);
+        assert!(reg.module_functions("Date").len() >= 11);
+    }
+
+    #[test]
+    fn lookup_date_now() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Date", "now").unwrap();
+        assert_eq!(f.codegen, "new Date()");
+        assert!(f.params.is_empty());
+    }
+
+    #[test]
+    fn lookup_date_from() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Date", "from").unwrap();
+        assert_eq!(f.codegen, "new Date($0)");
+    }
+
+    #[test]
+    fn lookup_date_from_millis() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Date", "fromMillis").unwrap();
+        assert_eq!(f.codegen, "new Date($0)");
+    }
+
+    #[test]
+    fn lookup_date_year() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Date", "year").unwrap();
+        assert_eq!(f.codegen, "$0.getFullYear()");
+    }
+
+    #[test]
+    fn lookup_date_month() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Date", "month").unwrap();
+        assert_eq!(f.codegen, "($0.getMonth() + 1)");
+    }
+
+    #[test]
+    fn lookup_date_millis() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Date", "millis").unwrap();
+        assert_eq!(f.codegen, "$0.getTime()");
+    }
+
+    #[test]
+    fn lookup_date_to_iso() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("Date", "toIso").unwrap();
+        assert_eq!(f.codegen, "$0.toISOString()");
     }
 
     #[test]

--- a/src/type_layout.rs
+++ b/src/type_layout.rs
@@ -39,6 +39,7 @@ pub const MOD_OPTION: &str = "Option";
 pub const MOD_RESULT: &str = "Result";
 pub const MOD_MAP: &str = "Map";
 pub const MOD_SET: &str = "Set";
+pub const MOD_DATE: &str = "Date";
 
 // ── Variant classification ───────────────────────────────────────
 
@@ -130,6 +131,7 @@ pub fn type_to_stdlib_module(ty: &crate::checker::Type) -> Option<&'static str> 
         Type::Number => Some(MOD_NUMBER),
         Type::Option(_) => Some(MOD_OPTION),
         Type::Result { .. } => Some(MOD_RESULT),
+        Type::Named(name) if name == "Date" => Some(MOD_DATE),
         _ => None,
     }
 }

--- a/tests/fixtures/stdlib.fl
+++ b/tests/fixtures/stdlib.fl
@@ -101,6 +101,19 @@ const _set_union = Set.union(_set, _set2)
 const _set_inter = Set.intersect(_set, _set2)
 const _set_diff = Set.diff(_set, _set2)
 
+// ── Date ──────────────────────────────────────────────────
+const _date_now = Date.now()
+const _date_from = Date.from("2024-01-15")
+const _date_from_ms = Date.fromMillis(1705276800000)
+const _date_year = Date.year(_date_now)
+const _date_month = Date.month(_date_now)
+const _date_day = Date.day(_date_now)
+const _date_hour = Date.hour(_date_now)
+const _date_minute = Date.minute(_date_now)
+const _date_second = Date.second(_date_now)
+const _date_millis = Date.millis(_date_now)
+const _date_iso = Date.toIso(_date_now)
+
 // ── Pipes with stdlib ───────────────────────────────────────
 const _piped = [3, 1, 2] |> Array.sort
 const _pipe_chain = [1, 2, 3, 4, 5]
@@ -111,3 +124,4 @@ const _pipe_chain = [1, 2, 3, 4, 5]
 const _pipe_opt = Some(10) |> Option.map((n) => n + 1)
 const _pipe_str = "  hello  " |> String.trim
 const _pipe_num = "42" |> Number.parse
+const _pipe_date = Date.now() |> Date.toIso

--- a/tests/snapshots/snapshot_codegen__snapshot_stdlib.snap
+++ b/tests/snapshots/snapshot_codegen__snapshot_stdlib.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/snapshot_codegen.rs
-assertion_line: 100
 expression: output
 ---
 function __floeEq(a: unknown, b: unknown): boolean {
@@ -183,6 +182,28 @@ const _set_inter = new Set([..._set].filter(x => _set2.has(x)));
 
 const _set_diff = new Set([..._set].filter(x => !_set2.has(x)));
 
+const _date_now = new Date();
+
+const _date_from = new Date("2024-01-15");
+
+const _date_from_ms = new Date(1705276800000);
+
+const _date_year = _date_now.getFullYear();
+
+const _date_month = (_date_now.getMonth() + 1);
+
+const _date_day = _date_now.getDate();
+
+const _date_hour = _date_now.getHours();
+
+const _date_minute = _date_now.getMinutes();
+
+const _date_second = _date_now.getSeconds();
+
+const _date_millis = _date_now.getTime();
+
+const _date_iso = _date_now.toISOString();
+
 const _piped = [...[3, 1, 2]].sort((a, b) => a - b);
 
 const _pipe_chain = [...[1, 2, 3, 4, 5].filter((n) => n > 2).map((n) => n * 10)].reverse();
@@ -192,3 +213,5 @@ const _pipe_opt = 10 !== undefined ? ((n) => n + 1)(10) : undefined;
 const _pipe_str = "  hello  ".trim();
 
 const _pipe_num = (() => { const _n = Number("42"); return Number.isNaN(_n) || "42".trim() === "" ? { ok: false as const, error: { message: `Failed to parse "${"42"}" as number` } } : { ok: true as const, value: _n }; })();
+
+const _pipe_date = new Date().toISOString();


### PR DESCRIPTION
closes #509

## Summary

- Add `Date` module with 11 stdlib functions: `now`, `from`, `fromMillis`, `year`, `month`, `day`, `hour`, `minute`, `second`, `millis`, `toIso`
- `Date.month` is 1-indexed (Jan=1), fixing the JS `getMonth()` footgun
- Type-directed pipe support via `Named("Date")` mapping in `type_layout.rs`
- Updated docs: `design.md`, `llms.txt`, `stdlib.md`

## Test plan

- [x] `cargo test` — all pass including new Date unit tests + updated snapshot
- [x] `cargo clippy -- -D warnings` — clean
- [x] `floe fmt/check/build` on example apps — all pass
- [x] LSP tests — 215 passed, 0 failed