### PR TITLE
feat: [#548] Support tsconfig paths aliases in import resolution

### DIFF
--- a/src/interop/tsgo.rs
+++ b/src/interop/tsgo.rs
@@ -42,9 +42,11 @@ impl TsgoResolver {
         program: &Program,
         resolved_imports: &HashMap<String, crate::resolve::ResolvedImports>,
         source_dir: &Path,
+        tsconfig_paths: &crate::resolve::TsconfigPaths,
     ) -> HashMap<String, Vec<DtsExport>> {
-        // Find relative imports that resolved to .ts/.tsx (not .fl)
-        let ts_imports = find_relative_ts_imports(program, resolved_imports, source_dir);
+        // Find imports that resolved to .ts/.tsx (not .fl)
+        let ts_imports =
+            find_relative_ts_imports(program, resolved_imports, source_dir, tsconfig_paths);
 
         let probe = generate_probe(program, resolved_imports, &ts_imports);
         if probe.is_empty() {
@@ -106,23 +108,33 @@ impl TsgoResolver {
     }
 }
 
-/// Find relative imports that don't resolve to `.fl` files but do resolve to
-/// `.ts`/`.tsx` files. Returns a map from the original import source (e.g.
-/// `"../utils/date"`) to its absolute file path.
+/// Find imports that don't resolve to `.fl` files but do resolve to
+/// `.ts`/`.tsx` files. Handles both relative imports and tsconfig path aliases.
 fn find_relative_ts_imports(
     program: &Program,
     resolved_imports: &HashMap<String, crate::resolve::ResolvedImports>,
     source_dir: &Path,
+    tsconfig_paths: &crate::resolve::TsconfigPaths,
 ) -> HashMap<String, PathBuf> {
     let mut ts_imports = HashMap::new();
     for item in &program.items {
         if let ItemKind::Import(decl) = &item.kind {
+            // Skip already-resolved .fl imports
+            if resolved_imports.contains_key(&decl.source) {
+                continue;
+            }
+
             let is_relative = decl.source.starts_with("./") || decl.source.starts_with("../");
-            if is_relative
-                && !resolved_imports.contains_key(&decl.source)
-                && let Some(ts_path) = crate::resolve::resolve_ts_path(source_dir, &decl.source)
-            {
-                ts_imports.insert(decl.source.clone(), ts_path);
+            if is_relative {
+                if let Some(ts_path) = crate::resolve::resolve_ts_path(source_dir, &decl.source) {
+                    ts_imports.insert(decl.source.clone(), ts_path);
+                }
+            } else if let Some(resolved_path) = tsconfig_paths.resolve(&decl.source) {
+                // Tsconfig path alias that resolved to a .ts/.tsx file
+                let ext = resolved_path.extension().and_then(|e| e.to_str());
+                if matches!(ext, Some("ts" | "tsx")) {
+                    ts_imports.insert(decl.source.clone(), resolved_path);
+                }
             }
         }
     }
@@ -1561,7 +1573,12 @@ const [input, setInput] = useState("")
         let probe = generate_probe(&program, &HashMap::new(), &HashMap::new());
         eprintln!("PROBE:\n{probe}");
         let mut resolver = TsgoResolver::new(&todo_app_dir);
-        let result = resolver.resolve_imports(&program, &HashMap::new(), Path::new("."));
+        let result = resolver.resolve_imports(
+            &program,
+            &HashMap::new(),
+            Path::new("."),
+            &crate::resolve::TsconfigPaths::default(),
+        );
 
         eprintln!("tsgo result keys: {:?}", result.keys().collect::<Vec<_>>());
         if let Some(react_exports) = result.get("react") {
@@ -1608,7 +1625,12 @@ const [filter, setFilter] = useState<Filter>(Filter.All)
         eprintln!("PROBE:\n{probe}");
 
         let mut resolver = TsgoResolver::new(&todo_app_dir);
-        let result = resolver.resolve_imports(&program, &HashMap::new(), Path::new("."));
+        let result = resolver.resolve_imports(
+            &program,
+            &HashMap::new(),
+            Path::new("."),
+            &crate::resolve::TsconfigPaths::default(),
+        );
 
         if let Some(react_exports) = result.get("react") {
             for export in react_exports {

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -220,10 +220,15 @@ impl FloeLsp {
                 let mut index = SymbolIndex::build(&program);
 
                 // Resolve .fl imports for cross-file type checking
-                let resolved_imports = if let Ok(source_path) = uri.to_file_path() {
-                    crate::resolve::resolve_imports(&source_path, &program)
+                let (resolved_imports, tsconfig_paths) = if let Ok(source_path) = uri.to_file_path()
+                {
+                    let source_dir = source_path.parent().unwrap_or(Path::new("."));
+                    let project_dir = find_project_dir(source_dir);
+                    let paths = crate::resolve::TsconfigPaths::from_project_dir(&project_dir);
+                    let resolved = crate::resolve::resolve_imports(&source_path, &program, &paths);
+                    (resolved, paths)
                 } else {
-                    Default::default()
+                    (Default::default(), Default::default())
                 };
 
                 // Resolve .d.ts imports BEFORE the checker so it gets npm type info
@@ -233,8 +238,6 @@ impl FloeLsp {
                     let source_dir = source_path.parent().unwrap_or(Path::new("."));
                     let project_dir = find_project_dir(source_dir);
                     let cache = self.dts_cache.read().await.clone();
-                    let tsconfig_paths =
-                        crate::resolve::TsconfigPaths::from_project_dir(&project_dir);
                     let (import_diags, new_cache) = enrich_from_imports(
                         &program,
                         &project_dir,
@@ -247,8 +250,12 @@ impl FloeLsp {
 
                     // Use tsgo for fully-resolved types — no fallback
                     let mut tsgo_resolver = crate::interop::TsgoResolver::new(&project_dir);
-                    dts_map =
-                        tsgo_resolver.resolve_imports(&program, &resolved_imports, source_dir);
+                    dts_map = tsgo_resolver.resolve_imports(
+                        &program,
+                        &resolved_imports,
+                        source_dir,
+                        &tsconfig_paths,
+                    );
 
                     if !new_cache.is_empty() {
                         let mut cache_write = self.dts_cache.write().await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,19 @@ use floe::diagnostic;
 use floe::find_project_dir;
 use floe::parser::Parser as ZsParser;
 use floe::parser::ast::Program;
-use floe::resolve::{self, ResolvedImports};
+use floe::resolve::{self, ResolvedImports, TsconfigPaths};
+
+/// Resolve the source directory, project directory, and tsconfig paths for a file.
+fn resolve_context(file_path: &Path) -> (PathBuf, PathBuf, TsconfigPaths) {
+    let source_dir = file_path
+        .parent()
+        .unwrap_or(Path::new("."))
+        .canonicalize()
+        .unwrap_or_else(|_| file_path.parent().unwrap_or(Path::new(".")).to_path_buf());
+    let project_dir = find_project_dir(&source_dir);
+    let tsconfig_paths = TsconfigPaths::from_project_dir(&project_dir);
+    (source_dir, project_dir, tsconfig_paths)
+}
 
 #[derive(Parser)]
 #[command(name = "floe", version, about = "The Floe compiler")]
@@ -114,16 +126,11 @@ fn compile_source(file_path: &Path, filename: &str, source: &str) -> Result<Comp
         anyhow::anyhow!("{rendered}")
     })?;
 
-    let resolved = resolve::resolve_imports(file_path, &program);
+    let (source_dir, project_dir, tsconfig_paths) = resolve_context(file_path);
+    let resolved = resolve::resolve_imports(file_path, &program, &tsconfig_paths);
 
-    let source_dir = file_path
-        .parent()
-        .unwrap_or(Path::new("."))
-        .canonicalize()
-        .unwrap_or_else(|_| file_path.parent().unwrap_or(Path::new(".")).to_path_buf());
-    let project_dir = find_project_dir(&source_dir);
     let mut tsgo_resolver = floe::interop::TsgoResolver::new(&project_dir);
-    let dts_map = tsgo_resolver.resolve_imports(&program, &resolved, &source_dir);
+    let dts_map = tsgo_resolver.resolve_imports(&program, &resolved, &source_dir, &tsconfig_paths);
 
     let checker = if dts_map.is_empty() {
         Checker::with_imports(resolved.clone())
@@ -298,16 +305,16 @@ fn cmd_check(path: &Path) -> Result<()> {
         let filename = file.to_string_lossy();
         match ZsParser::new(&source).parse_program() {
             Ok(program) => {
-                let resolved = resolve::resolve_imports(file, &program);
+                let (source_dir, project_dir, tsconfig_paths) = resolve_context(file);
+                let resolved = resolve::resolve_imports(file, &program, &tsconfig_paths);
 
-                let source_dir = file
-                    .parent()
-                    .unwrap_or(Path::new("."))
-                    .canonicalize()
-                    .unwrap_or_else(|_| file.parent().unwrap_or(Path::new(".")).to_path_buf());
-                let project_dir = find_project_dir(&source_dir);
                 let mut tsgo_resolver = floe::interop::TsgoResolver::new(&project_dir);
-                let dts_map = tsgo_resolver.resolve_imports(&program, &resolved, &source_dir);
+                let dts_map = tsgo_resolver.resolve_imports(
+                    &program,
+                    &resolved,
+                    &source_dir,
+                    &tsconfig_paths,
+                );
 
                 let check_diags = if dts_map.is_empty() {
                     Checker::with_imports(resolved).check(&program)
@@ -394,7 +401,8 @@ fn cmd_test(path: &Path) -> Result<()> {
 
     for (file, source, filename, program) in &mut test_files {
         // Resolve imports
-        let resolved = resolve::resolve_imports(file, program);
+        let (_source_dir, _project_dir, tsconfig_paths) = resolve_context(file);
+        let resolved = resolve::resolve_imports(file, program, &tsconfig_paths);
 
         // Type check
         let (check_diags, expr_types) = Checker::with_imports(resolved.clone()).check_full(program);

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -135,9 +135,13 @@ pub struct ResolvedImports {
 /// Resolve all relative imports for a given file.
 ///
 /// Returns a map from import source (e.g., `"./types"`) to its resolved symbols.
-/// Non-relative imports (npm packages) are skipped.
+/// Non-relative imports (npm packages) are skipped, unless they match a tsconfig path alias.
 /// Circular imports are handled by tracking visited files.
-pub fn resolve_imports(file_path: &Path, program: &Program) -> HashMap<String, ResolvedImports> {
+pub fn resolve_imports(
+    file_path: &Path,
+    program: &Program,
+    tsconfig_paths: &TsconfigPaths,
+) -> HashMap<String, ResolvedImports> {
     let mut results = HashMap::new();
     let mut visited = HashSet::new();
 
@@ -152,18 +156,36 @@ pub fn resolve_imports(file_path: &Path, program: &Program) -> HashMap<String, R
 
     for item in &program.items {
         if let ItemKind::Import(decl) = &item.kind {
-            // Skip npm/non-relative imports
-            if !decl.source.starts_with('.') {
-                continue;
-            }
-
             // Already resolved this source
             if results.contains_key(&decl.source) {
                 continue;
             }
 
-            if let Some(resolved) = resolve_single_import(base_dir, &decl.source, &mut visited) {
-                results.insert(decl.source.clone(), resolved);
+            let is_relative = decl.source.starts_with('.');
+
+            if is_relative {
+                if let Some(resolved) =
+                    resolve_single_import(base_dir, &decl.source, &mut visited, tsconfig_paths)
+                {
+                    results.insert(decl.source.clone(), resolved);
+                }
+            } else if let Some(resolved_path) = tsconfig_paths.resolve(&decl.source) {
+                // Tsconfig path alias that resolved to a .fl file
+                if resolved_path.extension().is_some_and(|e| e == "fl")
+                    && let Some(stem) = resolved_path.file_stem()
+                {
+                    let alias_dir = resolved_path.parent().unwrap_or(Path::new("."));
+                    let relative_source = format!("./{}", stem.to_string_lossy());
+                    if let Some(resolved) = resolve_single_import(
+                        alias_dir,
+                        &relative_source,
+                        &mut visited,
+                        tsconfig_paths,
+                    ) {
+                        results.insert(decl.source.clone(), resolved);
+                    }
+                }
+                // .ts/.tsx aliases are handled by tsgo, not here
             }
         }
     }
@@ -176,6 +198,7 @@ fn resolve_single_import(
     base_dir: &Path,
     source: &str,
     visited: &mut HashSet<PathBuf>,
+    tsconfig_paths: &TsconfigPaths,
 ) -> Option<ResolvedImports> {
     let resolved_path = resolve_path(base_dir, source)?;
 
@@ -196,7 +219,7 @@ fn resolve_single_import(
 
     // Also resolve transitive imports from the imported file
     let transitive_dir = resolved_path.parent().unwrap_or(Path::new("."));
-    let transitive = resolve_imports_inner(transitive_dir, &program, visited);
+    let transitive = resolve_imports_inner(transitive_dir, &program, visited, tsconfig_paths);
 
     // Collect transitive type decls, for-blocks, and trait decls so the checker can register them
     for resolved in transitive.values() {
@@ -313,6 +336,7 @@ fn resolve_imports_inner(
     base_dir: &Path,
     program: &Program,
     visited: &mut HashSet<PathBuf>,
+    tsconfig_paths: &TsconfigPaths,
 ) -> HashMap<String, ResolvedImports> {
     let mut results = HashMap::new();
 
@@ -324,7 +348,9 @@ fn resolve_imports_inner(
             if results.contains_key(&decl.source) {
                 continue;
             }
-            if let Some(resolved) = resolve_single_import(base_dir, &decl.source, visited) {
+            if let Some(resolved) =
+                resolve_single_import(base_dir, &decl.source, visited, tsconfig_paths)
+            {
                 results.insert(decl.source.clone(), resolved);
             }
         }
@@ -580,7 +606,7 @@ mod tests {
         let (_dir, base) = setup_files(&[("main.fl", "")]);
         let main_path = base.join("main.fl");
         let program = parse_program("");
-        let result = resolve_imports(&main_path, &program);
+        let result = resolve_imports(&main_path, &program, &TsconfigPaths::default());
         assert!(result.is_empty());
     }
 
@@ -589,7 +615,7 @@ mod tests {
         let (_dir, base) = setup_files(&[("main.fl", "const x = 1")]);
         let main_path = base.join("main.fl");
         let program = parse_program("const x = 1");
-        let result = resolve_imports(&main_path, &program);
+        let result = resolve_imports(&main_path, &program, &TsconfigPaths::default());
         assert!(result.is_empty());
     }
 
@@ -600,7 +626,7 @@ mod tests {
         let (_dir, base) = setup_files(&[("main.fl", "")]);
         let main_path = base.join("main.fl");
         let program = parse_program("import { useState } from \"react\"");
-        let result = resolve_imports(&main_path, &program);
+        let result = resolve_imports(&main_path, &program, &TsconfigPaths::default());
         assert!(result.is_empty());
     }
 
@@ -614,7 +640,7 @@ mod tests {
         ]);
         let main_path = base.join("main.fl");
         let program = parse_program("import { User } from \"./types\"");
-        let result = resolve_imports(&main_path, &program);
+        let result = resolve_imports(&main_path, &program, &TsconfigPaths::default());
         let resolved = result.get("./types").unwrap();
         assert_eq!(resolved.type_decls.len(), 1);
         assert_eq!(resolved.type_decls[0].name, "User");
@@ -626,7 +652,7 @@ mod tests {
             setup_files(&[("main.fl", ""), ("helpers.fl", "export fn greet() { 1 }")]);
         let main_path = base.join("main.fl");
         let program = parse_program("import { greet } from \"./helpers\"");
-        let result = resolve_imports(&main_path, &program);
+        let result = resolve_imports(&main_path, &program, &TsconfigPaths::default());
         let resolved = result.get("./helpers").unwrap();
         assert_eq!(resolved.function_decls.len(), 1);
         assert_eq!(resolved.function_decls[0].name, "greet");
@@ -637,7 +663,7 @@ mod tests {
         let (_dir, base) = setup_files(&[("main.fl", ""), ("config.fl", "export const MAX = 100")]);
         let main_path = base.join("main.fl");
         let program = parse_program("import { MAX } from \"./config\"");
-        let result = resolve_imports(&main_path, &program);
+        let result = resolve_imports(&main_path, &program, &TsconfigPaths::default());
         let resolved = result.get("./config").unwrap();
         assert_eq!(resolved.const_names, vec!["MAX".to_string()]);
     }
@@ -655,7 +681,7 @@ mod tests {
         ]);
         let main_path = base.join("main.fl");
         let program = parse_program("import { Secret } from \"./internal\"");
-        let result = resolve_imports(&main_path, &program);
+        let result = resolve_imports(&main_path, &program, &TsconfigPaths::default());
         let resolved = result.get("./internal").unwrap();
         assert!(resolved.type_decls.is_empty());
         assert!(resolved.function_decls.is_empty());
@@ -675,7 +701,7 @@ mod tests {
         ]);
         let main_path = base.join("main.fl");
         let program = parse_program("import { A } from \"./lib\"\nimport { b } from \"./lib\"");
-        let result = resolve_imports(&main_path, &program);
+        let result = resolve_imports(&main_path, &program, &TsconfigPaths::default());
         // Should only resolve once
         assert_eq!(result.len(), 1);
         let resolved = result.get("./lib").unwrap();
@@ -696,7 +722,7 @@ mod tests {
         ]);
         let main_path = base.join("main.fl");
         let program = parse_program("import { for User } from \"./ext\"");
-        let result = resolve_imports(&main_path, &program);
+        let result = resolve_imports(&main_path, &program, &TsconfigPaths::default());
         let resolved = result.get("./ext").unwrap();
         // The exported for-block function should be present
         assert!(!resolved.for_blocks.is_empty());
@@ -710,7 +736,7 @@ mod tests {
         let (_dir, base) = setup_files(&[("main.fl", "")]);
         let main_path = base.join("main.fl");
         let program = parse_program("import { foo } from \"./missing\"");
-        let result = resolve_imports(&main_path, &program);
+        let result = resolve_imports(&main_path, &program, &TsconfigPaths::default());
         // Missing file should not appear in results
         assert!(!result.contains_key("./missing"));
     }
@@ -722,7 +748,7 @@ mod tests {
         let (_dir, base) = setup_files(&[("sub/main.fl", ""), ("lib.fl", "export const X = 1")]);
         let main_path = base.join("sub/main.fl");
         let program = parse_program("import { X } from \"../lib\"");
-        let result = resolve_imports(&main_path, &program);
+        let result = resolve_imports(&main_path, &program, &TsconfigPaths::default());
         assert!(result.contains_key("../lib"));
     }
 
@@ -737,7 +763,7 @@ mod tests {
         ]);
         let main_path = base.join("main.fl");
         let program = parse_program("import { Display } from \"./traits\"");
-        let result = resolve_imports(&main_path, &program);
+        let result = resolve_imports(&main_path, &program, &TsconfigPaths::default());
         let resolved = result.get("./traits").unwrap();
         assert_eq!(resolved.trait_decls.len(), 1);
         assert_eq!(resolved.trait_decls[0].name, "Display");
@@ -751,7 +777,7 @@ mod tests {
         ]);
         let main_path = base.join("main.fl");
         let program = parse_program("import { Button } from \"./components\"");
-        let result = resolve_imports(&main_path, &program);
+        let result = resolve_imports(&main_path, &program, &TsconfigPaths::default());
         let resolved = result.get("./components").unwrap();
         assert_eq!(resolved.function_decls.len(), 1);
     }
@@ -771,7 +797,7 @@ mod tests {
         ]);
         let main_path = base.join("main.fl");
         let program = parse_program("import { Product } from \"./types\"");
-        let result = resolve_imports(&main_path, &program);
+        let result = resolve_imports(&main_path, &program, &TsconfigPaths::default());
         let resolved = result.get("./types").unwrap();
 
         // Product should be present
@@ -819,7 +845,7 @@ mod tests {
         ]);
         let main_path = base.join("main.fl");
         let program = parse_program("import { C } from \"./types\"");
-        let result = resolve_imports(&main_path, &program);
+        let result = resolve_imports(&main_path, &program, &TsconfigPaths::default());
         let resolved = result.get("./types").unwrap();
 
         let c_decl = &resolved.type_decls[0];


### PR DESCRIPTION
closes #548

## Summary
- **Thread `TsconfigPaths` through the entire import resolution pipeline** — `resolve_imports`, `resolve_single_import`, `TsgoResolver::resolve_imports`, and `find_relative_ts_imports`
- **`.fl` imports matching path aliases** (e.g. `#/types`) resolve via the alias, same as relative imports
- **`.ts/.tsx` imports matching path aliases** are treated as local TS imports in tsgo (not npm packages), so they get proper type resolution
- **All entry points updated** — `floe build`, `floe check`, `floe test`, and the LSP all use tsconfig paths
- The existing `TsconfigPaths` struct (parsing `tsconfig.json` paths + baseUrl) was already implemented but not wired into the compiler pipeline — this PR connects it

## Test plan
- [x] `cargo fmt && cargo clippy -- -D warnings && RUSTFLAGS="-D warnings" cargo test` — all pass (981 tests)
- [x] `floe check/build` on example apps — all pass
- [ ] CI
- [ ] Manual test with a project using `#/*` or `@/*` path aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)