### PR TITLE
feat: [#690] Support Record<K, V> from TS interop as Map with bracket-access codegen

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -2391,9 +2391,10 @@ impl Checker {
                 true // empty array [] is compatible with any Array<T>
             }
             (Type::Array(a), Type::Array(b)) => self.types_compatible(a, b),
-            (Type::Map { key: k1, value: v1 }, Type::Map { key: k2, value: v2 }) => {
-                self.types_compatible(k1, k2) && self.types_compatible(v1, v2)
-            }
+            (
+                Type::Map { key: k1, value: v1 } | Type::RecordMap { key: k1, value: v1 },
+                Type::Map { key: k2, value: v2 } | Type::RecordMap { key: k2, value: v2 },
+            ) => self.types_compatible(k1, k2) && self.types_compatible(v1, v2),
             (Type::Set { element: e1 }, Type::Set { element: e2 }) => self.types_compatible(e1, e2),
             (Type::Tuple(a), Type::Tuple(b)) => {
                 a.len() == b.len()

--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -1495,7 +1495,7 @@ impl Checker {
                 Self::collect_generic_params_from_type(ok, names, seen);
                 Self::collect_generic_params_from_type(err, names, seen);
             }
-            Type::Map { key, value } => {
+            Type::Map { key, value } | Type::RecordMap { key, value } => {
                 Self::collect_generic_params_from_type(key, names, seen);
                 Self::collect_generic_params_from_type(value, names, seen);
             }
@@ -1546,7 +1546,10 @@ impl Checker {
             (Type::Array(p), Type::Array(a)) => {
                 Self::unify_for_inference(p, a, generics, subs);
             }
-            (Type::Map { key: pk, value: pv }, Type::Map { key: ak, value: av }) => {
+            (
+                Type::Map { key: pk, value: pv } | Type::RecordMap { key: pk, value: pv },
+                Type::Map { key: ak, value: av } | Type::RecordMap { key: ak, value: av },
+            ) => {
                 Self::unify_for_inference(pk, ak, generics, subs);
                 Self::unify_for_inference(pv, av, generics, subs);
             }
@@ -1592,6 +1595,10 @@ impl Checker {
             Type::Named(n) if subs.contains_key(n) => subs[n].clone(),
             Type::Array(inner) => Type::Array(Box::new(Self::substitute_generics(inner, subs))),
             Type::Map { key, value } => Type::Map {
+                key: Box::new(Self::substitute_generics(key, subs)),
+                value: Box::new(Self::substitute_generics(value, subs)),
+            },
+            Type::RecordMap { key, value } => Type::RecordMap {
                 key: Box::new(Self::substitute_generics(key, subs)),
                 value: Box::new(Self::substitute_generics(value, subs)),
             },

--- a/src/checker/types.rs
+++ b/src/checker/types.rs
@@ -41,8 +41,14 @@ pub enum Type {
     },
     /// Array type
     Array(Box<Type>),
-    /// Map type: Map<K, V>
+    /// Map type: Map<K, V> (JS Map at runtime)
     Map {
+        key: Box<Type>,
+        value: Box<Type>,
+    },
+    /// TS Record<K, V> — plain object at runtime, supports Map operations
+    /// via bracket access codegen instead of JS Map API
+    RecordMap {
         key: Box<Type>,
         value: Box<Type>,
     },
@@ -125,7 +131,7 @@ impl Type {
                 format!("({}) -> {}", p.join(", "), return_type.display_name())
             }
             Type::Array(inner) => format!("Array<{}>", inner.display_name()),
-            Type::Map { key, value } => {
+            Type::Map { key, value } | Type::RecordMap { key, value } => {
                 format!("Map<{}, {}>", key.display_name(), value.display_name())
             }
             Type::Set { element } => format!("Set<{}>", element.display_name()),

--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -4,6 +4,22 @@ const DEEP_EQUAL_FN: &str = "__floeEq";
 const THROW_NOT_IMPLEMENTED: &str = "(() => { throw new Error(\"not implemented\"); })()";
 const THROW_UNREACHABLE: &str = "(() => { throw new Error(\"unreachable\"); })()";
 
+/// Alternative codegen templates for Map operations on plain-object Records.
+/// TS Record<K, V> maps to Floe Map<K, V>, but at runtime it's a plain object,
+/// not a JS Map, so we use bracket access instead of Map API methods.
+fn record_map_template(method: &str) -> Option<&'static str> {
+    match method {
+        "get" => Some("$0[$1]"),
+        "has" => Some("($1 in $0)"),
+        "keys" => Some("Object.keys($0)"),
+        "values" => Some("Object.values($0)"),
+        "entries" => Some("Object.entries($0)"),
+        "size" => Some("Object.keys($0).length"),
+        "isEmpty" => Some("Object.keys($0).length === 0"),
+        _ => None,
+    }
+}
+
 impl Codegen {
     // ── Expressions ──────────────────────────────────────────────
 
@@ -489,12 +505,27 @@ impl Codegen {
             && let ExprKind::Identifier(module) = &object.kind
             && let Some(stdlib_fn) = self.stdlib.lookup(module, field)
         {
-            let template = stdlib_fn.codegen.to_string();
+            // For Map.get(obj, key) etc., check if the first arg is a Record-backed Map
+            let template = if module == "Map"
+                && let Some(first_arg) = args.first()
+                && let Arg::Positional(first_expr) = first_arg
+                && self.is_record_map(&first_expr.ty)
+            {
+                record_map_template(field).unwrap_or(stdlib_fn.codegen)
+            } else {
+                stdlib_fn.codegen
+            };
             let arg_strings = self.emit_arg_strings(args);
-            Some(self.apply_stdlib_template(&template, &arg_strings))
+            Some(self.apply_stdlib_template(template, &arg_strings))
         } else {
             None
         }
+    }
+
+    /// Check if an expression's type is a Map that came from a TS Record
+    /// (plain object at runtime, not a JS Map).
+    fn is_record_map(&self, ty: &crate::checker::Type) -> bool {
+        matches!(ty, crate::checker::Type::RecordMap { .. })
     }
 
     /// Try to emit a stdlib call in pipe context (piped value is first arg).
@@ -508,11 +539,15 @@ impl Codegen {
             && let ExprKind::Identifier(module) = &object.kind
             && let Some(stdlib_fn) = self.stdlib.lookup(module, field)
         {
-            let template = stdlib_fn.codegen.to_string();
+            let template = if module == "Map" && self.is_record_map(&left.ty) {
+                record_map_template(field).unwrap_or(stdlib_fn.codegen)
+            } else {
+                stdlib_fn.codegen
+            };
             let left_str = self.emit_expr_string(left);
             let mut arg_strings = vec![left_str];
             arg_strings.extend(self.emit_arg_strings(extra_args));
-            Some(self.apply_stdlib_template(&template, &arg_strings))
+            Some(self.apply_stdlib_template(template, &arg_strings))
         } else {
             None
         }

--- a/src/interop/wrapper.rs
+++ b/src/interop/wrapper.rs
@@ -46,6 +46,11 @@ pub fn wrap_boundary_type(ts_type: &TsType) -> Type {
                 "FloeOption" if args.len() == 1 => {
                     Type::Option(Box::new(wrap_boundary_type(&args[0])))
                 }
+                // TS Record<K, V> → Floe RecordMap<K, V> (plain-object map)
+                "Record" if args.len() == 2 => Type::RecordMap {
+                    key: Box::new(wrap_boundary_type(&args[0])),
+                    value: Box::new(wrap_boundary_type(&args[1])),
+                },
                 // React's Dispatch<SetStateAction<T>> is a function: (T) -> ()
                 "Dispatch" if args.len() == 1 => {
                     let inner = unwrap_set_state_action(&args[0]);

--- a/src/lsp/stdlib_hover.rs
+++ b/src/lsp/stdlib_hover.rs
@@ -31,7 +31,9 @@ pub(super) fn format_type(ty: &crate::checker::Type) -> String {
         Type::Promise(inner) => format!("Promise<{}>", format_type(inner)),
         Type::Var(id) => type_var_name(*id).to_string(),
         Type::Array(inner) => format!("Array<{}>", format_type(inner)),
-        Type::Map { key, value } => format!("Map<{}, {}>", format_type(key), format_type(value)),
+        Type::Map { key, value } | Type::RecordMap { key, value } => {
+            format!("Map<{}, {}>", format_type(key), format_type(value))
+        }
         Type::Set { element } => format!("Set<{}>", format_type(element)),
         Type::Option(inner) => format!("Option<{}>", format_type(inner)),
         Type::Settable(inner) => format!("Settable<{}>", format_type(inner)),

--- a/src/type_layout.rs
+++ b/src/type_layout.rs
@@ -170,7 +170,7 @@ pub fn type_to_stdlib_module(ty: &crate::checker::Type) -> Option<&'static str> 
     use crate::checker::Type;
     match ty {
         Type::Array(_) => Some(MOD_ARRAY),
-        Type::Map { .. } => Some(MOD_MAP),
+        Type::Map { .. } | Type::RecordMap { .. } => Some(MOD_MAP),
         Type::Set { .. } => Some(MOD_SET),
         Type::String => Some(MOD_STRING),
         Type::Number => Some(MOD_NUMBER),


### PR DESCRIPTION
closes #690

## Summary
- TS `Record<K, V>` constants can now be imported and used in Floe via `Map` operations
- Adds `Type::RecordMap` variant to distinguish plain-object maps from JS `Map` instances
- `RecordMap` is type-compatible with `Map` everywhere (checker, generic inference, stdlib dispatch)
- Codegen emits object-compatible templates for `RecordMap`: bracket access instead of JS Map API

## Example
```ts
// constants.ts
export const PRIORITY_ICONS: Record<string, string> = { Highest: "⬆", Low: "⬇" };
```
```floe
// component.fl
import trusted { PRIORITY_ICONS } from "./constants"
const icon = PRIORITY_ICONS |> Map.get(priority) |> Option.unwrapOr("▶")
```
```ts
// Compiles to:
const icon = PRIORITY_ICONS[priority] ?? "▶";
```

## Codegen templates for RecordMap
| Operation | Map (JS Map) | RecordMap (plain object) |
|---|---|---|
| `Map.get` | `$0.has($1) ? $0.get($1) : undefined` | `$0[$1]` |
| `Map.has` | `$0.has($1)` | `($1 in $0)` |
| `Map.keys` | `[...$0.keys()]` | `Object.keys($0)` |
| `Map.values` | `[...$0.values()]` | `Object.values($0)` |
| `Map.entries` | `[...$0.entries()]` | `Object.entries($0)` |
| `Map.size` | `$0.size` | `Object.keys($0).length` |

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (1053 tests)
- [x] `floe check` and `floe build` on example apps pass
- [x] Verified: `Record<string, string>` import → `Map.get` → bracket access codegen

🤖 Generated with [Claude Code](https://claude.com/claude-code)