### PR TITLE
feat: [#617] Support JSX spread attributes

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -562,6 +562,11 @@ export fn App() -> JSX.Element {
         </ul>
     </div>
 }
+
+// JSX spread attributes — forward all props
+export fn Card(props: CardProps) -> JSX.Element {
+    <div {...props} className="card" />
+}
 ```
 
 ## Tests

--- a/docs/site/src/content/docs/guide/jsx.md
+++ b/docs/site/src/content/docs/guide/jsx.md
@@ -63,6 +63,18 @@ Use pipes with `map`:
 </ul>
 ```
 
+## Spread Attributes
+
+Forward all props to a child element:
+
+```floe
+export fn Card(props: CardProps) -> JSX.Element {
+    <div {...props} className="card" />
+}
+```
+
+Compiles to `<div {...props} className={"card"} />` in TypeScript.
+
 ## Fragments
 
 ```floe

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -2068,15 +2068,22 @@ impl Checker {
                     }
                 }
                 for prop in props {
-                    if let Some(ref value) = prop.value {
-                        // For event handler props, set context so lambda params get event type
-                        if prop.name.starts_with("on") && prop.name.len() > 2 {
-                            let prev = self.ctx.event_handler_context;
-                            self.ctx.event_handler_context = true;
-                            self.check_expr(value);
-                            self.ctx.event_handler_context = prev;
-                        } else {
-                            self.check_expr(value);
+                    match prop {
+                        JsxProp::Named { name, value, .. } => {
+                            if let Some(value) = value {
+                                // For event handler props, set context so lambda params get event type
+                                if name.starts_with("on") && name.len() > 2 {
+                                    let prev = self.ctx.event_handler_context;
+                                    self.ctx.event_handler_context = true;
+                                    self.check_expr(value);
+                                    self.ctx.event_handler_context = prev;
+                                } else {
+                                    self.check_expr(value);
+                                }
+                            }
+                        }
+                        JsxProp::Spread { expr, .. } => {
+                            self.check_expr(expr);
                         }
                     }
                 }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1608,8 +1608,15 @@ fn collect_value_names_from_jsx(jsx: &JsxElement, names: &mut HashSet<String>) {
                 names.insert(name.clone());
             }
             for prop in props {
-                if let Some(value) = &prop.value {
-                    collect_value_names_from_expr(value, names);
+                match prop {
+                    JsxProp::Named { value, .. } => {
+                        if let Some(value) = value {
+                            collect_value_names_from_expr(value, names);
+                        }
+                    }
+                    JsxProp::Spread { expr, .. } => {
+                        collect_value_names_from_expr(expr, names);
+                    }
                 }
             }
             for child in children {

--- a/src/codegen/jsx.rs
+++ b/src/codegen/jsx.rs
@@ -16,11 +16,20 @@ impl Codegen {
                 self.push(&format!("<{name}"));
                 for prop in props {
                     self.push(" ");
-                    self.push(&prop.name);
-                    if let Some(value) = &prop.value {
-                        self.push("={");
-                        self.emit_expr(value);
-                        self.push("}");
+                    match prop {
+                        JsxProp::Named { name, value, .. } => {
+                            self.push(name);
+                            if let Some(value) = value {
+                                self.push("={");
+                                self.emit_expr(value);
+                                self.push("}");
+                            }
+                        }
+                        JsxProp::Spread { expr, .. } => {
+                            self.push("{...");
+                            self.emit_expr(expr);
+                            self.push("}");
+                        }
                     }
                 }
                 if *self_closing {

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -1851,3 +1851,17 @@ fn string_literal_type_arg() {
         "should emit string literal type arg, got: {result}"
     );
 }
+
+#[test]
+fn jsx_spread_prop() {
+    let result = emit(
+        "type Props { x: number }
+fn _test(props: Props) -> JSX.Element {
+    <div {...props} />
+}",
+    );
+    assert!(
+        result.contains("{...props}"),
+        "should emit JSX spread prop, got: {result}"
+    );
+}

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -1985,6 +1985,20 @@ impl<'src> CstParser<'src> {
     }
 
     fn parse_jsx_prop(&mut self) {
+        // JSX spread: {...expr}
+        if self.at(TokenKind::LeftBrace) && self.peek_is(TokenKind::DotDotDot) {
+            self.builder.start_node(SyntaxKind::JSX_SPREAD_PROP.into());
+            self.bump(); // {
+            self.eat_trivia();
+            self.bump(); // ...
+            self.eat_trivia();
+            self.parse_expr();
+            self.eat_trivia();
+            self.expect(TokenKind::RightBrace);
+            self.builder.finish_node();
+            return;
+        }
+
         self.builder.start_node(SyntaxKind::JSX_PROP.into());
         // Accept identifiers and keywords as JSX prop names (e.g., type="text", for="id")
         if self.is_ident() || self.is_keyword() {

--- a/src/formatter/jsx.rs
+++ b/src/formatter/jsx.rs
@@ -11,7 +11,7 @@ impl Formatter<'_> {
 
         let props: Vec<_> = node
             .children()
-            .filter(|c| c.kind() == SyntaxKind::JSX_PROP)
+            .filter(|c| c.kind() == SyntaxKind::JSX_PROP || c.kind() == SyntaxKind::JSX_SPREAD_PROP)
             .collect();
 
         let children = self.jsx_collect_children(node);
@@ -111,6 +111,37 @@ impl Formatter<'_> {
     }
 
     fn fmt_jsx_prop(&mut self, node: &SyntaxNode) {
+        // JSX spread prop: {...expr}
+        if node.kind() == SyntaxKind::JSX_SPREAD_PROP {
+            self.write("{...");
+            let mut past_dots = false;
+            for child_or_tok in node.children_with_tokens() {
+                if child_or_tok
+                    .as_token()
+                    .is_some_and(|t| t.kind() == SyntaxKind::DOT_DOT_DOT)
+                {
+                    past_dots = true;
+                    continue;
+                }
+                if !past_dots {
+                    continue;
+                }
+                match child_or_tok {
+                    rowan::NodeOrToken::Token(tok) => {
+                        if tok.kind() == SyntaxKind::R_BRACE {
+                            break;
+                        }
+                        if !tok.kind().is_trivia() {
+                            self.write(tok.text());
+                        }
+                    }
+                    rowan::NodeOrToken::Node(child) => self.fmt_node(&child),
+                }
+            }
+            self.write("}");
+            return;
+        }
+
         // JSX prop names can be identifiers or keywords (e.g., `type`, `for`)
         if let Some(name) = self.first_ident(node) {
             self.write(&name);
@@ -338,7 +369,7 @@ impl Formatter<'_> {
     pub(crate) fn jsx_has_multiline_props(&self, node: &SyntaxNode) -> bool {
         let props: Vec<_> = node
             .children()
-            .filter(|c| c.kind() == SyntaxKind::JSX_PROP)
+            .filter(|c| c.kind() == SyntaxKind::JSX_PROP || c.kind() == SyntaxKind::JSX_SPREAD_PROP)
             .collect();
         !(props.is_empty() || props.len() <= 3 && self.jsx_props_short(&props))
     }

--- a/src/interop/tsgo.rs
+++ b/src/interop/tsgo.rs
@@ -957,8 +957,15 @@ fn collect_member_accesses_jsx(
             props, children, ..
         } => {
             for prop in props {
-                if let Some(value) = &prop.value {
-                    collect_member_accesses_expr(value, imported_names, accesses);
+                match prop {
+                    JsxProp::Named { value, .. } => {
+                        if let Some(value) = value {
+                            collect_member_accesses_expr(value, imported_names, accesses);
+                        }
+                    }
+                    JsxProp::Spread { expr, .. } => {
+                        collect_member_accesses_expr(expr, imported_names, accesses);
+                    }
                 }
             }
             for child in children {

--- a/src/lower/jsx.rs
+++ b/src/lower/jsx.rs
@@ -53,6 +53,11 @@ impl<'src> Lowerer<'src> {
                         props.push(prop);
                     }
                 }
+                SyntaxKind::JSX_SPREAD_PROP => {
+                    if let Some(prop) = self.lower_jsx_spread_prop(&child) {
+                        props.push(prop);
+                    }
+                }
                 SyntaxKind::JSX_EXPR_CHILD => {
                     if let Some(expr) = self.lower_first_expr(&child) {
                         children.push(JsxChild::Expr(expr));
@@ -121,6 +126,13 @@ impl<'src> Lowerer<'src> {
             None
         };
 
-        Some(JsxProp { name, value, span })
+        Some(JsxProp::Named { name, value, span })
+    }
+
+    pub(super) fn lower_jsx_spread_prop(&mut self, node: &SyntaxNode) -> Option<JsxProp> {
+        let span = self.node_span(node);
+        let expr = self.lower_first_expr(node)?;
+
+        Some(JsxProp::Spread { expr, span })
     }
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -699,10 +699,15 @@ pub enum JsxElementKind {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct JsxProp {
-    pub name: String,
-    pub value: Option<Expr>,
-    pub span: Span,
+pub enum JsxProp {
+    /// `name={value}` or `name="string"`
+    Named {
+        name: String,
+        value: Option<Expr>,
+        span: Span,
+    },
+    /// `{...expr}`
+    Spread { expr: Expr, span: Span },
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -977,8 +977,8 @@ fn jsx_with_props() {
             ..
         }) => {
             assert_eq!(props.len(), 2);
-            assert_eq!(props[0].name, "label");
-            assert_eq!(props[1].name, "onClick");
+            assert!(matches!(&props[0], JsxProp::Named { name, .. } if name == "label"));
+            assert!(matches!(&props[1], JsxProp::Named { name, .. } if name == "onClick"));
         }
         _ => panic!("expected jsx element"),
     }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -178,6 +178,7 @@ pub enum SyntaxKind {
     JSX_CLOSING_TAG,
     JSX_SELF_CLOSING_TAG,
     JSX_PROP,
+    JSX_SPREAD_PROP,
     JSX_EXPR_CHILD,
     JSX_TEXT,
 

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -313,8 +313,15 @@ fn walk_jsx_children(element: &JsxElement, f: &mut impl FnMut(&Expr)) {
             props, children, ..
         } => {
             for prop in props {
-                if let Some(value) = &prop.value {
-                    walk_expr(value, f);
+                match prop {
+                    JsxProp::Named { value, .. } => {
+                        if let Some(value) = value {
+                            walk_expr(value, f);
+                        }
+                    }
+                    JsxProp::Spread { expr, .. } => {
+                        walk_expr(expr, f);
+                    }
                 }
             }
             for child in children {
@@ -344,8 +351,15 @@ fn walk_jsx_children(element: &JsxElement, f: &mut impl FnMut(&Expr)) {
 fn walk_jsx_mut(element: &mut JsxElement, f: &mut impl FnMut(&mut Expr)) {
     if let JsxElementKind::Element { props, .. } = &mut element.kind {
         for prop in props {
-            if let Some(value) = &mut prop.value {
-                walk_expr_mut(value, f);
+            match prop {
+                JsxProp::Named { value, .. } => {
+                    if let Some(value) = value {
+                        walk_expr_mut(value, f);
+                    }
+                }
+                JsxProp::Spread { expr, .. } => {
+                    walk_expr_mut(expr, f);
+                }
             }
         }
     }


### PR DESCRIPTION
closes #617

## Summary
- JSX elements now support spread attributes: `<div {...props} />`
- `JsxProp` changed from struct to enum with `Named` and `Spread` variants
- Full pipeline: parser, lowerer, checker, codegen, formatter, walker, tsgo probes

## Example

```floe
export fn Card(props: CardProps) -> JSX.Element {
    <div {...props} className="card" />
}
```

Compiles to:
```typescript
export function Card(props: CardProps): JSX.Element {
  return <div {...props} className={"card"} />;
}
```

## Test plan
- [x] Codegen test: JSX spread prop emits `{...props}`
- [x] Parser test: updated for new JsxProp enum
- [x] Formatter: preserves `{...props}` correctly
- [x] Quality gate: cargo fmt, clippy, tests (all passing)
- [x] Floe examples: fmt, check, build all pass
- [x] Docs updated: guide/jsx.md, llms.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)