### PR TITLE
fix: [#615] Intersection type fails after generic type application

### DIFF
--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -3718,3 +3718,16 @@ type Extended = typeof config & { timeout: number }",
         "typeof & record intersection should work: {diags:?}"
     );
 }
+
+#[test]
+fn intersection_after_generic_type() {
+    let diags = check(
+        "type A { x: number }
+type B { y: string }
+type C = Array<A> & B",
+    );
+    assert!(
+        diags.is_empty(),
+        "intersection after generic type should work: {diags:?}"
+    );
+}

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -1814,3 +1814,16 @@ type D = A & B & { z: boolean }",
         "should emit three-way intersection, got: {result}"
     );
 }
+
+#[test]
+fn intersection_after_generic_type() {
+    let result = emit(
+        "type A { x: number }
+type B { y: string }
+type C = Array<A> & B",
+    );
+    assert!(
+        result.contains("type C = Array<A> & B;"),
+        "should emit intersection after generic type, got: {result}"
+    );
+}

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -941,6 +941,7 @@ impl<'src> CstParser<'src> {
                 self.eat_trivia();
                 self.parse_comma_separated(Self::parse_type_expr, TokenKind::GreaterThan);
                 self.expect(TokenKind::GreaterThan);
+                self.eat_trivia();
             }
         }
 


### PR DESCRIPTION
closes #615

## Summary
- Add missing `eat_trivia()` after `expect(GreaterThan)` in `parse_type_expr` (line 943 of `cst.rs`)
- `type X = Generic<T> & B` now parses correctly
- Every other `expect(GreaterThan)` in the codebase already had `eat_trivia()` — this was the only one missing

## Test plan
- [x] Checker test: `Array<A> & B` intersection after generic type
- [x] Codegen test: emits `Array<A> & B` correctly
- [x] Quality gate: cargo fmt, clippy, tests (all passing)
- [x] Floe examples: fmt, check, build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)