### PR TITLE
fix: [#624] Expand opaque named types via per-field probe destructuring

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1431,6 +1431,27 @@ impl Checker {
         found.map(|(_, _, e)| interop::wrap_boundary_type(&e.ts_type))
     }
 
+    /// Search for a per-field inlined probe (e.g. `__probe_data_inlined_N` for field `data`).
+    fn find_per_field_probe(&mut self, field_name: &str) -> Option<Type> {
+        let prefix = format!("__probe_{field_name}_inlined_");
+        let mut found: Option<(usize, usize, DtsExport)> = None;
+        for (spec_idx, exports) in self.dts_imports.values().enumerate() {
+            for (exp_idx, export) in exports.iter().enumerate() {
+                let key = (spec_idx, exp_idx);
+                if !self.probe_consumed.contains(&key)
+                    && export.name.starts_with(&prefix)
+                    && found.is_none()
+                {
+                    found = Some((spec_idx, exp_idx, export.clone()));
+                }
+            }
+        }
+        if let Some((spec_idx, exp_idx, _)) = &found {
+            self.probe_consumed.insert((*spec_idx, *exp_idx));
+        }
+        found.map(|(_, _, e)| interop::wrap_boundary_type(&e.ts_type))
+    }
+
     /// Determine the final type for a const binding given value type, declared type, and tsgo probe.
     fn resolve_const_type(
         &mut self,
@@ -1547,13 +1568,16 @@ impl Checker {
         }
 
         for name in names {
+            // First try extracting the field from the Record type
             let field_ty = field_map
                 .as_ref()
                 .and_then(|m| m.get(name.as_str()))
                 .cloned()
-                .cloned()
-                .unwrap_or(Type::Unknown);
-            self.define_const_binding(name, field_ty, false, span);
+                .cloned();
+            // If no field found (e.g. Foreign type), try a per-field probe lookup
+            let ty = field_ty
+                .unwrap_or_else(|| self.find_per_field_probe(name).unwrap_or(Type::Unknown));
+            self.define_const_binding(name, ty, false, span);
         }
     }
 

--- a/src/interop/tsgo.rs
+++ b/src/interop/tsgo.rs
@@ -374,13 +374,32 @@ fn generate_probe(
                     let method_chain = &name[obj_name.len() + 1..]; // preserves full chain e.g. "auth.signInWithPassword"
                     if let Some(obj_expr) = local_const_exprs.get(obj_name) {
                         let ts_args: Vec<String> = args.iter().map(arg_to_ts_approx).collect();
-                        let binding_name = const_binding_name(&decl.binding);
-                        // Use a separate counter to avoid conflicting with _rN indices
                         let inlined_id = format!("inlined_{}", lines.len());
-                        lines.push(format!(
-                            "export const __probe_{binding_name}_{inlined_id} = {obj_expr}.{method_chain}({});",
-                            ts_args.join(", "),
-                        ));
+                        let call_expr =
+                            format!("{obj_expr}.{method_chain}({})", ts_args.join(", "),);
+                        // For object destructuring, generate per-field exports so tsgo
+                        // expands opaque named types through member access
+                        if let ConstBinding::Object(names) = &decl.binding {
+                            let has_await = matches!(decl.value.kind, ExprKind::Await(_))
+                                || matches!(
+                                    &decl.value.kind,
+                                    ExprKind::Try(inner) if matches!(inner.kind, ExprKind::Await(_))
+                                );
+                            let await_prefix = if has_await { "await " } else { "" };
+                            lines.push(format!(
+                                "const _tmp_{inlined_id} = {await_prefix}{call_expr};"
+                            ));
+                            for field in names {
+                                lines.push(format!(
+                                    "export const __probe_{field}_{inlined_id} = _tmp_{inlined_id}.{field};"
+                                ));
+                            }
+                        } else {
+                            let binding_name = const_binding_name(&decl.binding);
+                            lines.push(format!(
+                                "export const __probe_{binding_name}_{inlined_id} = {call_expr};"
+                            ));
+                        }
                         // Don't increment probe_index — these don't use _rN naming
                         continue;
                     }


### PR DESCRIPTION
closes #624

## Summary
- When tsgo returns opaque named types like `AuthTokenResponsePassword` for chained method calls, the checker can't destructure them because they're `Foreign` types
- Fixed by generating per-field probe exports when the binding is an object destructure: instead of one export for the whole call result, generate separate exports for each destructured field (e.g. `_tmp.data`, `_tmp.error`), forcing tsgo to expand the type through member access
- Added `find_per_field_probe` fallback in the checker for when the whole-binding probe returns a non-Record type

## What this fixes
- `const { data, error } = await supabase.auth.signInWithPassword(...)` now correctly types `data` and `error` from expanded field access
- `error` resolves to `AuthError | null` (wrapped as `Option<AuthError>`)
- `data.session` resolves to `Session | null` (wrapped as `Option<Session>`)

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (1048 tests)
- [x] Example app errors are pre-existing (verified same errors on main without this change)
- [x] Verified on kansai-accent-floe: `signIn`, `signOut`, `signUp` now get expanded field types

🤖 Generated with [Claude Code](https://claude.com/claude-code)