### PR TITLE
fix: [#636] Canonicalize LSP import resolution paths

### DIFF
--- a/src/lsp/resolution.rs
+++ b/src/lsp/resolution.rs
@@ -61,12 +61,12 @@ pub(super) fn resolve_relative_import(specifier: &str, source_dir: &Path) -> Opt
     for ext in &[".fl", ".ts", ".tsx", "/index.fl", "/index.ts", "/index.tsx"] {
         let path = PathBuf::from(format!("{}{}", base.display(), ext));
         if path.exists() {
-            return Some(path);
+            return path.canonicalize().ok();
         }
     }
     // Maybe it already has an extension
     if base.exists() && base.is_file() {
-        return Some(base);
+        return base.canonicalize().ok();
     }
     None
 }


### PR DESCRIPTION
closes #636

## Summary
- `resolve_relative_import` was returning paths with literal `../` segments (e.g. `src/features/shared/providers/../../../services/supabase/auth/auth-service.fl`)
- VS Code caches these non-canonical URIs from go-to-definition responses and shows them as separate entries in Quick Open file search
- Fix: call `.canonicalize()` on resolved paths before returning them

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [ ] Open a Floe project with deep relative imports, use go-to-definition, verify Quick Open no longer shows duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)