### PR TITLE
fix: [#595] Lexer does not support unicode escape sequences in strings

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -464,14 +464,44 @@ impl<'src> Lexer<'src> {
     /// Process a common escape sequence byte, returning the unescaped char.
     /// Returns `None` for context-specific escapes (e.g. `"`, `` ` ``, `$`),
     /// which must be handled at the call site.
-    fn process_escape(&self, escaped: u8) -> Option<char> {
+    fn process_escape(&mut self, escaped: u8) -> Option<char> {
         match escaped {
             b'n' => Some('\n'),
             b't' => Some('\t'),
             b'r' => Some('\r'),
             b'\\' => Some('\\'),
             b'0' => Some('\0'),
+            b'u' => self.process_unicode_escape(),
             _ => None,
+        }
+    }
+
+    /// Process a `\uXXXX` or `\u{XXXX}` unicode escape sequence.
+    /// The `u` has already been consumed. Returns `None` if the sequence is invalid.
+    fn process_unicode_escape(&mut self) -> Option<char> {
+        if self.peek() == Some(b'{') {
+            // \u{XXXX} braced form — 1 to 6 hex digits
+            self.advance(); // consume '{'
+            let start = self.pos;
+            while !self.is_at_end() && self.peek() != Some(b'}') {
+                self.advance();
+            }
+            let hex = &self.source[start..self.pos];
+            if !self.is_at_end() {
+                self.advance(); // consume '}'
+            }
+            u32::from_str_radix(hex, 16).ok().and_then(char::from_u32)
+        } else {
+            // \uXXXX fixed 4-digit form
+            let start = self.pos;
+            for _ in 0..4 {
+                if self.is_at_end() {
+                    return None;
+                }
+                self.advance();
+            }
+            let hex = &self.source[start..self.pos];
+            u32::from_str_radix(hex, 16).ok().and_then(char::from_u32)
         }
     }
 

--- a/src/lower.rs
+++ b/src/lower.rs
@@ -1084,6 +1084,17 @@ impl<'src> Lowerer<'src> {
                     b'0' => current_raw.push('\0'),
                     b'`' => current_raw.push('`'),
                     b'$' => current_raw.push('$'),
+                    b'u' => {
+                        if let Some((ch, consumed)) =
+                            Self::parse_unicode_escape_bytes(&inner[i + 1..])
+                        {
+                            current_raw.push(ch);
+                            i += consumed;
+                        } else {
+                            current_raw.push('\\');
+                            current_raw.push('u');
+                        }
+                    }
                     c => {
                         current_raw.push('\\');
                         current_raw.push(c as char);
@@ -1335,6 +1346,14 @@ impl<'src> Lowerer<'src> {
                         Some('\\') => result.push('\\'),
                         Some('"') => result.push('"'),
                         Some('0') => result.push('\0'),
+                        Some('u') => {
+                            if let Some(ch) = Self::parse_unicode_escape(&mut chars) {
+                                result.push(ch);
+                            } else {
+                                result.push('\\');
+                                result.push('u');
+                            }
+                        }
                         Some(c) => {
                             result.push('\\');
                             result.push(c);
@@ -1348,6 +1367,44 @@ impl<'src> Lowerer<'src> {
             result
         } else {
             text.to_string()
+        }
+    }
+
+    /// Parse a `\uXXXX` or `\u{XXXX}` unicode escape from a char iterator.
+    /// The `\u` has already been consumed.
+    fn parse_unicode_escape(chars: &mut std::str::Chars<'_>) -> Option<char> {
+        let mut hex = String::new();
+        if chars.as_str().starts_with('{') {
+            chars.next(); // consume '{'
+            for ch in chars.by_ref() {
+                if ch == '}' {
+                    break;
+                }
+                hex.push(ch);
+            }
+        } else {
+            for _ in 0..4 {
+                hex.push(chars.next()?);
+            }
+        }
+        u32::from_str_radix(&hex, 16).ok().and_then(char::from_u32)
+    }
+
+    /// Parse a `\uXXXX` or `\u{XXXX}` unicode escape from a byte slice.
+    /// The `\u` has already been consumed; `rest` starts after the `u`.
+    /// Returns the parsed char and the number of additional bytes consumed.
+    fn parse_unicode_escape_bytes(rest: &str) -> Option<(char, usize)> {
+        if rest.starts_with('{') {
+            let end = rest.find('}')?;
+            let hex = &rest[1..end];
+            let ch = u32::from_str_radix(hex, 16).ok().and_then(char::from_u32)?;
+            Some((ch, end + 1)) // consume through '}'
+        } else if rest.len() >= 4 {
+            let hex = &rest[..4];
+            let ch = u32::from_str_radix(hex, 16).ok().and_then(char::from_u32)?;
+            Some((ch, 4)) // consumed 4 hex digits
+        } else {
+            None
         }
     }
 

--- a/tests/fixtures/unicode_escapes.fl
+++ b/tests/fixtures/unicode_escapes.fl
@@ -1,0 +1,15 @@
+fn nbsp() -> string {
+    "\u00A0"
+}
+
+fn smiley() -> string {
+    "\u{1F600}"
+}
+
+fn mixed() -> string {
+    "hello\u0020world"
+}
+
+fn in_template() -> string {
+    `before\u00A0after`
+}

--- a/tests/snapshot_codegen.rs
+++ b/tests/snapshot_codegen.rs
@@ -190,3 +190,9 @@ fn snapshot_pipe_unwrap() {
     let output = compile_fixture("pipe_unwrap");
     insta::assert_snapshot!(output);
 }
+
+#[test]
+fn snapshot_unicode_escapes() {
+    let output = compile_fixture("unicode_escapes");
+    insta::assert_snapshot!(output);
+}

--- a/tests/snapshots/snapshot_codegen__snapshot_unicode_escapes.snap
+++ b/tests/snapshots/snapshot_codegen__snapshot_unicode_escapes.snap
@@ -1,0 +1,19 @@
+---
+source: tests/snapshot_codegen.rs
+expression: output
+---
+function nbsp(): string {
+  return " ";
+}
+
+function smiley(): string {
+  return "😀";
+}
+
+function mixed(): string {
+  return "hello world";
+}
+
+function in_template(): string {
+  return `before after`;
+}


### PR DESCRIPTION
closes #595

## Summary
- Add `\uXXXX` and `\u{XXXXX}` unicode escape handling to the lexer (`process_escape`), lowerer (`unquote_string`), and template literal processing
- Previously `"\u00A0"` compiled to literal `\\u00A0` in the TypeScript output instead of the actual non-breaking space character
- Fixes all three escape processing sites: lexer (for tokenization), `unquote_string` (for regular string literals in CST->AST lowering), and `lower_template_literal` (for template literals)

## Test plan
- [x] Added `unicode_escapes.fl` fixture with snapshot test covering `\uXXXX`, `\u{XXXXX}`, mixed, and template literal cases
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] Floe example quality gate (fmt/check/build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)