### PR TITLE
fix: [#612] Probe inlining drops intermediate member access in chained calls

### DIFF
--- a/src/interop/tsgo.rs
+++ b/src/interop/tsgo.rs
@@ -371,14 +371,14 @@ fn generate_probe(
                 // Inline the const's expression to let tsgo resolve the full chain
                 if name.contains('.') {
                     let obj_name = name.split('.').next().unwrap_or("");
-                    let method = name.rsplit('.').next().unwrap_or("");
+                    let method_chain = &name[obj_name.len() + 1..]; // preserves full chain e.g. "auth.signInWithPassword"
                     if let Some(obj_expr) = local_const_exprs.get(obj_name) {
                         let ts_args: Vec<String> = args.iter().map(arg_to_ts_approx).collect();
                         let binding_name = const_binding_name(&decl.binding);
                         // Use a separate counter to avoid conflicting with _rN indices
                         let inlined_id = format!("inlined_{}", lines.len());
                         lines.push(format!(
-                            "export const __probe_{binding_name}_{inlined_id} = {obj_expr}.{method}({});",
+                            "export const __probe_{binding_name}_{inlined_id} = {obj_expr}.{method_chain}({});",
                             ts_args.join(", "),
                         ));
                         // Don't increment probe_index — these don't use _rN naming


### PR DESCRIPTION
closes #612

## Summary
- When a local const assigned from an import call (e.g. `const supabase = getSupabaseClient()`) was used in a chained member call (e.g. `supabase.auth.signInWithPassword(...)`), the probe inlining code used `rsplit('.').next()` to get only the last method name, dropping intermediate member accesses like `.auth`
- The probe generated `getSupabaseClient().signInWithPassword(...)` instead of `getSupabaseClient().auth.signInWithPassword(...)`, causing tsgo to resolve the result as `any`
- Fixed by preserving the full member chain after the object name

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] `floe check` and `floe build` on example apps pass
- [x] Verified probe output on kansai-accent-floe project: `AuthTokenResponsePassword`, `AuthResponse` etc. resolve correctly instead of `any`

🤖 Generated with [Claude Code](https://claude.com/claude-code)