### PR TITLE
fix: [#584] Member access hover shows resolved field types

### DIFF
--- a/src/lsp/handlers.rs
+++ b/src/lsp/handlers.rs
@@ -210,6 +210,20 @@ impl LanguageServer for FloeLsp {
                     }));
                 }
 
+                // Check typed AST before falling back to generic display
+                if let Some((_, ref ty)) = typed_ast {
+                    return Ok(Some(Hover {
+                        contents: HoverContents::Markup(MarkupContent {
+                            kind: MarkupKind::Markdown,
+                            value: format!(
+                                "```floe\n(property) {word}: {}\n```",
+                                ty.display_name()
+                            ),
+                        }),
+                        range: None,
+                    }));
+                }
+
                 // Fall back to showing object type + member
                 return Ok(Some(Hover {
                     contents: HoverContents::Markup(MarkupContent {

--- a/tests/lsp/fixtures.py
+++ b/tests/lsp/fixtures.py
@@ -809,3 +809,15 @@ type ButtonProps {
     label: string,
 }
 """
+
+# ── Member access hover ─────────────────────────────────────
+
+MEMBER_ACCESS = """\
+type User {
+    name: string,
+    age: number,
+}
+
+const user = User(name: "Ryan", age: 30)
+const _name = user.name
+"""

--- a/tests/lsp/test_hover.py
+++ b/tests/lsp/test_hover.py
@@ -335,6 +335,13 @@ class TestHoverRecordSpread:
         assert "onClick" in h, f"Expected onClick field in hover, got: {h}"
         assert "label" in h, f"Expected label field in hover, got: {h}"
 
+    def test_member_access_shows_field_type(self, lsp):
+        open_doc(lsp, URI, F.MEMBER_ACCESS)
+        # Hover on 'name' in user.name (line 6, col 21)
+        h = hover_text(lsp.hover(URI, 6, 21))
+        assert h is not None, f"Expected hover for user.name, got None"
+        assert "string" in h, f"Expected string type for name field, got: {h}"
+
     def test_pipe_into_match_fn(self, lsp):
         open_doc(lsp, URI,F.PIPE_INTO_MATCH)
         h = hover_text(lsp.hover(URI, 0, 3))


### PR DESCRIPTION
closes #584

## Summary
- Member access hover (e.g. `user.name`) now shows the resolved field type from the typed AST
- Previously showed generic `(property) user.name` with `user: User` — now shows `(property) name: string`
- The typed AST already has resolved types for nested member access chains (`props.entry.reading`) — this just ensures the hover handler uses them before falling back

## Before
```
(property) user.name
`user: User`
```

## After
```
(property) name: string
```

## Note
Nested field access (#584's original issue) was already fixed by #606 (typed AST hover refactor). This PR improves the remaining case where the type_map field lookup misses but the typed AST has the answer.

## Test plan
- [x] New LSP test: `test_member_access_shows_field_type`
- [x] All 215 LSP tests pass
- [x] Quality gate: cargo fmt, clippy, tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)