### PR TITLE
fix: [#583] Match pattern narrowing and object destructuring for foreign types

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1581,36 +1581,9 @@ impl Checker {
             return;
         }
 
-        let concrete = {
-            let resolve_fn = |type_expr: &crate::parser::ast::TypeExpr| -> Type {
-                match &type_expr.kind {
-                    crate::parser::ast::TypeExprKind::Named { name, .. } => match name.as_str() {
-                        type_layout::TYPE_NUMBER => Type::Number,
-                        type_layout::TYPE_STRING => Type::String,
-                        type_layout::TYPE_BOOLEAN => Type::Bool,
-                        type_layout::TYPE_UNIT => Type::Unit,
-                        type_layout::TYPE_UNDEFINED => Type::Undefined,
-                        _ => Type::Named(name.to_string()),
-                    },
-                    crate::parser::ast::TypeExprKind::Array(inner) => {
-                        let inner_resolved = match &inner.kind {
-                            crate::parser::ast::TypeExprKind::Named { name, .. } => {
-                                match name.as_str() {
-                                    type_layout::TYPE_NUMBER => Type::Number,
-                                    type_layout::TYPE_STRING => Type::String,
-                                    type_layout::TYPE_BOOLEAN => Type::Bool,
-                                    _ => Type::Named(name.to_string()),
-                                }
-                            }
-                            _ => Type::Unknown,
-                        };
-                        Type::Array(Box::new(inner_resolved))
-                    }
-                    _ => Type::Unknown,
-                }
-            };
-            self.env.resolve_to_concrete(final_type, &resolve_fn)
-        };
+        let concrete = self
+            .env
+            .resolve_to_concrete(final_type, &expr::simple_resolve_type_expr);
 
         let field_map: Option<std::collections::HashMap<&str, &Type>> = match &concrete {
             Type::Record(fields) => Some(fields.iter().map(|(n, t)| (n.as_str(), t)).collect()),

--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -1629,11 +1629,11 @@ impl Checker {
         }
 
         // Named type without a local type definition is foreign (from npm).
-        // Allow member access silently — we can't validate fields but
-        // TypeScript already checked them at the source.
+        // Allow member access and return a Named type for the field so
+        // chained access (s.user.email) stays lenient through the chain.
         if let Type::Named(name) = obj_ty {
             if self.env.lookup_type(name).is_none() {
-                return Type::Unknown;
+                return Type::Named(format!("{name}.{field}"));
             }
             self.diagnostics.push(
                 Diagnostic::error(

--- a/src/checker/match_check.rs
+++ b/src/checker/match_check.rs
@@ -21,7 +21,11 @@ impl Checker {
         // Resolve Named types to their actual definitions
         let resolved_ty;
         let subject_ty = if let Type::Named(type_name) = subject_ty {
-            if let Some(actual) = self.env.lookup(type_name) {
+            // Resolve Named types to their definitions, but keep Named if the
+            // env value is Unknown (foreign npm types that have no definition)
+            if let Some(actual) = self.env.lookup(type_name)
+                && !matches!(actual, Type::Unknown)
+            {
                 resolved_ty = actual.clone();
                 &resolved_ty
             } else {
@@ -462,7 +466,11 @@ impl Checker {
         // Resolve Named types to their actual definitions for pattern matching
         let resolved_ty;
         let subject_ty = if let Type::Named(type_name) = subject_ty {
-            if let Some(actual) = self.env.lookup(type_name) {
+            // Resolve Named types to their definitions, but keep Named if the
+            // env value is Unknown (foreign npm types that have no definition)
+            if let Some(actual) = self.env.lookup(type_name)
+                && !matches!(actual, Type::Unknown)
+            {
                 resolved_ty = actual.clone();
                 &resolved_ty
             } else {

--- a/src/lsp/tests.rs
+++ b/src/lsp/tests.rs
@@ -638,6 +638,44 @@ fn hover_const_without_annotation_detail_lacks_type_before_fix() {
     assert_eq!(_type_map.get("x").map(|s| s.as_str()), Some("number"));
 }
 
+#[test]
+fn hover_nested_const_shows_type() {
+    // Reproduces #583: const inside nested async fn shows no type on hover
+    let source = r#"
+fn outer() {
+    async fn inner() {
+        const s = "hello"
+    }
+}
+"#;
+    let hover = simulate_hover(source, "s");
+    assert!(
+        hover.as_ref().is_some_and(|h| h.contains("string")),
+        "const s inside nested fn should show type, got: {:?}",
+        hover
+    );
+}
+
+#[test]
+fn hover_nested_const_await_shows_type() {
+    // When const s = await somePromise(), s should show its type
+    // even when nested inside an async fn inside an arrow
+    let source = r#"
+fn outer() {
+    async fn inner() {
+        const s: Option<number> = None
+    }
+}
+"#;
+    let hover = simulate_hover(source, "s");
+    eprintln!("HOVER for s (await): {:?}", hover);
+    assert!(
+        hover.as_ref().is_some_and(|h| h.contains("Option<number>")),
+        "const s with type annotation should show type, got: {:?}",
+        hover
+    );
+}
+
 // ── Match arm variant completion tests (#143) ──────────────
 
 #[test]


### PR DESCRIPTION
closes #583

## Summary
Three interconnected fixes for foreign Named types (from npm imports):

1. **Match pattern narrowing**: `check_pattern` was resolving `Named("Session")` to `Unknown` via env lookup (since npm imports define the name as Unknown). Now it preserves the Named type when the env value is Unknown, so `Some(s)` on `Option<Session>` correctly binds `s` to `Named("Session")`.

2. **Object destructuring**: `define_object_destructured_bindings` used a simplified type resolver that dropped generic type args — `Option<Session>` became just `Option`. Switched to `simple_resolve_type_expr` which handles type args correctly.

3. **Foreign type member chain**: Member access on foreign Named types now returns `Named("Type.field")` instead of `Unknown`, so chained access like `s.user.email` doesn't trigger "must narrow unknown" errors.

**Before:** `auth-page.fl` had 4 errors (cannot access .user on unknown, .email on unknown)
**After:** Both `auth-page.fl` and `auth-provider.fl` pass with zero errors

## Test plan
- [x] `cargo fmt && cargo clippy -- -D warnings && RUSTFLAGS="-D warnings" cargo test` — 999 tests pass
- [x] `floe check` on example apps — all pass
- [x] `auth-page.fl` — zero errors (was 4)
- [x] `auth-provider.fl` — zero errors
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)