### PR TITLE
fix: [#623] Async fn return type check does not unwrap Promise

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1087,6 +1087,13 @@ impl Checker {
                     .unwrap_or(Type::Unknown);
                 Type::Array(Box::new(inner))
             }
+            "Promise" => {
+                let inner = type_args
+                    .first()
+                    .map(|t| self.resolve_type(t))
+                    .unwrap_or(Type::Unknown);
+                Type::Promise(Box::new(inner))
+            }
             _ => {
                 // Check if this is a known user-defined type or imported name.
                 // Skip validation during type registration (forward references).
@@ -1661,7 +1668,20 @@ impl Checker {
         // Check return type compatibility
         if let Some(ref declared_return) = decl.return_type {
             let resolved = self.resolve_type(declared_return);
-            if !self.types_compatible(&resolved, &body_type) && !matches!(body_type, Type::Var(_)) {
+            // For async functions, unwrap Promise from the declared type before comparing,
+            // since the body type is the inner value (async implicitly wraps in Promise)
+            let effective_declared = if decl.async_fn {
+                if let Type::Promise(inner) = &resolved {
+                    inner.as_ref().clone()
+                } else {
+                    resolved.clone()
+                }
+            } else {
+                resolved.clone()
+            };
+            if !self.types_compatible(&effective_declared, &body_type)
+                && !matches!(body_type, Type::Var(_))
+            {
                 self.diagnostics.push(
                     Diagnostic::error(
                         format!(


### PR DESCRIPTION
closes #623

## Summary
- `Promise<T>` in type annotations was resolving to `Type::Named("Promise")` instead of `Type::Promise(T)` because `resolve_named_type` had no special case for it (unlike `Result`, `Option`, `Array`). Added the missing case.
- For `async fn` return type checking, the declared type (e.g. `Promise<Option<Session>>`) is now unwrapped to its inner type before comparing with the body type, since `async` implicitly wraps the return value.

## What this fixes
- `async fn getSession() -> Promise<Option<Session>>` no longer reports a false error
- `async fn signOut() -> Promise<Result<Unit, Error>>` no longer reports a false error (the `Result` type now matches correctly)

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (1048 tests)
- [x] `floe check` and `floe build` on example apps pass
- [x] Verified on kansai-accent-floe: `getSession` and `signOut` now pass type checking

🤖 Generated with [Claude Code](https://claude.com/claude-code)