### PR TITLE
fix: [#621] Probe counter blocks reuse of same-named probes across functions

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -105,9 +105,9 @@ pub struct Checker {
     resolved_imports: HashMap<String, ResolvedImports>,
     /// Pre-resolved .d.ts exports for npm imports, keyed by specifier (e.g. "react").
     dts_imports: HashMap<String, Vec<DtsExport>>,
-    /// Counter for disambiguating probe lookups when the same binding name appears
-    /// multiple times (e.g. two `const { data } = ...` destructures).
-    probe_counters: HashSet<String>,
+    /// Tracks consumed probe export indices to prevent reuse.
+    /// Uses (specifier_index, export_index) pairs to identify specific exports.
+    probe_consumed: HashSet<(usize, usize)>,
     /// Maps variable/function names to their inferred type display names.
     /// Accumulated as names are defined so inner-scope names aren't lost.
     name_types: HashMap<String, String>,
@@ -288,7 +288,7 @@ impl Checker {
             registering_types: false,
             resolved_imports: HashMap::new(),
             dts_imports: HashMap::new(),
-            probe_counters: HashSet::new(),
+            probe_consumed: HashSet::new(),
             name_types: HashMap::new(),
             ambiguous_variants: HashMap::new(),
             fn_required_params: HashMap::new(),
@@ -1387,28 +1387,29 @@ impl Checker {
         let probe_key = format!("__probe_{binding_name}");
         let probe_prefix = format!("__probe_{binding_name}_");
 
-        let mut found_export = None;
-        let mut found_inlined = None;
-        for exports in self.dts_imports.values() {
-            for export in exports {
-                if !self.probe_counters.contains(&export.name)
+        let mut found_export: Option<(usize, usize, DtsExport)> = None;
+        let mut found_inlined: Option<(usize, usize, DtsExport)> = None;
+        for (spec_idx, exports) in self.dts_imports.values().enumerate() {
+            for (exp_idx, export) in exports.iter().enumerate() {
+                let key = (spec_idx, exp_idx);
+                if !self.probe_consumed.contains(&key)
                     && (export.name == probe_key || export.name.starts_with(&probe_prefix))
                 {
                     if export.name.contains("inlined") {
                         if found_inlined.is_none() {
-                            found_inlined = Some(export.clone());
+                            found_inlined = Some((spec_idx, exp_idx, export.clone()));
                         }
                     } else if found_export.is_none() {
-                        found_export = Some(export.clone());
+                        found_export = Some((spec_idx, exp_idx, export.clone()));
                     }
                 }
             }
         }
-        let found_export = found_inlined.or(found_export);
-        if let Some(ref export) = found_export {
-            self.probe_counters.insert(export.name.clone());
+        let found = found_inlined.or(found_export);
+        if let Some((spec_idx, exp_idx, _)) = &found {
+            self.probe_consumed.insert((*spec_idx, *exp_idx));
         }
-        found_export.map(|e| interop::wrap_boundary_type(&e.ts_type))
+        found.map(|(_, _, e)| interop::wrap_boundary_type(&e.ts_type))
     }
 
     /// Determine the final type for a const binding given value type, declared type, and tsgo probe.


### PR DESCRIPTION
closes #621

## Summary
- The probe counter used `HashSet<String>` to track consumed probes, which prevented the same probe name from being consumed more than once across the entire file
- When multiple functions had `const supabase = getSupabaseClient()`, only the first function got the correct `SupabaseClient` type - the rest fell back to `unknown`, causing cascading "cannot access .auth on unknown" errors
- Changed to track consumed probes by `(specifier_index, export_index)` position pairs, so each duplicate-named probe export can be consumed independently

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (1048 tests)
- [x] `floe check` and `floe build` on example apps pass (no regression)
- [x] Verified on kansai-accent-floe: all 4 functions now get the correct `SupabaseClient` type for `supabase`

🤖 Generated with [Claude Code](https://claude.com/claude-code)