### PR TITLE
fix: [#602] [#603] Pipe map lambda inference and for-block import of foreign types

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1278,11 +1278,19 @@ impl Checker {
 
     /// Register for-block functions from an imported module without checking bodies.
     fn check_for_block_imported_with_source(&mut self, block: &ForBlock, source: &str) {
-        let for_type = self.resolve_type(&block.type_name);
         let type_name = match &block.type_name.kind {
             TypeExprKind::Named { name, .. } => name.clone(),
             _ => String::new(),
         };
+
+        // Ensure the for-block's target type is defined before resolving.
+        // The type may be foreign (from npm/TS, not defined in Floe).
+        if !type_name.is_empty() && self.env.lookup(&type_name).is_none() {
+            self.env
+                .define(&type_name, Type::Foreign(type_name.clone()));
+        }
+
+        let for_type = self.resolve_type(&block.type_name);
 
         for func in &block.functions {
             let return_type = func

--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -1297,10 +1297,6 @@ impl Checker {
         left_ty: &Type,
         right: &Expr,
     ) -> Type {
-        let ret = match (&stdlib_fn.return_type, left_ty) {
-            (Type::Array(_), Type::Array(elem)) => Type::Array(elem.clone()),
-            _ => stdlib_fn.return_type.clone(),
-        };
         if let Some(first_param) = stdlib_fn.params.first()
             && !self.types_compatible(first_param, left_ty)
         {
@@ -1319,23 +1315,54 @@ impl Checker {
         }
         if let Type::Array(elem) = left_ty {
             self.ctx.lambda_param_hint = Some((**elem).clone());
+        } else if let Type::Option(inner) = left_ty {
+            self.ctx.lambda_param_hint = Some((**inner).clone());
         }
-        self.check_pipe_right_args(right);
+
+        // Check lambda args and capture return type for generic inference
+        let lambda_return = self.check_pipe_right_args_with_return(right);
         self.ctx.lambda_param_hint = None;
-        ret
+
+        // Resolve return type: if the stdlib fn's return type uses a different
+        // type var than the input (e.g. map: Array<T> -> Array<U>), infer U
+        // from the lambda's actual return type.
+        let infer_from_lambda = lambda_return.is_some()
+            && match (&stdlib_fn.return_type, stdlib_fn.params.first()) {
+                (Type::Array(ret_elem), Some(Type::Array(in_elem))) => ret_elem != in_elem,
+                (Type::Option(ret_elem), Some(Type::Option(in_elem))) => ret_elem != in_elem,
+                _ => false,
+            };
+        match (&stdlib_fn.return_type, left_ty) {
+            (Type::Array(_), _) if infer_from_lambda => {
+                Type::Array(Box::new(lambda_return.unwrap()))
+            }
+            (Type::Array(_), Type::Array(elem)) => Type::Array(elem.clone()),
+            (Type::Option(_), _) if infer_from_lambda => {
+                Type::Option(Box::new(lambda_return.unwrap()))
+            }
+            (Type::Option(_), Type::Option(inner)) => Type::Option(inner.clone()),
+            _ => stdlib_fn.return_type.clone(),
+        }
     }
 
-    /// Check arguments in the right side of a pipe without checking the callee identifier.
-    fn check_pipe_right_args(&mut self, right: &Expr) {
+    /// Check arguments in the right side of a pipe and return the lambda's return type.
+    fn check_pipe_right_args_with_return(&mut self, right: &Expr) -> Option<Type> {
+        let mut lambda_return = None;
         if let ExprKind::Call { args, .. } = &right.kind {
-            for arg in args {
+            for (i, arg) in args.iter().enumerate() {
                 match arg {
                     Arg::Positional(e) | Arg::Named { value: e, .. } => {
-                        self.check_expr(e);
+                        let ty = self.check_expr(e);
+                        if i == 0
+                            && let Type::Function { return_type, .. } = &ty
+                        {
+                            lambda_return = Some(*return_type.clone());
+                        }
                     }
                 }
             }
         }
+        lambda_return
     }
 
     /// Collect single-letter type param names used in a function signature.


### PR DESCRIPTION
closes #602
closes #603

## Summary

### Pipe map lambda return type inference (#602)
- `validate_stdlib_pipe_call` now checks lambda args and captures the return type
- For functions where the return type uses a different type var than the input (e.g. `map: Array<T> -> Array<U>` but NOT `filter: Array<T> -> Array<T>`), the return element type is inferred from the lambda
- `rows |> map((a) => a |> toModel)` now correctly gives `Array<Accent>` instead of `Array<AccentRow>`

### For-block import of foreign types (#603)
- `import { for AccentRow } from "./accent"` now works when `AccentRow` is a foreign type
- `check_for_block_imported_with_source` pre-registers the type as `Foreign` if it's not already in scope

**Before:** `entry.fl` had 2 errors (unknown type AccentRow, wrong array element type)
**After:** All four user files pass with zero errors

## Test plan
- [x] All 1000 tests pass
- [x] Example apps check clean
- [x] entry.fl, accent.fl, auth-provider.fl, auth-page.fl — zero errors
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)