### PR TITLE
fix: [#507] LSP hover on 'from' keyword shows Array.from instead of import syntax

### DIFF
--- a/scripts/test-lsp.py
+++ b/scripts/test-lsp.py
@@ -2239,6 +2239,18 @@ def main():
         f"Got: {h}",
     )
 
+    # --- Issue #507: 'from' keyword in import should not show Array.from ---
+    lsp.open_doc(URI, 'import { useState } from "react"\nconst x = 42\n')
+    lsp.collect_notifications("textDocument/publishDiagnostics", timeout=1)
+
+    # Hover on "from" keyword (line 0, char 20)
+    h = hover_text(lsp.hover(URI, 0, 20))
+    check(
+        "Hover #507: 'from' in import does not show Array.from",
+        h is None or "Array.from" not in h,
+        f"Got: {h}",
+    )
+
     # ── Done ─────────────────────────────────────────────
     lsp.shutdown()
 

--- a/src/lsp/handlers.rs
+++ b/src/lsp/handlers.rs
@@ -95,6 +95,14 @@ impl LanguageServer for FloeLsp {
             return Ok(None);
         }
 
+        // Check if cursor is on an import line — skip stdlib hover for keywords like `from`
+        let is_import_line = {
+            let line_start = doc.content[..offset].rfind('\n').map_or(0, |p| p + 1);
+            doc.content[line_start..]
+                .trim_start()
+                .starts_with("import ")
+        };
+
         // Compute word start position and whether this is member access (X.word)
         let word_start = {
             let mut s = offset;
@@ -186,7 +194,7 @@ impl LanguageServer for FloeLsp {
         }
 
         // Check stdlib module names (Array, String, Option, etc.)
-        if let Some(hover_text) = stdlib_hover::hover_stdlib_module(word) {
+        if !is_import_line && let Some(hover_text) = stdlib_hover::hover_stdlib_module(word) {
             return Ok(Some(Hover {
                 contents: HoverContents::Markup(MarkupContent {
                     kind: MarkupKind::Markdown,
@@ -197,7 +205,10 @@ impl LanguageServer for FloeLsp {
         }
 
         // Check bare stdlib function names (for pipe context only, not member access)
-        if !is_member_access && let Some(hover_text) = stdlib_hover::hover_stdlib_function(word) {
+        if !is_member_access
+            && !is_import_line
+            && let Some(hover_text) = stdlib_hover::hover_stdlib_function(word)
+        {
             return Ok(Some(Hover {
                 contents: HoverContents::Markup(MarkupContent {
                     kind: MarkupKind::Markdown,


### PR DESCRIPTION
closes #507

## Summary
- Skip stdlib module and function hover lookups when the cursor is on an import line
- Prevents `from` in `import { x } from "..."` from resolving to `Array.from`
- Added LSP integration test for this case

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `RUSTFLAGS="-D warnings" cargo test` passes
- [x] LSP integration tests: 216 passed, 0 failed (including new #507 test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)