### PR TITLE
chore: [#673] Restructure type docs with { } vs = mental model

### DIFF
--- a/docs/site/src/content/docs/guide/types.md
+++ b/docs/site/src/content/docs/guide/types.md
@@ -2,6 +2,26 @@
 title: Types
 ---
 
+## Two Kinds of Type Declarations
+
+Floe uses one keyword (`type`) with two forms:
+
+```floe
+type User { name: string }                  // { } — defines a new Floe type
+type DivProps = ComponentProps<"div">        // = — names a TypeScript shape
+```
+
+**`type Name { ... }`** creates a new, distinct Floe type. Two types with identical fields are NOT interchangeable — `User` is not `Product` even if both have a `name: string` field. Use `...Spread` to compose records.
+
+**`type Name = ...`** aliases an existing TypeScript type. Use this when bridging to npm libraries — for string literal unions (`"GET" | "POST"`), type aliases (`ComponentProps<"div">`), and intersections (`A & { extra: string }`).
+
+| | `{ }` — Floe types | `=` — TS bridge types |
+|---|---|---|
+| **Creates** | New nominal type | Alias to existing type |
+| **Used for** | Records, unions, newtypes, opaque | Aliases, string literal unions, `&` intersections |
+| **Composition** | `...Spread` | `&` |
+| **When to use** | Your own data types | Referencing TS library types |
+
 ## Primitives
 
 ```floe
@@ -171,7 +191,11 @@ result |> Result.mapErr(Validation)
 
 Unit variants (no fields) are values, not functions — `All` produces `{ tag: "All" }` directly.
 
-## String Literal Unions
+## TS Bridge Types (`=` syntax)
+
+The `=` syntax creates type aliases that reference TypeScript types. Use these when working with npm libraries.
+
+### String Literal Unions
 
 For npm interop with TypeScript libraries that use string literal unions:
 
@@ -194,13 +218,26 @@ fn describe(method: HttpMethod) -> string {
 // Compiler error if you miss a variant
 ```
 
-String literal unions compile to the same TypeScript type:
+For pure Floe code, prefer tagged unions (`type Method { | Get | Post }`) since they work with constructors, for-blocks, and provide better type safety. String literal unions exist for seamless npm interop.
 
-```typescript
-type HttpMethod = "GET" | "POST" | "PUT" | "DELETE";
+### Type Aliases
+
+Reference an existing type by a new name:
+
+```floe
+type DivProps = ComponentProps<"div">
+type Callback = (Event) -> ()
 ```
 
-For pure Floe code, prefer regular tagged unions (`| Get | Post`) since they work with constructors, for-blocks, and provide better type safety. String literal unions exist primarily for seamless npm interop.
+### Intersections
+
+Combine TypeScript types with `&` (only in `=` declarations):
+
+```floe
+type CardProps = VariantProps<typeof cardVariants> & { className: string }
+```
+
+For Floe-native record composition, use `...Spread` instead (see [Record Type Composition](#record-type-composition) above).
 
 ## Result and Option
 
@@ -304,13 +341,6 @@ match divmod(10, 3) {
 ```
 
 Tuples compile to TypeScript readonly tuples: `(number, string)` becomes `readonly [number, string]`, and `(1, "a")` becomes `[1, "a"] as const`.
-
-## Type Aliases
-
-```floe
-type Name = string
-type Callback = (Event) -> ()
-```
 
 ## Differences from TypeScript
 

--- a/docs/site/src/content/docs/guide/typescript-interop.md
+++ b/docs/site/src/content/docs/guide/typescript-interop.md
@@ -51,7 +51,11 @@ capitalize("hello")             // trusted, no try needed
 const data = try fetchData()    // not trusted, try required
 ```
 
-## String literal unions
+## Bridge types (`=` syntax)
+
+When you need to reference TypeScript types, Floe uses the `=` syntax. This is distinct from `{ }` which creates new Floe types. See [Types](/guide/types/#two-kinds-of-type-declarations) for the full mental model.
+
+### String literal unions
 
 Many TypeScript libraries use string literal unions for configuration and options:
 
@@ -79,6 +83,22 @@ fn describe(method: HttpMethod) -> string {
 ```
 
 The match is exhaustive -- if you miss a variant, the compiler tells you. The type compiles directly to the same TypeScript string union (no tags, no wrapping).
+
+### Type aliases and intersections
+
+Alias TypeScript types or combine them with `&`:
+
+```floe
+import trusted { ComponentProps } from "react"
+import trusted { tv, VariantProps } from "tailwind-variants"
+
+type DivProps = ComponentProps<"div">
+
+const cardVariants = tv({ base: "rounded-xl", variants: { size: { sm: "p-2" } } })
+type CardProps = VariantProps<typeof cardVariants> & { className: string }
+```
+
+`&` intersections are only valid in `=` declarations. For Floe-native record composition, use `...Spread` in `{ }` definitions.
 
 ## Nullable and optional type conversion
 

--- a/docs/site/src/content/docs/reference/types.md
+++ b/docs/site/src/content/docs/reference/types.md
@@ -19,7 +19,18 @@ title: Types Reference
 | `Array<T>` | Ordered collection |
 | `Promise<T>` | Async value |
 
-## Record Types
+## Type Declarations
+
+Floe has two forms of type declaration:
+
+| Syntax | Meaning | Used for |
+|---|---|---|
+| `type Name { ... }` | Define a new Floe type | Records, unions, newtypes, opaque types |
+| `type Name = ...` | Alias a TypeScript type | TS interop aliases, string literal unions, `&` intersections |
+
+## Floe Types (`{ }` syntax)
+
+### Record Types
 
 Named product types with fields:
 
@@ -86,7 +97,7 @@ Compiles to:
 type CardProps = VariantProps<typeof cardVariants> & { className: string };
 ```
 
-## Union Types
+### Union Types
 
 Tagged discriminated unions:
 
@@ -107,7 +118,30 @@ type Shape =
   | { _tag: "Point" };
 ```
 
-## String Literal Unions
+### Newtypes
+
+Single-variant wrappers that are distinct at compile time but erase to their base type at runtime:
+
+```floe
+type UserId { string }
+type PostId { string }
+```
+
+`UserId` and `PostId` are both `string` at runtime, but the compiler prevents mixing them up.
+
+### Opaque Types
+
+Types where internals are hidden from other modules:
+
+```floe
+opaque type Email { string }
+```
+
+Only code in the module that defines `Email` can construct or destructure it. Other modules see it as an opaque blob.
+
+## TS Bridge Types (`=` syntax)
+
+### String Literal Unions
 
 String literal unions for npm interop:
 
@@ -134,26 +168,21 @@ match method {
 
 Exhaustiveness is checked -- missing a variant is a compile error.
 
-## Newtypes
-
-Single-variant wrappers that are distinct at compile time but erase to their base type at runtime:
+### Type Aliases
 
 ```floe
-type UserId { string }
-type PostId { string }
+type DivProps = ComponentProps<"div">
 ```
 
-`UserId` and `PostId` are both `string` at runtime, but the compiler prevents mixing them up.
+### Intersections
 
-## Opaque Types
-
-Types where internals are hidden from other modules:
+Combine TypeScript types with `&` (only valid in `=` declarations):
 
 ```floe
-opaque type Email { string }
+type CardProps = VariantProps<typeof variants> & { className: string }
 ```
 
-Only code in the module that defines `Email` can construct or destructure it. Other modules see it as an opaque blob.
+For Floe-native record composition, use `...Spread` in `{ }` definitions instead.
 
 ## Type Expressions
 


### PR DESCRIPTION
closes #673

## Summary

Restructures the type documentation to clearly teach the `{ }` vs `=` mental model:

**guide/types.md:**
- New "Two Kinds of Type Declarations" section at the very top with comparison table
- String literal unions, type aliases, and intersections grouped under "TS Bridge Types (`=` syntax)" header
- Removed standalone "Type Aliases" section (merged into TS bridge section)

**reference/types.md:**
- Types grouped under "Floe Types (`{ }` syntax)" and "TS Bridge Types (`=` syntax)" headers
- Newtypes and opaque types moved under Floe types
- Added type aliases and intersections under TS bridge types

**guide/typescript-interop.md:**
- New "Bridge types (`=` syntax)" section with cross-reference to types guide
- Added type aliases and `&` intersections examples

## Test plan
- [x] Docs-only change, no code changes
- [x] All cross-references point to valid anchors

🤖 Generated with [Claude Code](https://claude.com/claude-code)