### PR TITLE
feat: [#616] Support string literal type arguments

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -114,6 +114,11 @@ type OrderId { number }
 // String literal union (for npm interop)
 type HttpMethod = "GET" | "POST" | "PUT" | "DELETE"
 
+// String literal type arguments (for npm interop)
+// Used with React's ComponentProps, event emitters, etc.
+import trusted { ComponentProps } from "react"
+type DivProps = ComponentProps<"div">
+
 // Record type composition with spread
 type BaseProps {
     className: string,

--- a/docs/site/src/content/docs/reference/types.md
+++ b/docs/site/src/content/docs/reference/types.md
@@ -178,6 +178,9 @@ Array<T>
 
 // Tuple
 (string, number)
+
+// String literal (for npm interop)
+ComponentProps<"div">
 ```
 
 ## Differences from TypeScript

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1024,6 +1024,7 @@ impl Checker {
                     first.unwrap_or_else(|| resolved.into_iter().next().unwrap_or(Type::Unknown))
                 }
             }
+            TypeExprKind::StringLiteral(value) => Type::Foreign(format!("\"{value}\"")),
             TypeExprKind::TypeOf(name) => {
                 let root = name.split('.').next().unwrap_or(name);
                 self.unused.used_names.insert(root.to_string());

--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -1766,6 +1766,7 @@ pub(crate) fn simple_resolve_type_expr(type_expr: &crate::parser::ast::TypeExpr)
             // Without environment context, typeof can't be resolved
             Type::Unknown
         }
+        TypeExprKind::StringLiteral(value) => Type::Foreign(format!("\"{value}\"")),
         TypeExprKind::Intersection(types) => {
             let resolved: Vec<Type> = types.iter().map(simple_resolve_type_expr).collect();
             let mut fields = Vec::new();

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -3747,3 +3747,15 @@ fn _test(b: B) -> number { b.x }",
         "record spread should allow accessing spread fields: {diags:?}"
     );
 }
+
+#[test]
+fn string_literal_type_arg() {
+    let diags = check(
+        "type A { x: number }
+type B = Array<\"div\">",
+    );
+    assert!(
+        diags.is_empty(),
+        "string literal type argument should parse and check: {diags:?}"
+    );
+}

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1063,6 +1063,9 @@ impl Codegen {
                     self.emit_type_expr(ty);
                 }
             }
+            TypeExprKind::StringLiteral(value) => {
+                self.push(&format!("\"{value}\""));
+            }
         }
     }
 

--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -878,11 +878,12 @@ impl Codegen {
                 self.emit_parse_checks(&elem_accessor, inner, &elem_path);
                 self.push("} ");
             }
-            TypeExprKind::Function { .. }
+            TypeExprKind::StringLiteral(_)
+            | TypeExprKind::Function { .. }
             | TypeExprKind::Tuple(_)
             | TypeExprKind::TypeOf(_)
             | TypeExprKind::Intersection(_) => {
-                // Can't validate functions, tuples, typeof, or intersections at runtime — skip
+                // Can't validate string literals, functions, tuples, typeof, or intersections at runtime — skip
             }
         }
     }
@@ -1004,6 +1005,9 @@ impl Codegen {
                     self.emit_mock_for_type(ty, &[], counter, "");
                 }
                 self.push("]");
+            }
+            TypeExprKind::StringLiteral(value) => {
+                self.push(&format!("\"{value}\""));
             }
             TypeExprKind::Function { .. }
             | TypeExprKind::TypeOf(_)

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -1842,3 +1842,12 @@ type B {
         "record spread should emit as intersection, got: {result}"
     );
 }
+
+#[test]
+fn string_literal_type_arg() {
+    let result = emit("type A = Array<\"div\">");
+    assert!(
+        result.contains("type A = Array<\"div\">;"),
+        "should emit string literal type arg, got: {result}"
+    );
+}

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -909,6 +909,10 @@ impl<'src> CstParser<'src> {
         else if self.at(TokenKind::LeftBrace) {
             self.parse_record_fields();
         }
+        // String literal type (e.g. ComponentProps<"div">)
+        else if self.at(TokenKind::String("".into())) {
+            self.bump();
+        }
         // typeof <ident> or typeof Module.value
         else if self.at(TokenKind::Typeof) {
             self.bump();

--- a/src/formatter/items.rs
+++ b/src/formatter/items.rs
@@ -486,6 +486,17 @@ impl Formatter<'_> {
             .filter(|c| c.kind() == SyntaxKind::TYPE_EXPR)
             .collect();
 
+        // String literal type: "div", "button"
+        let string_token = node.children_with_tokens().find_map(|t| {
+            t.as_token()
+                .filter(|tok| tok.kind() == SyntaxKind::STRING)
+                .map(|tok| tok.text().to_string())
+        });
+        if let Some(s) = string_token {
+            self.write(&s);
+            return;
+        }
+
         // Unit type: ()
         if has_lparen
             && idents.is_empty()

--- a/src/interop/tsgo.rs
+++ b/src/interop/tsgo.rs
@@ -737,6 +737,7 @@ fn collect_typeof_names(type_expr: &TypeExpr, callback: &mut dyn FnMut(&str)) {
                 collect_typeof_names(&f.type_ann, callback);
             }
         }
+        TypeExprKind::StringLiteral(_) => {}
     }
 }
 
@@ -778,6 +779,7 @@ fn type_expr_references_imports(
         TypeExprKind::Record(fields) => fields
             .iter()
             .any(|f| type_expr_references_imports(&f.type_ann, imported_names)),
+        TypeExprKind::StringLiteral(_) => false,
     }
 }
 
@@ -1097,6 +1099,7 @@ fn type_expr_to_ts(ty: &TypeExpr) -> String {
             let parts: Vec<String> = types.iter().map(type_expr_to_ts).collect();
             parts.join(" & ")
         }
+        TypeExprKind::StringLiteral(value) => format!("\"{value}\""),
     }
 }
 

--- a/src/lower.rs
+++ b/src/lower.rs
@@ -983,6 +983,18 @@ impl<'src> Lowerer<'src> {
             });
         }
 
+        let string_lit = node.children_with_tokens().find_map(|t| {
+            t.as_token()
+                .filter(|tok| tok.kind() == SyntaxKind::STRING)
+                .map(|tok| self.unquote_string(tok.text()))
+        });
+        if let Some(value) = string_lit {
+            return Some(TypeExpr {
+                kind: TypeExprKind::StringLiteral(value),
+                span,
+            });
+        }
+
         // Named type with optional type args
         if !idents.is_empty() {
             // Join dotted names

--- a/src/lsp/symbols.rs
+++ b/src/lsp/symbols.rs
@@ -649,5 +649,6 @@ pub(super) fn type_expr_to_string(ty: &TypeExpr) -> String {
             let parts: Vec<String> = types.iter().map(type_expr_to_string).collect();
             parts.join(" & ")
         }
+        TypeExprKind::StringLiteral(value) => format!("\"{value}\""),
     }
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -343,6 +343,8 @@ pub enum TypeExprKind {
     TypeOf(String),
     /// `A & B` — intersection type
     Intersection(Vec<TypeExpr>),
+    /// String literal type: `"div"`, `"button"` (for npm interop like `ComponentProps<"div">`)
+    StringLiteral(String),
 }
 
 // ── Expressions ──────────────────────────────────────────────────

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -693,6 +693,7 @@ fn collect_type_names(type_expr: &TypeExpr, names: &mut HashSet<String>) {
                 collect_type_names(ty, names);
             }
         }
+        TypeExprKind::StringLiteral(_) => {}
     }
 }
 


### PR DESCRIPTION
closes #616

## Summary
- String literals can now be used as generic type arguments: `ComponentProps<"div">`
- New `TypeExprKind::StringLiteral` variant flows through the full pipeline
- Parser, lowerer (using proper `unquote_string`), checker, codegen, formatter, LSP, and tsgo probes all handle the new variant

## Example

```floe
import trusted { ComponentProps } from "react"

type DivProps = ComponentProps<"div">
```

Compiles to:
```typescript
import type { ComponentProps } from "react";
type DivProps = ComponentProps<"div">;
```

## Test plan
- [x] Checker test: string literal type argument parses and checks
- [x] Codegen test: emits `Array<"div">` correctly
- [x] Formatter: preserves string literal type args
- [x] Quality gate: cargo fmt, clippy, tests (all passing)
- [x] Floe examples: fmt, check, build all pass
- [x] Docs updated: reference/types.md, llms.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)