### PR TITLE
fix: [#594] Vite plugin resolves .fl file when .ts file was intended for extensionless imports

### DIFF
--- a/integrations/vite-plugin-floe/src/index.ts
+++ b/integrations/vite-plugin-floe/src/index.ts
@@ -30,7 +30,7 @@ export default function floe(options: FloeOptions = {}) {
 
     config(config: { resolve?: { extensions?: string[] } }) {
       const existing = config.resolve?.extensions ?? [".mjs", ".js", ".mts", ".ts", ".jsx", ".tsx", ".json"];
-      const extensions = existing.includes(".fl") ? existing : [".fl", ...existing];
+      const extensions = existing.includes(".fl") ? existing : [...existing, ".fl"];
       return {
         resolve: { extensions },
         esbuild: {


### PR DESCRIPTION
closes #594

## Summary
- Move `.fl` to the end of Vite's `resolve.extensions` list instead of prepending it
- This ensures standard extensions (`.ts`, `.tsx`, `.js`, etc.) are tried first for extensionless imports
- Explicit `.fl` imports still work as before since they match the extension directly

## Test plan
- [ ] Verify extensionless import resolves to `.ts` when both `.ts` and `.fl` exist at the same path
- [ ] Verify explicit `.fl` import still resolves correctly
- [ ] Verify extensionless import resolves to `.fl` when no `.ts` file exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)