### PR TITLE
fix: [#580] Await on Promise with union return type and foreign type member access

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1128,6 +1128,83 @@ impl Checker {
         }
     }
 
+    /// Parse a type from a display name string (e.g. "Session | null" -> Option<Session>).
+    /// Used to reconstruct structured types from flattened Promise<T> inner strings.
+    fn parse_type_from_display_name(&self, s: &str) -> Type {
+        // Split at top-level " | " (respecting angle bracket depth)
+        let parts = Self::split_union_display_name(s);
+        if parts.len() > 1 {
+            let has_null = parts.iter().any(|p| *p == "null" || *p == "undefined");
+            let non_null: Vec<&str> = parts
+                .iter()
+                .filter(|p| **p != "null" && **p != "undefined")
+                .copied()
+                .collect();
+
+            let inner = if non_null.len() == 1 {
+                self.parse_type_from_display_name(non_null[0])
+            } else if non_null.is_empty() {
+                Type::Unit
+            } else {
+                Type::Unknown
+            };
+
+            return if has_null {
+                Type::Option(Box::new(inner))
+            } else {
+                inner
+            };
+        }
+
+        // Primitives
+        match s {
+            "number" => Type::Number,
+            "string" => Type::String,
+            "boolean" => Type::Bool,
+            "void" => Type::Unit,
+            "unknown" => Type::Unknown,
+            "null" | "undefined" => Type::Undefined,
+            _ => {
+                // Check for Array<T>
+                if let Some(inner) = s.strip_prefix("Array<").and_then(|s| s.strip_suffix('>')) {
+                    return Type::Array(Box::new(self.parse_type_from_display_name(inner)));
+                }
+                // Named type (foreign or local)
+                Type::Named(s.to_string())
+            }
+        }
+    }
+
+    /// Split a type display name at top-level ` | ` delimiters,
+    /// respecting `<>` nesting so `Map<A | B, C> | null` splits correctly.
+    fn split_union_display_name(s: &str) -> Vec<&str> {
+        let mut parts = Vec::new();
+        let mut depth = 0i32;
+        let mut start = 0;
+        let bytes = s.as_bytes();
+        let len = bytes.len();
+        let mut i = 0;
+        while i < len {
+            match bytes[i] {
+                b'<' | b'(' => depth += 1,
+                b'>' | b')' => depth -= 1,
+                b'|' if depth == 0
+                    && i > 0
+                    && bytes[i - 1] == b' '
+                    && i + 1 < len
+                    && bytes[i + 1] == b' ' =>
+                {
+                    parts.push(s[start..i - 1].trim());
+                    start = i + 2;
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+        parts.push(s[start..].trim());
+        parts
+    }
+
     // ── Item Checking ────────────────────────────────────────────
 
     fn check_item(&mut self, item: &Item) {

--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -312,11 +312,11 @@ impl Checker {
                 let ty = self.check_expr(inner);
                 // Unwrap Promise<T> to T
                 if let Type::Named(name) = &ty
-                    && let Some(inner_name) = name
+                    && let Some(inner_str) = name
                         .strip_prefix("Promise<")
                         .and_then(|s| s.strip_suffix('>'))
                 {
-                    return self.resolve_named_type(inner_name, &[], expr.span);
+                    return self.parse_type_from_display_name(inner_str);
                 }
                 // If not a Promise, pass through (e.g. await on a non-async value)
                 ty
@@ -1628,10 +1628,13 @@ impl Checker {
             _ => {}
         }
 
-        // Named type that couldn't be resolved to a concrete type definition.
-        // This happens when an imported type has no .d.ts resolution — field access
-        // cannot be validated, so we error rather than silently accepting any field.
+        // Named type without a local type definition is foreign (from npm).
+        // Allow member access silently — we can't validate fields but
+        // TypeScript already checked them at the source.
         if let Type::Named(name) = obj_ty {
+            if self.env.lookup_type(name).is_none() {
+                return Type::Unknown;
+            }
             self.diagnostics.push(
                 Diagnostic::error(
                     format!("cannot access `.{field}` on unresolved type `{name}`"),

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -3426,18 +3426,19 @@ for AccentRow {
 }
 "#,
     );
-    // With no import resolution, AccentRow is unknown.
-    // self.id and self.entryId should error because we can't validate them.
+    // With no import resolution, AccentRow is a foreign Named type.
+    // Member access on foreign types is allowed (returns unknown) since
+    // we can't validate fields but TypeScript would have checked them.
     let errors: Vec<_> = diags
         .iter()
         .filter(|d| d.severity == Severity::Error)
         .map(|d| format!("{}: {}", d.code.as_deref().unwrap_or(""), d.message))
         .collect();
     assert!(
-        errors
+        !errors
             .iter()
-            .any(|e| e.contains("E020") || e.contains("cannot access")),
-        "field access on unresolved imported type should error, got: {:?}",
+            .any(|e| e.contains("E020") && e.contains("AccentRow")),
+        "foreign type member access should not error, got: {:?}",
         errors
     );
 }


### PR DESCRIPTION
closes #580
closes #581

## Summary
- **Fix await on Promise<T | null>**: Parse the inner type string from `Promise<Session | null>` back into a structured type (`Option<Session>`), handling unions with null/undefined correctly. Previously, `await getSession()` produced `unknown` because `"Session | null"` couldn't be resolved as a named type.
- **Allow member access on foreign Named types**: Types from npm imports (like `Subscription`) now allow `.field` access without erroring, returning `unknown`. TypeScript already validated these fields at the source.

**Before:** `auth-provider.fl` had 3 errors (unknown type, argument mismatch, unresolved member)
**After:** Zero errors

## Test plan
- [x] `cargo fmt && cargo clippy -- -D warnings && RUSTFLAGS="-D warnings" cargo test` — 997 tests pass
- [x] `floe check` on example apps — all pass
- [x] `auth-provider.fl` — zero errors
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)