### PR TITLE
chore: [#654] Document the { } vs = type system mental model

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -26,7 +26,7 @@ A React developer should read Floe and understand it in 30 minutes. We keep fami
 
 ```
 (x) => arrow closures         (a) => a + 1
-->    match arms              Ok(x) -> x
+->    match arms, fn types    Ok(x) -> x, (T) -> U
 |>    pipe data through       data |> transform
 ?     unwrap Result/Option    fetchUser(id)?
 .x    dot shorthand           .name (implicit closure for field access)
@@ -66,7 +66,7 @@ All four of TypeScript's `?` uses (`?.`, `??`, `?:`, `? :`) are removed. `?` now
 | `unreachable` | assert unreachable, type `never` | `(() => { throw new Error("unreachable"); })()` |
 | `?` operator | `fetchUser(id)?` | early return on Err/None |
 | Newtypes | `type UserId { string }` | `string` at runtime (single-variant wrapper) |
-| Opaque types | `opaque type HashedPw = string` | `string`, but only the defining module can create/read |
+| Opaque types | `opaque type HashedPw { string }` | `string`, but only the defining module can create/read |
 | Tagged unions | `type Route { \| Home \| Profile { id: string } }` | discriminated union |
 | String literal unions | `type Method = "GET" \| "POST" \| "PUT"` | `"GET" \| "POST" \| "PUT"` (pass-through for npm interop) |
 | Nested unions | `type ApiError { \| Network { NetworkError } \| NotFound }` | nested discriminated union (compiler generates tags) |
@@ -116,7 +116,7 @@ All four of TypeScript's `?` uses (`?.`, `??`, `?:`, `? :`) are removed. `?` now
 | `x?: T` | Optional fields | `x: Option<T>` |
 | `+` on strings | Silent coercion bugs | Template literals only (warning) |
 | `void` | Not a real type, can't use in generics | Unit type `()` — a real value |
-| `=>` in expressions | Two syntaxes for functions is one too many | `fn(x) expr` for anonymous functions; `=>` is reserved for function types like `(T) => U` |
+| `=>` in expressions | Two syntaxes for functions is one too many | `fn(x) expr` for anonymous functions; `->` is used for function types like `(T) -> U` |
 | `function` | Verbose keyword | `fn` |
 | `if`/`else` | Redundant control flow | `match` expression |
 | `return` | Implicit returns — last expression is the value | Omit `return`; the last expression in a block is the return value |
@@ -453,7 +453,7 @@ type BaseProps {
 
 type ButtonProps {
   ...BaseProps,
-  onClick: () => (),
+  onClick: () -> (),
   label: string,
 }
 // ButtonProps has: className, disabled, onClick, label
@@ -613,7 +613,7 @@ sendEmail(id, "hello")  // COMPILE ERROR: UserId is not Email
 
 ```floe
 // auth/password.fl
-opaque type HashedPassword = string
+opaque type HashedPassword { string }
 
 export fn hash(raw: string): HashedPassword {
   bcrypt(raw)  // only this module can create one
@@ -772,7 +772,7 @@ fetchUsers(limit: 50, sort: Descending)          // override two
 // On React component props
 type ButtonProps {
   label: string                      // required
-  onClick: () => ()                  // required
+  onClick: () -> ()                  // required
   variant: Variant = Primary         // default
   size: Size = Medium                // default
   disabled: boolean = false             // default
@@ -1256,8 +1256,8 @@ Key tokens beyond standard TypeScript:
 | Token | Lexeme |
 |-------|--------|
 | `Pipe` | `\|>` |
-| `Arrow` | `->` (match arms, return types) |
-| `FatArrow` | `=>` (function types) |
+| `Arrow` | `->` (match arms, return types, function types) |
+| `FatArrow` | `=>` (closures) |
 | `Question` | `?` (postfix, Result/Option unwrap) |
 | `Underscore` | `_` (placeholder/partial application) |
 | `PipePipe` | `\|\|` (boolean OR) |
@@ -1291,7 +1291,7 @@ Banned tokens (immediate compile errors with helpful messages):
 - `enum` → "Use type with | variants"
 - `void` → "Use the unit type () instead"
 - `function` → "Use fn instead"
-- `=>` after `fn(x)` → "Use fn(x) for closures — the => is only for function types like (T) => U"
+- `=>` after `fn(x)` → "Use fn(x) for closures — function types use -> like (T) -> U"
 
 ### Parser (`floe_parser`)
 
@@ -1537,7 +1537,7 @@ Emits clean, readable `.tsx`. Zero runtime imports.
 | `Array.groupBy(arr, fn)` | `Object.groupBy(arr, fn)` |
 | `Number.parse("123")` | strict parse returning `Result` |
 | `type UserId { string }` | `string` (newtype erased) |
-| `opaque type X = T` | `T` (erased, access controlled at compile time) |
+| `opaque type X { T }` | `T` (erased, access controlled at compile time) |
 | `for User { fn display(self) -> string { ... } }` | `function display(self: User): string { ... }` |
 | `trait Display { fn display(self) -> string }` | *(erased — no output)* |
 | `for User: Display { fn display(self) -> string { ... } }` | `function display(self: User): string { ... }` (same as plain for block) |
@@ -1754,7 +1754,7 @@ fn deleteUser(id: UserId) -> Result<(), ApiError> {
 
 // Callbacks
 type ButtonProps {
-  onClick: () => ()
+  onClick: () -> ()
 }
 ```
 
@@ -1833,8 +1833,7 @@ const c = { ...a, ...b }    // WARNING: 'y' from 'a' is overwritten by 'b'
 |----------|----------|-----------|
 | Syntax style | TS keywords + Gleam match/pipe | Familiar to React devs, 30min learning curve |
 | Function style | `fn` for named, `(x) => expr` for inline closures, `.field` for shorthand | One keyword, two closure forms, no overlap |
-| Arrow `->` | Match arms, return types | "Maps to" for control flow and declarations |
-| Fat arrow `=>` | Function types | `(T) => U` mirrors TypeScript's function type syntax |
+| Arrow `->` | Match arms, return types, function types | `(T) -> U` for function types, `match x { A -> ... }` for match arms, `fn f() -> T` for return types |
 | `const name = (x) => ...` | Compile error | If it has a name, use `fn`. No two ways to name a function. |
 | Dot shorthand | `.field` in callback position creates implicit closure | Covers 80% of inline callbacks (filter, map, sort) |
 | Qualified variants | `Type.Variant` when ambiguous, bare when unambiguous | Compiler errors on ambiguous bare variants with helpful suggestion |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -111,14 +111,6 @@ type ApiError {
 // Newtype (single-value wrapper)
 type OrderId { number }
 
-// String literal union (for npm interop)
-type HttpMethod = "GET" | "POST" | "PUT" | "DELETE"
-
-// String literal type arguments (for npm interop)
-// Used with React's ComponentProps, event emitters, etc.
-import trusted { ComponentProps } from "react"
-type DivProps = ComponentProps<"div">
-
 // Record type composition with spread
 type BaseProps {
     className: string,
@@ -127,7 +119,7 @@ type BaseProps {
 
 type ButtonProps {
     ...BaseProps,
-    onClick: () => (),
+    onClick: () -> (),
     label: string,
 }
 // ButtonProps has: className, disabled, onClick, label
@@ -137,6 +129,25 @@ type A { x: number }
 type B { y: string }
 type C { ...A, ...B, z: boolean }
 
+// Newtypes (single-variant wrappers)
+type UserId { string }
+type Email { string }
+
+// ── Floe types use { }, TS interop types use = ──────
+
+// Opaque types (only defining module can create/read)
+opaque type HashedPassword { string }
+
+// ── TS interop types (= syntax) ────────────────────
+
+// String literal union (for npm interop)
+type HttpMethod = "GET" | "POST" | "PUT" | "DELETE"
+
+// String literal type arguments (for npm interop)
+// Used with React's ComponentProps, event emitters, etc.
+import trusted { ComponentProps } from "react"
+type DivProps = ComponentProps<"div">
+
 // Spread with generic types and typeof (npm interop)
 import trusted { tv, VariantProps } from "tailwind-variants"
 const variants = tv({ base: "rounded", variants: { size: { sm: "p-2" } } })
@@ -145,13 +156,6 @@ type Props {
     className: string,
 }
 // Compiles to: type Props = VariantProps<typeof variants> & { className: string };
-
-// Newtypes (single-variant wrappers)
-type UserId { string }
-type Email { string }
-
-// Opaque types (only defining module can create/read)
-opaque type HashedPassword = string
 
 // Tuples
 const point: (number, number) = (10, 20)
@@ -610,7 +614,7 @@ match key {
 | `? :` (ternary) | `match` expression |
 | `?.` (optional chain) | `match` on `Option` or `?` |
 | `??` (nullish coalesce) | `Option.unwrapOr` |
-| `=>` (arrow function) | `(x) => expr` closure; `=>` reserved for function types `(T) => U` |
+| `=>` (arrow function) | `(x) => expr` closure; function types use `->`: `(T) -> U` |
 | `function` keyword | `fn` |
 | `void` | Unit type `()` |
 | `as` (type assertion) | Type guards or `match` |

--- a/docs/site/src/content/docs/guide/from-typescript.md
+++ b/docs/site/src/content/docs/guide/from-typescript.md
@@ -41,7 +41,7 @@ const result = items |> Array.filter(.active)
 onClick={() => setCount(count + 1)}
 ```
 
-### `->` for return types, `=>` for function types
+### `->` for return types and function types
 
 ```typescript
 // TypeScript
@@ -50,7 +50,7 @@ type Transform = (s: string) => number
 
 // Floe
 fn add(a: number, b: number) -> number { ... }
-type Transform = (string) => number
+type Transform = (string) -> number
 ```
 
 ### `const` only

--- a/docs/site/src/content/docs/guide/functions.md
+++ b/docs/site/src/content/docs/guide/functions.md
@@ -65,7 +65,7 @@ fn identity<T>(x: T) -> T { x }
 
 fn pair<A, B>(a: A, b: B) -> (A, B) { (a, b) }
 
-fn mapResult<T, U, E>(r: Result<T, E>, f: (T) => U) -> Result<U, E> {
+fn mapResult<T, U, E>(r: Result<T, E>, f: (T) -> U) -> Result<U, E> {
     match r {
         Ok(value) -> Ok(f(value)),
         Err(e) -> Err(e),
@@ -118,12 +118,12 @@ fn double(x: number) -> number { x * 2 }
 
 ### Function Types
 
-Use `=>` to describe function types:
+Use `->` to describe function types:
 
 ```floe
-type Transform = (string) => number
-type Predicate = (Todo) => boolean
-type Callback = () => ()
+type Transform = (string) -> number
+type Predicate = (Todo) -> boolean
+type Callback = () -> ()
 ```
 
 ### Async Functions
@@ -170,7 +170,7 @@ Console.log("done")
 - **No `class`** - use functions and records
 - **No `this`** - functions are pure by default
 - **No `function*` generators** - use arrays and pipes
-- **No `=>` in expressions** - use `fn(x)` for closures; `=>` is only for function types like `(T) => U`
+- **No `=>` in expressions** - use `fn(x)` for closures; `->` is used for function types like `(T) -> U`
 - **No `function` keyword** - use `fn` for named functions
 
 These are removed intentionally. See the [comparison](/guide/comparison) for the reasoning.

--- a/docs/site/src/content/docs/guide/jsx.md
+++ b/docs/site/src/content/docs/guide/jsx.md
@@ -26,7 +26,7 @@ Components are exported `fn` declarations with a `JSX.Element` return type. The 
 ```floe
 type ButtonProps {
   label: string,
-  onClick: () => (),
+  onClick: () -> (),
   disabled: boolean,
 }
 

--- a/docs/site/src/content/docs/guide/pipes.md
+++ b/docs/site/src/content/docs/guide/pipes.md
@@ -144,9 +144,8 @@ Pipes shine when you have a sequence of transformations. They replace:
 Floe has three arrow-like operators:
 
 ```
-fn(x) anonymous closures  fn(a) a + 1
-->    match arms / returns Ok(x) -> x, fn add(a) -> number
-=>    function types       (string) => number
+(x) => closures            (a) => a + 1
+->    match arms / returns / function types  Ok(x) -> x, fn add(a) -> number, (string) -> number
 |>    pipe data             data |> transform
 ```
 

--- a/docs/site/src/content/docs/guide/tour.md
+++ b/docs/site/src/content/docs/guide/tour.md
@@ -160,7 +160,7 @@ const id = OrderId(42)
 const OrderId(n) = id   // destructure to get inner value
 
 // Opaque types — only the defining module can create/read
-opaque type HashedPassword = string
+opaque type HashedPassword { string }
 
 // String literal unions (for npm interop)
 type Method = "GET" | "POST" | "PUT" | "DELETE"
@@ -168,7 +168,7 @@ type Method = "GET" | "POST" | "PUT" | "DELETE"
 // Record composition
 type ButtonProps {
     ...BaseProps,
-    onClick: () => (),
+    onClick: () -> (),
     label: string,
 }
 

--- a/docs/site/src/content/docs/guide/types.md
+++ b/docs/site/src/content/docs/guide/types.md
@@ -44,7 +44,7 @@ type BaseProps {
 
 type ButtonProps {
   ...BaseProps,
-  onClick: () => (),
+  onClick: () -> (),
   label: string,
 }
 // ButtonProps has: className, disabled, onClick, label
@@ -274,7 +274,7 @@ type PostId { string }
 Types where only the defining module can see the internal structure:
 
 ```floe
-opaque type Email = string
+opaque type Email { string }
 
 // Only this module can construct/destructure Email values
 ```
@@ -309,7 +309,7 @@ Tuples compile to TypeScript readonly tuples: `(number, string)` becomes `readon
 
 ```floe
 type Name = string
-type Callback = (Event) => ()
+type Callback = (Event) -> ()
 ```
 
 ## Differences from TypeScript

--- a/docs/site/src/content/docs/reference/operators.md
+++ b/docs/site/src/content/docs/reference/operators.md
@@ -62,8 +62,7 @@ The `?` operator unwraps `Ok(value)` or `Some(value)`, and returns early with `E
 |----------|---------|---------|
 | `(x) =>` | Closures | `(x) => x + 1` |
 | `.field` | Dot shorthand | `.name` (implicit field-access closure) |
-| `->` | Match arms, return types | `Ok(x) -> x`, `fn add(a) -> number` |
-| `=>` | Function types | `(string) => number` |
+| `->` | Match arms, return types, function types | `Ok(x) -> x`, `fn add(a) -> number`, `(string) -> number` |
 | `\|>` | Pipes | `data \|> transform` |
 
 ## Precedence (high to low)

--- a/docs/site/src/content/docs/reference/stdlib.md
+++ b/docs/site/src/content/docs/reference/stdlib.md
@@ -23,12 +23,12 @@ All array functions return new arrays. They never mutate the original.
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `Array.sort` | `Array<number> -> Array<number>` | Sort numerically (returns new array) |
-| `Array.sortBy` | `Array<T>, (T) => number -> Array<T>` | Sort by key function |
-| `Array.map` | `Array<T>, (T) => U -> Array<U>` | Transform each element |
-| `Array.filter` | `Array<T>, (T) => boolean -> Array<T>` | Keep elements matching predicate |
-| `Array.find` | `Array<T>, (T) => boolean -> Option<T>` | First element matching predicate |
-| `Array.findIndex` | `Array<T>, (T) => boolean -> Option<number>` | Index of first match |
-| `Array.flatMap` | `Array<T>, (T) => Array<U> -> Array<U>` | Map then flatten one level |
+| `Array.sortBy` | `Array<T>, (T) -> number -> Array<T>` | Sort by key function |
+| `Array.map` | `Array<T>, (T) -> U -> Array<U>` | Transform each element |
+| `Array.filter` | `Array<T>, (T) -> boolean -> Array<T>` | Keep elements matching predicate |
+| `Array.find` | `Array<T>, (T) -> boolean -> Option<T>` | First element matching predicate |
+| `Array.findIndex` | `Array<T>, (T) -> boolean -> Option<number>` | Index of first match |
+| `Array.flatMap` | `Array<T>, (T) -> Array<U> -> Array<U>` | Map then flatten one level |
 | `Array.at` | `Array<T>, number -> Option<T>` | Safe index access |
 | `Array.contains` | `Array<T>, T -> boolean` | Check if element exists (structural equality) |
 | `Array.head` | `Array<T> -> Option<T>` | First element |
@@ -36,16 +36,16 @@ All array functions return new arrays. They never mutate the original.
 | `Array.take` | `Array<T>, number -> Array<T>` | First n elements |
 | `Array.drop` | `Array<T>, number -> Array<T>` | All except first n elements |
 | `Array.reverse` | `Array<T> -> Array<T>` | Reverse order (returns new array) |
-| `Array.reduce` | `Array<T>, U, (U, T) => U -> U` | Fold into a single value |
+| `Array.reduce` | `Array<T>, U, (U, T) -> U -> U` | Fold into a single value |
 | `Array.length` | `Array<T> -> number` | Number of elements |
-| `Array.any` | `Array<T>, (T) => boolean -> boolean` | True if any element matches predicate |
-| `Array.all` | `Array<T>, (T) => boolean -> boolean` | True if all elements match predicate |
+| `Array.any` | `Array<T>, (T) -> boolean -> boolean` | True if any element matches predicate |
+| `Array.all` | `Array<T>, (T) -> boolean -> boolean` | True if all elements match predicate |
 | `Array.sum` | `Array<number> -> number` | Sum all elements |
 | `Array.join` | `Array<string>, string -> string` | Join elements with separator |
 | `Array.isEmpty` | `Array<T> -> boolean` | True if array has no elements |
 | `Array.chunk` | `Array<T>, number -> Array<Array<T>>` | Split into chunks of given size |
 | `Array.unique` | `Array<T> -> Array<T>` | Remove duplicate elements |
-| `Array.groupBy` | `Array<T>, (T) => string -> Record` | Group elements by key function |
+| `Array.groupBy` | `Array<T>, (T) -> string -> Record` | Group elements by key function |
 | `Array.zip` | `Array<T>, Array<U> -> Array<[T, U]>` | Pair elements from two arrays |
 
 ### Examples
@@ -94,8 +94,8 @@ Functions for working with `Option<T>` (`Some(v)` / `None`) values.
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `Option.map` | `Option<T>, (T) => U -> Option<U>` | Transform the inner value if present |
-| `Option.flatMap` | `Option<T>, (T) => Option<U> -> Option<U>` | Chain option-returning operations |
+| `Option.map` | `Option<T>, (T) -> U -> Option<U>` | Transform the inner value if present |
+| `Option.flatMap` | `Option<T>, (T) -> Option<U> -> Option<U>` | Chain option-returning operations |
 | `Option.unwrapOr` | `Option<T>, T -> T` | Extract value or use default |
 | `Option.isSome` | `Option<T> -> boolean` | Check if value is present |
 | `Option.isNone` | `Option<T> -> boolean` | Check if value is absent |
@@ -130,9 +130,9 @@ Functions for working with `Result<T, E>` (`Ok(v)` / `Err(e)`) values.
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `Result.map` | `Result<T, E>, (T) => U -> Result<U, E>` | Transform the Ok value |
-| `Result.mapErr` | `Result<T, E>, (E) => F -> Result<T, F>` | Transform the Err value |
-| `Result.flatMap` | `Result<T, E>, (T) => Result<U, E> -> Result<U, E>` | Chain result-returning operations |
+| `Result.map` | `Result<T, E>, (T) -> U -> Result<U, E>` | Transform the Ok value |
+| `Result.mapErr` | `Result<T, E>, (E) -> F -> Result<T, F>` | Transform the Err value |
+| `Result.flatMap` | `Result<T, E>, (T) -> Result<U, E> -> Result<U, E>` | Chain result-returning operations |
 | `Result.unwrapOr` | `Result<T, E>, T -> T` | Extract Ok value or use default |
 | `Result.isOk` | `Result<T, E> -> boolean` | Check if result is Ok |
 | `Result.isErr` | `Result<T, E> -> boolean` | Check if result is Err |
@@ -284,7 +284,7 @@ Standard math functions. Compile directly to JavaScript `Math` methods.
 | `Math.sin` | `number -> number` | Sine |
 | `Math.cos` | `number -> number` | Cosine |
 | `Math.tan` | `number -> number` | Tangent |
-| `Math.random` | `() => number` | Random number between 0 (inclusive) and 1 (exclusive) |
+| `Math.random` | `() -> number` | Random number between 0 (inclusive) and 1 (exclusive) |
 
 ### Examples
 
@@ -503,7 +503,7 @@ Utility functions for pipeline debugging and control flow.
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `tap` | `T, (T) => () -> T` | Call a function for side effects, return value unchanged |
+| `tap` | `T, (T) -> () -> T` | Call a function for side effects, return value unchanged |
 
 ### Examples
 

--- a/docs/site/src/content/docs/reference/syntax.md
+++ b/docs/site/src/content/docs/reference/syntax.md
@@ -77,7 +77,7 @@ type Name = string
 type UserId { string }
 
 // Opaque
-opaque type Email = string
+opaque type Email { string }
 
 // Deriving traits
 type Point {
@@ -246,9 +246,9 @@ Dot shorthand for field access:
 ### Function Types
 
 ```floe
-() => ()                    // takes nothing, returns nothing
-(string) => number          // takes string, returns number
-(number, number) => boolean    // takes two numbers, returns boolean
+() -> ()                    // takes nothing, returns nothing
+(string) -> number          // takes string, returns number
+(number, number) -> boolean    // takes two numbers, returns boolean
 ```
 
 ### JSX

--- a/docs/site/src/content/docs/reference/types.md
+++ b/docs/site/src/content/docs/reference/types.md
@@ -53,7 +53,7 @@ type BaseProps {
 
 type ButtonProps {
   ...BaseProps,
-  onClick: () => (),
+  onClick: () -> (),
   label: string,
 }
 ```
@@ -150,7 +150,7 @@ type PostId { string }
 Types where internals are hidden from other modules:
 
 ```floe
-opaque type Email = string
+opaque type Email { string }
 ```
 
 Only code in the module that defines `Email` can construct or destructure it. Other modules see it as an opaque blob.
@@ -168,7 +168,7 @@ Result<User, Error>
 Option<string>
 
 // Function
-(number, number) => number
+(number, number) -> number
 
 // Record (inline)
 { name: string, age: number }


### PR DESCRIPTION
closes #654

## Summary

Updates all documentation to reflect the type system syntax changes from the #649 epic:

- **`docs/design.md`** — function types use `->`, opaque types use `{ }`, token table updated
- **`docs/llms.txt`** — reorganized with `{ }` vs `=` section headers, all syntax examples updated
- **`docs/site/`** — 10 guide/reference pages updated (types, functions, jsx, tour, pipes, operators, stdlib, syntax, from-typescript)

**The mental model:**
- `type Name { ... }` = defining a new Floe type (records, unions, newtypes, opaque)
- `type Name = ...` = naming a TS shape (aliases, intersections, string literal unions)
- `->` means "produces" everywhere (fn signatures, match arms, function types)
- `=>` stays only for closure expressions

## Test plan
- [x] All 1015 tests pass (docs-only change, no code changes)
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)