### PR TITLE
fix: [#516] For-block functions from different types clash when both imported

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -119,6 +119,9 @@ pub struct Checker {
     fn_required_params: HashMap<String, usize>,
     /// Maps function names to their parameter names (for validating named arguments).
     fn_param_names: HashMap<String, Vec<String>>,
+    /// Maps for-block function names to their parent type name.
+    /// Used to allow same-named functions on different types (e.g. Entry.fromRow, Accent.fromRow).
+    for_block_fn_types: HashMap<String, String>,
 }
 
 /// Signature of a trait method (for checking implementations).
@@ -287,6 +290,7 @@ impl Checker {
             ambiguous_variants: HashMap::new(),
             fn_required_params: HashMap::new(),
             fn_param_names: HashMap::new(),
+            for_block_fn_types: HashMap::new(),
         }
     }
 
@@ -1169,6 +1173,10 @@ impl Checker {
     /// Register for-block functions from an imported module without checking bodies.
     fn check_for_block_imported_with_source(&mut self, block: &ForBlock, source: &str) {
         let for_type = self.resolve_type(&block.type_name);
+        let type_name = match &block.type_name.kind {
+            TypeExprKind::Named { name, .. } => name.clone(),
+            _ => String::new(),
+        };
 
         for func in &block.functions {
             let return_type = func
@@ -1201,6 +1209,8 @@ impl Checker {
                 func.name.clone(),
                 format!("for-block function from \"{}\"", source),
             );
+            self.for_block_fn_types
+                .insert(func.name.clone(), type_name.clone());
 
             // Track required (non-default) parameter count
             let required_params = func.params.iter().filter(|p| p.default.is_none()).count();
@@ -1592,6 +1602,10 @@ impl Checker {
 
     fn check_for_block(&mut self, block: &ForBlock, _span: Span) {
         let for_type = self.resolve_type(&block.type_name);
+        let type_name = match &block.type_name.kind {
+            TypeExprKind::Named { name, .. } => name.clone(),
+            _ => String::new(),
+        };
 
         // If this is a trait impl block, validate the trait contract
         if let Some(ref trait_name) = block.trait_name {
@@ -1627,11 +1641,21 @@ impl Checker {
                 params: param_types.clone(),
                 return_type: Box::new(return_type.clone()),
             };
-            self.check_no_redefinition(&func.name, block.span);
+            // Allow for-block functions with the same name on different types
+            // (e.g. Entry.fromRow and Accent.fromRow are not in conflict)
+            let is_different_for_block = self
+                .for_block_fn_types
+                .get(&func.name)
+                .is_some_and(|existing_type| *existing_type != type_name);
+            if !is_different_for_block {
+                self.check_no_redefinition(&func.name, block.span);
+            }
             self.env.define(&func.name, fn_type);
             self.unused
                 .defined_sources
                 .insert(func.name.clone(), "for-block function".to_string());
+            self.for_block_fn_types
+                .insert(func.name.clone(), type_name.clone());
 
             // Track required (non-default) parameter count
             let required_params = func.params.iter().filter(|p| p.default.is_none()).count();

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -3121,3 +3121,137 @@ fn uppercase_variant_name_ok() {
 
 // Note: uppercase field names are already rejected by the parser
 // (uppercase identifiers are parsed as types/variants, not field names)
+
+// ── Bug #516: For-block functions from different types clash ──
+
+#[test]
+fn for_block_same_fn_name_different_types_no_conflict() {
+    // Importing a type whose for-block defines `fromRow`, then defining a local
+    // for-block with the same function name on a different type, should NOT error.
+    use crate::lexer::span::Span;
+    use crate::parser::ast::*;
+    use crate::resolve::ResolvedImports;
+    use std::collections::HashMap;
+
+    let dummy_span = Span::new(0, 0, 0, 0);
+
+    let mut imports = HashMap::new();
+    let mut resolved = ResolvedImports::default();
+
+    // Simulate: type Accent { id: number }
+    resolved.type_decls.push(TypeDecl {
+        exported: true,
+        opaque: false,
+        name: "Accent".to_string(),
+        type_params: vec![],
+        def: TypeDef::Record(vec![RecordEntry::Field(Box::new(RecordField {
+            name: "id".to_string(),
+            type_ann: TypeExpr {
+                kind: TypeExprKind::Named {
+                    name: "number".to_string(),
+                    type_args: vec![],
+                    bounds: vec![],
+                },
+                span: dummy_span,
+            },
+            default: None,
+            span: dummy_span,
+        }))]),
+        deriving: vec![],
+    });
+
+    // Simulate: for Accent { export fn fromRow() -> Accent { ... } }
+    resolved.for_blocks.push(ForBlock {
+        type_name: TypeExpr {
+            kind: TypeExprKind::Named {
+                name: "Accent".to_string(),
+                type_args: vec![],
+                bounds: vec![],
+            },
+            span: dummy_span,
+        },
+        trait_name: None,
+        functions: vec![FunctionDecl {
+            exported: true,
+            async_fn: false,
+            name: "fromRow".to_string(),
+            type_params: vec![],
+            params: vec![],
+            return_type: Some(TypeExpr {
+                kind: TypeExprKind::Named {
+                    name: "Accent".to_string(),
+                    type_args: vec![],
+                    bounds: vec![],
+                },
+                span: dummy_span,
+            }),
+            body: Box::new(Expr {
+                id: ExprId(0),
+                kind: ExprKind::Construct {
+                    type_name: "Accent".to_string(),
+                    spread: None,
+                    args: vec![Arg::Named {
+                        label: "id".to_string(),
+                        value: Expr {
+                            id: ExprId(0),
+                            kind: ExprKind::Number("0".to_string()),
+                            ty: Type::Unknown,
+                            span: dummy_span,
+                        },
+                    }],
+                },
+                ty: Type::Unknown,
+                span: dummy_span,
+            }),
+        }],
+        span: dummy_span,
+    });
+
+    imports.insert("./accent".to_string(), resolved);
+
+    let source = r#"
+import { Accent } from "./accent"
+
+type Entry {
+    id: number,
+    accents: Array<Accent>,
+}
+
+for Entry {
+    export fn fromRow() -> Entry {
+        Entry(id: 0, accents: [])
+    }
+}
+"#;
+
+    let program = Parser::new(source)
+        .parse_program()
+        .expect("parse should succeed");
+    let diags = Checker::with_imports(imports).check(&program);
+    assert!(
+        !has_error(&diags, "E016"),
+        "for-block functions with the same name on different types should not conflict, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn for_block_same_fn_name_same_type_still_errors() {
+    // Two for-blocks on the SAME type with the same function name SHOULD error.
+    let diags = check(
+        r#"
+type Todo { text: string }
+for Todo {
+    fn format(self) -> string { self.text }
+}
+for Todo {
+    fn format(self) -> string { self.text }
+}
+"#,
+    );
+    assert!(
+        has_error(&diags, "E016"),
+        "duplicate for-block function on same type should error, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
closes #516

## Summary
- Added `for_block_fn_types` map to the checker that tracks which type each for-block function belongs to
- When defining a local for-block function, the redefinition check now skips if the existing definition is a for-block function on a **different** type (e.g. `Entry.fromRow` vs `Accent.fromRow`)
- Same-type duplicates still correctly error with E016

## Test plan
- [x] New test: `for_block_same_fn_name_different_types_no_conflict` — importing a type with `fromRow`, then defining local `fromRow` on a different type, produces no E016
- [x] New test: `for_block_same_fn_name_same_type_still_errors` — two for-blocks on the same type with duplicate function names still error
- [x] All existing shadowing tests pass
- [x] Full Rust quality gate (fmt, clippy, test)
- [x] Floe example quality gate (fmt, check, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)