### PR TITLE
chore: [#653] Verify string literal unions restricted to = type aliases

### DIFF
--- a/src/cst.rs
+++ b/src/cst.rs
@@ -2691,6 +2691,17 @@ mod tests {
     }
 
     #[test]
+    fn type_string_literal_union_rejected_in_braces() {
+        // String literal unions are only valid in = type aliases (TS interop).
+        // They must not be accepted inside { } type definitions.
+        let parse = cst_parse(r#"type Method { | "GET" | "POST" }"#);
+        assert!(
+            !parse.errors.is_empty(),
+            "string literal union in {{ }} should produce parse errors"
+        );
+    }
+
+    #[test]
     fn type_alias() {
         assert_no_errors("type Name = string");
     }


### PR DESCRIPTION
closes #653

## Summary

The parser already restricts string literal unions (`type X = "A" | "B"`) to `=` type aliases — they can't appear inside `{ }` bodies. This adds an explicit test documenting that behavior.

No code changes needed since the parser already enforces this correctly.

## Test plan
- [x] All 1015 tests pass (1 new)
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)