### PR TITLE
fix: [#691] floe fmt should skip files with parse errors

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -8,14 +8,17 @@ use crate::cst::CstParser;
 use crate::lexer::Lexer;
 use crate::syntax::{SyntaxKind, SyntaxNode};
 
-/// Format Floe source code.
-pub fn format(source: &str) -> String {
+/// Format Floe source code. Returns `None` if the file has parse errors.
+pub fn format(source: &str) -> Option<String> {
     let tokens = Lexer::new(source).tokenize_with_trivia();
     let parse = CstParser::new(source, tokens).parse();
+    if !parse.errors.is_empty() {
+        return None;
+    }
     let root = parse.syntax();
     let mut formatter = Formatter::new(source);
     formatter.fmt_node(&root);
-    formatter.finish()
+    Some(formatter.finish())
 }
 
 pub(crate) enum JsxChildInfo {

--- a/src/formatter/tests.rs
+++ b/src/formatter/tests.rs
@@ -1,7 +1,7 @@
 use super::format;
 
 fn assert_fmt(input: &str, expected: &str) {
-    let result = format(input);
+    let result = format(input).expect("format should succeed (no parse errors)");
     assert_eq!(
         result.trim(),
         expected.trim(),
@@ -345,8 +345,8 @@ fn format_preserves_block_comment_in_block() {
 // ── Idempotency ────────────────────────────────────────
 
 fn assert_idempotent(input: &str) {
-    let first = format(input);
-    let second = format(&first);
+    let first = format(input).expect("first format should succeed");
+    let second = format(&first).expect("second format should succeed");
     assert_eq!(
         first, second,
         "\nFormatter is not idempotent!\n--- 1st ---\n{first}\n--- 2nd ---\n{second}"

--- a/src/lsp/handlers.rs
+++ b/src/lsp/handlers.rs
@@ -856,7 +856,10 @@ impl LanguageServer for FloeLsp {
             return Ok(None);
         };
 
-        let formatted = crate::formatter::format(&doc.content);
+        let Some(formatted) = crate::formatter::format(&doc.content) else {
+            // Skip formatting if file has parse errors
+            return Ok(None);
+        };
 
         if formatted == doc.content {
             return Ok(None);

--- a/src/main.rs
+++ b/src/main.rs
@@ -486,11 +486,16 @@ fn cmd_fmt(path: &Path, check_only: bool) -> Result<()> {
 
     let mut unformatted = 0;
     let mut formatted = 0;
+    let mut skipped = 0;
 
     for file in &files {
         let source = read_fl_file(file)?;
 
-        let result = floe::formatter::format(&source);
+        let Some(result) = floe::formatter::format(&source) else {
+            eprintln!("  skipping {} (parse error)", file.display());
+            skipped += 1;
+            continue;
+        };
 
         if result == source {
             formatted += 1;
@@ -518,6 +523,9 @@ fn cmd_fmt(path: &Path, check_only: bool) -> Result<()> {
         println!("{total} file(s) already formatted");
     } else {
         println!("{total} file(s) formatted");
+    }
+    if skipped > 0 {
+        eprintln!("{skipped} file(s) skipped due to parse errors");
     }
     Ok(())
 }


### PR DESCRIPTION
closes #691

## Summary

`floe fmt` now skips files that have parse errors instead of producing garbled output.

- `format()` returns `Option<String>` — `None` if the file has parse errors
- CLI prints `skipping foo.fl (parse error)` and continues with other files
- `--check` mode also skips broken files
- LSP formatting handler returns no edits for unparseable files
- Summary line shows skipped count: `1 file(s) skipped due to parse errors`

## Test plan
- [x] All 1053 unit tests pass
- [x] All 216 LSP tests pass
- [x] Manual test: broken + valid files in same dir — broken skipped, valid formatted
- [x] Manual test: `--check` mode skips broken files correctly
- [x] Example apps pass fmt/check/build

🤖 Generated with [Claude Code](https://claude.com/claude-code)