### PR TITLE
fix: [#552] Show type info on hover for lambda parameters

### DIFF
--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -235,6 +235,10 @@ impl Checker {
                                 }
                             });
                         self.env.define(&p.name, ty.clone());
+                        // Persist lambda param type for LSP hover (scope is
+                        // popped after the arrow body is checked, so the param
+                        // would be lost from the final name_types merge)
+                        self.name_types.insert(p.name.clone(), ty.display_name());
                         // For destructured params, also define the field names
                         if let Some(ref destructure) = p.destructure {
                             match destructure {

--- a/src/lsp/symbols.rs
+++ b/src/lsp/symbols.rs
@@ -114,6 +114,8 @@ impl SymbolIndex {
                         }
                         ConstBinding::Name(_) => {}
                     }
+
+                    Self::collect_expr(&decl.value, symbols);
                 }
                 ItemKind::Function(decl) => {
                     let vis = if decl.exported { "export " } else { "" };
@@ -450,13 +452,46 @@ impl SymbolIndex {
             ExprKind::Block(items) => {
                 Self::collect_items(items, symbols);
             }
-            ExprKind::Arrow { body, .. } => {
+            ExprKind::Arrow { params, body, .. } => {
+                for param in params {
+                    let type_ann = param
+                        .type_ann
+                        .as_ref()
+                        .map(|t| format!(": {}", type_expr_to_string(t)))
+                        .unwrap_or_default();
+                    symbols.push(Symbol {
+                        name: param.name.clone(),
+                        kind: SymbolKind::VARIABLE,
+                        start: param.span.start,
+                        end: param.span.end,
+                        import_source: None,
+                        detail: format!("parameter {}{type_ann}", param.name),
+                        first_param_type: None,
+                        return_type_str: None,
+                        owner_type: None,
+                    });
+                }
                 Self::collect_expr(body, symbols);
             }
             ExprKind::Match { arms, .. } => {
                 for arm in arms {
                     Self::collect_expr(&arm.body, symbols);
                 }
+            }
+            ExprKind::Call { callee, args, .. } => {
+                Self::collect_expr(callee, symbols);
+                for arg in args {
+                    match arg {
+                        crate::parser::ast::Arg::Positional(e)
+                        | crate::parser::ast::Arg::Named { value: e, .. } => {
+                            Self::collect_expr(e, symbols);
+                        }
+                    }
+                }
+            }
+            ExprKind::Pipe { left, right } => {
+                Self::collect_expr(left, symbols);
+                Self::collect_expr(right, symbols);
             }
             ExprKind::Await(inner) | ExprKind::Grouped(inner) => {
                 Self::collect_expr(inner, symbols);


### PR DESCRIPTION
closes #552

## Summary

- Lambda params like `(x)` in `Array.map((x) => x * 2)` now show their inferred type on hover (e.g. `parameter x: number`)
- **Checker**: persist lambda param types in `name_types` immediately — the lambda scope is popped after checking the body, so params were lost from the final merge
- **Symbol index**: recurse into const initializers, call args, and pipe expressions to discover lambda params nested inside these expressions

## Test plan

- [x] Manual LSP test: hover on `x` in `Array.map((x) => x * 2)` shows `parameter x: number`
- [x] 981 unit tests pass, 0 failures
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)