### PR TITLE
fix: [#525] Break after -> in match arms when JSX body has multiline props

### DIFF
--- a/examples/store/src/pages/cart.fl
+++ b/examples/store/src/pages/cart.fl
@@ -119,12 +119,13 @@ export fn CartPage(
     <div>
         <h1 className="mb-6 text-3xl font-bold">{`Cart (${_count} item${_count |> match { 1 -> "", _ -> "s" }})`}</h1>
         {props.cart |> match {
-            [] -> <div
-                className="rounded-xl border border-zinc-800 bg-zinc-900/50 p-12 text-center"
-            >
-                <p className="text-lg text-zinc-500">Your cart is empty</p>
-                <p className="mt-2 text-sm text-zinc-600">Browse the store to add some products!</p>
-            </div>,
+            [] ->
+                <div
+                    className="rounded-xl border border-zinc-800 bg-zinc-900/50 p-12 text-center"
+                >
+                    <p className="text-lg text-zinc-500">Your cart is empty</p>
+                    <p className="mt-2 text-sm text-zinc-600">Browse the store to add some products!</p>
+                </div>,
             items -> <div className="flex gap-8">
                 <div className="flex-1 space-y-3">{items |> Array.map((item) => <CartItemRow
                     key={item.product.id}

--- a/examples/store/src/pages/catalog.fl
+++ b/examples/store/src/pages/catalog.fl
@@ -47,11 +47,12 @@ fn ProductCard(props: { product: Product, onAddToCart: (Product) => () }) -> JSX
                 false -> <span />,
             }}
             {match hasDiscount {
-                true -> <span
-                    className="rounded bg-emerald-900/50 px-1.5 py-0.5 text-xs text-emerald-400"
-                >
-                    {`-${Math.round(product.discountPercentage)}%`}
-                </span>,
+                true ->
+                    <span
+                        className="rounded bg-emerald-900/50 px-1.5 py-0.5 text-xs text-emerald-400"
+                    >
+                        {`-${Math.round(product.discountPercentage)}%`}
+                    </span>,
                 false -> <span />,
             }}
         </div>

--- a/examples/store/src/pages/product-detail.fl
+++ b/examples/store/src/pages/product-detail.fl
@@ -97,11 +97,12 @@ fn ProductDetailContent(
                         false -> <span />,
                     }}
                     {match hasDiscount {
-                        true -> <span
-                            className="rounded bg-emerald-900/50 px-2 py-1 text-sm text-emerald-400"
-                        >
-                            {`Save ${product |> savings |> formatPrice}`}
-                        </span>,
+                        true ->
+                            <span
+                                className="rounded bg-emerald-900/50 px-2 py-1 text-sm text-emerald-400"
+                            >
+                                {`Save ${product |> savings |> formatPrice}`}
+                            </span>,
                         false -> <span />,
                     }}
                 </div>

--- a/src/formatter/expr.rs
+++ b/src/formatter/expr.rs
@@ -264,9 +264,43 @@ impl Formatter<'_> {
             }
         }
 
+        // Body: expression after ->
+        // Check if the body is a JSX element with multiline props — if so, break
+        // after `->` and indent so the JSX gets its own clean indentation context.
+        let body_node = {
+            let mut past_arrow = false;
+            let mut found = None;
+            for t in node.children_with_tokens() {
+                if let Some(tok) = t.as_token() {
+                    if tok.kind() == SyntaxKind::THIN_ARROW {
+                        past_arrow = true;
+                    }
+                } else if let Some(child) = t.into_node()
+                    && past_arrow
+                {
+                    found = Some(child);
+                    break;
+                }
+            }
+            found
+        };
+
+        let break_after_arrow = body_node.as_ref().is_some_and(|n| {
+            n.kind() == SyntaxKind::JSX_ELEMENT && self.jsx_has_multiline_props(n)
+        });
+
+        if break_after_arrow {
+            self.write(" ->");
+            self.indent += 1;
+            self.newline();
+            self.write_indent();
+            self.fmt_node(body_node.as_ref().unwrap());
+            self.indent -= 1;
+            return;
+        }
+
         self.write(" -> ");
 
-        // Body: expression after ->
         let mut past_arrow = false;
         for t in node.children_with_tokens() {
             if let Some(tok) = t.as_token() {

--- a/src/formatter/jsx.rs
+++ b/src/formatter/jsx.rs
@@ -334,6 +334,15 @@ impl Formatter<'_> {
         comment
     }
 
+    /// Check if a JSX element will be formatted with multi-line props.
+    pub(crate) fn jsx_has_multiline_props(&self, node: &SyntaxNode) -> bool {
+        let props: Vec<_> = node
+            .children()
+            .filter(|c| c.kind() == SyntaxKind::JSX_PROP)
+            .collect();
+        !(props.is_empty() || props.len() <= 3 && self.jsx_props_short(&props))
+    }
+
     fn jsx_props_short(&self, props: &[SyntaxNode]) -> bool {
         let total: usize = props
             .iter()

--- a/src/formatter/tests.rs
+++ b/src/formatter/tests.rs
@@ -587,3 +587,27 @@ fn idempotent_jsx_multiline_tag_with_text() {
         "<Link to=\"/search\" className=\"text-2xl font-bold\" title=\"Home\" target=\"_blank\">京阪アクセント辞典</Link>",
     );
 }
+
+#[test]
+fn format_match_arm_jsx_multiline_props_breaks_after_arrow() {
+    assert_fmt(
+        r#"match menuOpen { true -> <div className="absolute left-0 top-20 z-50 w-full border-b border-[var(--line)] bg-[var(--bg)] px-4 pb-4 sm:hidden"><ul>items</ul></div>, false -> <></> }"#,
+        "match menuOpen {\n    true ->\n        <div\n            className=\"absolute left-0 top-20 z-50 w-full border-b border-[var(--line)] bg-[var(--bg)] px-4 pb-4 sm:hidden\"\n        >\n            <ul>items</ul>\n        </div>,\n    false -> <></>,\n}",
+    );
+}
+
+#[test]
+fn format_match_arm_jsx_short_props_stays_inline() {
+    // JSX with few short props should stay on the same line as ->
+    assert_fmt(
+        r#"match x { true -> <X size={24} />, false -> <Y /> }"#,
+        "match x {\n    true -> <X size={24} />,\n    false -> <Y />,\n}",
+    );
+}
+
+#[test]
+fn idempotent_match_arm_jsx_multiline_props() {
+    assert_idempotent(
+        r#"match menuOpen { true -> <div className="absolute left-0 top-20 z-50 w-full border-b border-[var(--line)] bg-[var(--bg)] px-4 pb-4 sm:hidden"><ul>items</ul></div>, false -> <></> }"#,
+    );
+}


### PR DESCRIPTION
closes #525

When a match arm's body is a JSX element with multiline attributes, the formatter now breaks after `->` and indents, giving the JSX its own clean indentation context.

**Before:**
```
true -> <div
    className="long classes..."
>
    content
</div>,
```

**After:**
```
true ->
    <div
        className="long classes..."
    >
        content
    </div>,
```

Short/inline arms like `false -> <></>` remain on one line.

## Test plan
- [x] 3 new formatter tests (multiline break, short props stays inline, idempotency)
- [x] All 78 formatter tests pass
- [x] Full test suite passes (`cargo test`)
- [x] Clippy clean (`-D warnings`)
- [x] Floe example apps pass fmt/check/build (3 store examples updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)