### PR TITLE
fix: [#562] Allow concrete values to be assignable to Option<T>

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -2091,6 +2091,8 @@ impl Checker {
                 true // None (Option<Unknown>) is compatible with any Option<T>
             }
             (Type::Option(a), Type::Option(b)) => self.types_compatible(a, b),
+            // A concrete value T is assignable to Option<T> (implicit Some wrapping)
+            (Type::Option(inner), actual) => self.types_compatible(inner, actual),
             (Type::Settable(_), Type::Settable(b)) if matches!(**b, Type::Unknown) => {
                 true // Clear/Unchanged (Settable<Unknown>) is compatible with any Settable<T>
             }

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -3643,3 +3643,35 @@ fn greet(name: string) -> string { `Hello, ${name}!` }",
         "typeof forward ref to local fn should error: {diags:?}"
     );
 }
+
+// ── Boundary type compatibility ──────────────────────────
+
+#[test]
+fn value_assignable_to_option() {
+    // A concrete value should be assignable to Option<T> (implicit Some wrapping)
+    let diags = check("const x: Option<number> = 42");
+    assert!(
+        !has_error(&diags, "E001"),
+        "concrete value should be assignable to Option<T>, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn array_assignable_to_option_array() {
+    // An array should be assignable to Option<Array<T>>
+    let diags = check("const x: Option<Array<number>> = [1, 2, 3]");
+    assert!(
+        !has_error(&diags, "E001"),
+        "array should be assignable to Option<Array<T>>, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
closes #562

## Summary
- A concrete value `T` is now compatible with `Option<T>` in type checking (implicit Some wrapping)
- Fixes false positives like `useEffect(() => {...}, [])` where `[]` (Array) couldn't match `Option<DependencyList>`
- Added 2 regression tests: value-to-Option and array-to-Option<Array>

**Before:** `argument 2 to useEffect: expected Option<DependencyList>, found Array<unknown>`
**After:** No error (array is assignable to Option<array-like>)

## Test plan
- [x] `cargo fmt && cargo clippy -- -D warnings && RUSTFLAGS="-D warnings" cargo test` — 989 tests pass
- [x] `floe check/build` on example apps — all pass
- [x] Verified useEffect deps error gone on real project
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)