### PR TITLE
fix: [#665] useContext returns unknown - probe unit type and generic inference

### DIFF
--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -1,6 +1,36 @@
 use super::*;
 use crate::type_layout;
 
+/// Check if a string is a single uppercase letter (generic type parameter).
+fn is_generic_param(s: &str) -> bool {
+    s.len() == 1 && s.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+}
+
+/// Parse a Foreign type string like "Context<AuthContextValue>" into
+/// ("Context", ["AuthContextValue"]). Returns None if no generics.
+fn parse_foreign_generics(s: &str) -> Option<(String, Vec<String>)> {
+    let open = s.find('<')?;
+    let base = s[..open].to_string();
+    let inner = s.get(open + 1..s.len() - 1)?; // strip < and >
+    // Split by top-level commas (respecting nested <>)
+    let mut args = Vec::new();
+    let mut depth = 0;
+    let mut start = 0;
+    for (i, c) in inner.char_indices() {
+        match c {
+            '<' => depth += 1,
+            '>' => depth -= 1,
+            ',' if depth == 0 => {
+                args.push(inner[start..i].trim().to_string());
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    args.push(inner[start..].trim().to_string());
+    Some((base, args))
+}
+
 // ── Expression Checking ──────────────────────────────────────
 
 impl Checker {
@@ -1381,7 +1411,7 @@ impl Checker {
         seen: &mut std::collections::HashSet<String>,
     ) {
         match ty {
-            Type::Named(n) if n.len() == 1 && n.chars().next().unwrap().is_ascii_uppercase() => {
+            Type::Named(n) if is_generic_param(n) => {
                 if seen.insert(n.clone()) {
                     names.push(n.clone());
                 }
@@ -1413,6 +1443,16 @@ impl Checker {
             }
             Type::Set { element } => {
                 Self::collect_generic_params_from_type(element, names, seen);
+            }
+            Type::Foreign(s) => {
+                // Extract generic params from Foreign strings like "Context<T>"
+                if let Some((_, args)) = parse_foreign_generics(s) {
+                    for arg in &args {
+                        if is_generic_param(arg) && seen.insert(arg.clone()) {
+                            names.push(arg.clone());
+                        }
+                    }
+                }
             }
             _ => {}
         }
@@ -1461,6 +1501,23 @@ impl Checker {
             (Type::Result { ok: po, err: pe }, Type::Result { ok: ao, err: ae }) => {
                 Self::unify_for_inference(po, ao, generics, subs);
                 Self::unify_for_inference(pe, ae, generics, subs);
+            }
+            // Foreign types with matching base names: extract and unify generic args
+            // e.g., Foreign("Context<T>") with Foreign("Context<AuthContextValue>")
+            (Type::Foreign(p_str), Type::Foreign(a_str)) => {
+                if let Some((p_base, p_args)) = parse_foreign_generics(p_str)
+                    && let Some((a_base, a_args)) = parse_foreign_generics(a_str)
+                    && p_base == a_base
+                    && p_args.len() == a_args.len()
+                {
+                    for (p_arg, a_arg) in p_args.iter().zip(a_args.iter()) {
+                        // If the param arg is a single uppercase letter (generic), bind it
+                        if is_generic_param(p_arg) && generics.contains(p_arg) {
+                            subs.entry(p_arg.clone())
+                                .or_insert_with(|| Type::Foreign(a_arg.clone()));
+                        }
+                    }
+                }
             }
             // Union param: try matching arg against first non-generic member
             // e.g., S | (() => S) with arg "hello" → S = string

--- a/src/interop/tsgo.rs
+++ b/src/interop/tsgo.rs
@@ -1071,6 +1071,9 @@ fn type_expr_to_ts(ty: &TypeExpr) -> String {
             name, type_args, ..
         } => {
             let ts_name = match name.as_str() {
+                "()" => "void",
+                "undefined" => "undefined",
+                "never" => "never",
                 "bool" => "boolean",
                 "Option" if type_args.len() == 1 => {
                     let inner = type_expr_to_ts(&type_args[0]);


### PR DESCRIPTION
closes #665
closes #666

## Summary
Two root causes found and fixed:

1. **Unit type breaks DTS parser**: The probe emitted Floe's `()` unit type as `"()"` in TypeScript type positions, producing invalid syntax like `unsubscribe: () => () =>` (double arrow). Changed to emit `"void"` instead. This was causing the entire probe to fail to parse, so NO npm type information was available for the file.

2. **Generic inference for Foreign types**: Added `parse_foreign_generics()` to extract generic args from `Foreign("Context<T>")` strings. The generic unifier now matches `Foreign("Context<T>")` against `Foreign("Context<AuthContextValue>")` and infers `T = AuthContextValue`. Also updated `collect_generic_params` to find generic params inside Foreign type strings.

## What this fixes
- `useContext(AuthContext)` now returns `AuthContextValue` instead of `unknown`
- `onAuthStateChange(callback)` callback parameter type now infers correctly
- Any file with `() -> ()` function types in records no longer breaks the probe

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (1014 tests)
- [x] `floe check` and `floe build` on example apps pass
- [x] kansai-accent-floe: **10 files, 0 errors** (was 9 ok, 1 with errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)