### PR TITLE
feat: [#574] Log version, executable path, and project dir on LSP startup

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -7,8 +7,8 @@ mod symbols;
 #[cfg(test)]
 mod tests;
 
-use std::collections::HashMap;
-use std::path::Path;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
@@ -189,6 +189,8 @@ pub struct FloeLsp {
     documents: Arc<RwLock<HashMap<Url, Document>>>,
     /// Cache of resolved .d.ts exports per module specifier
     dts_cache: Arc<RwLock<HashMap<String, Vec<crate::interop::DtsExport>>>>,
+    /// Project directories we've already logged startup info for
+    logged_projects: Arc<RwLock<HashSet<PathBuf>>>,
 }
 
 impl FloeLsp {
@@ -197,7 +199,56 @@ impl FloeLsp {
             client,
             documents: Arc::new(RwLock::new(HashMap::new())),
             dts_cache: Arc::new(RwLock::new(HashMap::new())),
+            logged_projects: Arc::new(RwLock::new(HashSet::new())),
         }
+    }
+
+    /// Log project directory, tsconfig, and path alias info (once per project).
+    async fn log_project_info(
+        &self,
+        project_dir: &Path,
+        tsconfig_paths: &crate::resolve::TsconfigPaths,
+    ) {
+        let canonical = project_dir.to_path_buf();
+        {
+            let logged = self.logged_projects.read().await;
+            if logged.contains(&canonical) {
+                return;
+            }
+        }
+        self.logged_projects.write().await.insert(canonical);
+
+        self.client
+            .log_message(
+                MessageType::INFO,
+                format!("Project directory: {}", project_dir.display()),
+            )
+            .await;
+
+        let parsed = crate::resolve::ParsedTsconfig::from_project_dir(project_dir);
+        match parsed {
+            Some(ref ts) => {
+                self.client
+                    .log_message(
+                        MessageType::INFO,
+                        format!("tsconfig.json: {}", ts.tsconfig_path.display()),
+                    )
+                    .await;
+            }
+            None => {
+                self.client
+                    .log_message(MessageType::INFO, "tsconfig.json: not found")
+                    .await;
+            }
+        }
+
+        let alias_count = tsconfig_paths.mappings.len();
+        self.client
+            .log_message(
+                MessageType::INFO,
+                format!("Path alias mappings: {alias_count}"),
+            )
+            .await;
     }
 
     /// Parse and type-check a document, update symbol index, publish diagnostics.
@@ -225,6 +276,10 @@ impl FloeLsp {
                     let source_dir = source_path.parent().unwrap_or(Path::new("."));
                     let project_dir = find_project_dir(source_dir);
                     let paths = crate::resolve::TsconfigPaths::from_project_dir(&project_dir);
+
+                    // Log project info once per project directory
+                    self.log_project_info(&project_dir, &paths).await;
+
                     let resolved = crate::resolve::resolve_imports(&source_path, &program, &paths);
                     (resolved, paths)
                 } else {

--- a/src/lsp/handlers.rs
+++ b/src/lsp/handlers.rs
@@ -50,8 +50,16 @@ impl LanguageServer for FloeLsp {
     }
 
     async fn initialized(&self, _: InitializedParams) {
+        let version = env!("CARGO_PKG_VERSION");
+        let exe_path = std::env::current_exe()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| "unknown".to_string());
+
         self.client
-            .log_message(MessageType::INFO, "Floe LSP initialized")
+            .log_message(
+                MessageType::INFO,
+                format!("Floe LSP initialized (v{version}, {exe_path})"),
+            )
             .await;
     }
 


### PR DESCRIPTION
closes #574

## Summary

- Logs Floe version and executable path on LSP initialization (`initialized`)
- Logs project directory, tsconfig.json path, and path alias mapping count once per project when the first document in that project is opened

## Example output

```
Floe LSP initialized (v0.1.17, /usr/local/bin/floe)
Project directory: /home/user/my-app
tsconfig.json: /home/user/my-app/tsconfig.json
Path alias mappings: 2
```

## Test plan

- [ ] Open a Floe file in VS Code and check the Floe LSP output panel shows version, exe path, project dir, tsconfig info
- [ ] Open a project without tsconfig.json and verify it logs "tsconfig.json: not found"
- [ ] Open files from two different projects and verify each project's info is logged once

🤖 Generated with [Claude Code](https://claude.com/claude-code)