### PR TITLE
fix: [#614] Use inlined probe results for destructured const bindings

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1334,7 +1334,16 @@ impl Checker {
         {
             self.expr_types.insert(decl.value.id, declared.clone());
         }
-        let tsgo_type = self.find_and_consume_tsgo_probe(&decl.binding);
+        let tsgo_type = self.find_and_consume_tsgo_probe(&decl.binding).map(|ty| {
+            // The tsgo probe generates the raw call expression without `await`,
+            // so if the Floe code has `await`, unwrap Promise from the probe type.
+            if Self::expr_has_await(&decl.value)
+                && let Type::Promise(inner) = ty
+            {
+                return *inner;
+            }
+            ty
+        });
         let final_type = self.resolve_const_type(value_type, declared_type, &tsgo_type, span);
 
         match &decl.binding {
@@ -1446,6 +1455,15 @@ impl Checker {
         }
     }
 
+    /// Check if an expression is wrapped in `await` (possibly through `try`).
+    fn expr_has_await(expr: &Expr) -> bool {
+        match &expr.kind {
+            ExprKind::Await(_) => true,
+            ExprKind::Try(inner) => Self::expr_has_await(inner),
+            _ => false,
+        }
+    }
+
     /// Infer the type of an element from an array/tuple destructuring at a given index.
     fn array_element_type(effective_type: &Type, i: usize) -> Type {
         match effective_type {
@@ -1487,12 +1505,6 @@ impl Checker {
         has_tsgo: bool,
         span: Span,
     ) {
-        // If tsgo resolved this as a single-field destructure, assign directly
-        if has_tsgo && names.len() == 1 {
-            self.define_const_binding(&names[0], final_type.clone(), false, span);
-            return;
-        }
-
         let concrete = self
             .env
             .resolve_to_concrete(final_type, &expr::simple_resolve_type_expr);
@@ -1501,6 +1513,18 @@ impl Checker {
             Type::Record(fields) => Some(fields.iter().map(|(n, t)| (n.as_str(), t)).collect()),
             _ => None,
         };
+
+        // If tsgo resolved a single-field destructure and the type isn't a Record
+        // with that field, assign it directly (legacy behavior for field-level probes)
+        if has_tsgo
+            && names.len() == 1
+            && field_map
+                .as_ref()
+                .is_none_or(|m| !m.contains_key(names[0].as_str()))
+        {
+            self.define_const_binding(&names[0], final_type.clone(), false, span);
+            return;
+        }
 
         for name in names {
             let field_ty = field_map

--- a/src/interop/wrapper.rs
+++ b/src/interop/wrapper.rs
@@ -134,6 +134,9 @@ fn wrap_union_boundary(parts: &[TsType]) -> Type {
     } else if non_null_parts.is_empty() {
         // `null | undefined` -> Option<Void> (shouldn't happen in practice)
         Type::Unit
+    } else if let Some(merged) = try_merge_object_union(&non_null_parts) {
+        // All union members are objects — merge common fields for destructuring
+        merged
     } else {
         // Multi-type union without null/undefined: stay as Unknown for now
         // A full implementation would create proper union types
@@ -145,6 +148,91 @@ fn wrap_union_boundary(parts: &[TsType]) -> Type {
     } else {
         inner_type
     }
+}
+
+/// Try to merge a union of object types into a single Record with common fields.
+/// Each field's type is the union of that field across all members.
+/// Returns None if any member is not an object or if there are no common fields.
+///
+/// Example: `{ data: A, error: null } | { data: B, error: E }` → `Record { data: A|B, error: null|E }`
+fn try_merge_object_union(parts: &[&TsType]) -> Option<Type> {
+    use super::ts_types::ObjectField;
+    use std::collections::HashMap;
+
+    if parts.len() < 2 {
+        return None;
+    }
+
+    // Check all parts are objects
+    let objects: Vec<&Vec<ObjectField>> = parts
+        .iter()
+        .filter_map(|p| {
+            if let TsType::Object(fields) = p {
+                Some(fields)
+            } else {
+                None
+            }
+        })
+        .collect();
+    if objects.len() != parts.len() {
+        return None;
+    }
+
+    // Find field names that appear in ALL members
+    let first_names: Vec<&str> = objects[0].iter().map(|f| f.name.as_str()).collect();
+    let common_names: Vec<&str> = first_names
+        .into_iter()
+        .filter(|name| {
+            objects[1..]
+                .iter()
+                .all(|obj| obj.iter().any(|f| f.name == *name))
+        })
+        .collect();
+    if common_names.is_empty() {
+        return None;
+    }
+
+    // Build merged fields: each field's type is a union of its type across all members
+    let mut merged_fields: Vec<(String, Type)> = Vec::new();
+    for name in &common_names {
+        let mut field_types: Vec<TsType> = Vec::new();
+        let mut any_optional = false;
+        for obj in &objects {
+            if let Some(field) = obj.iter().find(|f| f.name == *name) {
+                any_optional |= field.optional;
+                field_types.push(field.ty.clone());
+            }
+        }
+        // Deduplicate identical types
+        field_types.dedup();
+        let merged_ty = if field_types.len() == 1 {
+            let ty = wrap_boundary_type(&field_types[0]);
+            if any_optional {
+                Type::Option(Box::new(ty))
+            } else {
+                ty
+            }
+        } else {
+            // Create a union and wrap it
+            let ty = wrap_boundary_type(&TsType::Union(field_types));
+            if any_optional && !matches!(ty, Type::Option(_)) {
+                Type::Option(Box::new(ty))
+            } else {
+                ty
+            }
+        };
+        // Collect into a hashmap to avoid duplicates from different key positions
+        merged_fields.push((name.to_string(), merged_ty));
+    }
+
+    // Deduplicate by field name (shouldn't happen but just in case)
+    let mut seen = HashMap::new();
+    let deduped: Vec<(String, Type)> = merged_fields
+        .into_iter()
+        .filter(|(name, _)| seen.insert(name.clone(), ()).is_none())
+        .collect();
+
+    Some(Type::Record(deduped))
 }
 
 /// Try to detect the Result discriminated union pattern:


### PR DESCRIPTION
closes #614

## Summary
- Unwrap `Promise<T>` from inlined probe types when the value expression has `await` - the probe generates raw calls without await, so the checker now strips the Promise wrapper
- Merge union-of-objects into a single Record for destructuring: when all union members are objects with common fields (e.g. Supabase's `{ data, error }` pattern), merge them so `const { data, error } = await ...` works
- Fix single-field object destructure regression: when the probe resolves a Record type containing the destructured field, extract the field value instead of assigning the entire Record

## What now works
- `const { error } = await supabase.auth.signOut()` - correctly types `error` as `Option<AuthError>`
- `const { data } = await supabase.auth.getSession()` - correctly types `data.session` as `Option<Session>`

## Remaining limitations (separate issues)
- `signIn`/`signUp` return opaque named types (`AuthTokenResponsePassword`, `AuthResponse`) that tsgo doesn't expand, so their fields can't be extracted
- Intermediate expressions like `supabase.auth.X()` still emit "cannot access on unknown" diagnostics even when the const binding is correctly typed by the probe

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (1046 tests)
- [x] `floe check` and `floe build` on example apps pass
- [x] Verified on kansai-accent-floe: `getSession` and `signOut` destructuring now resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)