### PR TITLE
fix: [#607] Pipe does not support qualified for-block syntax

### DIFF
--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -1349,6 +1349,17 @@ impl Checker {
             return self.validate_stdlib_pipe_call(&stdlib_fn, &display, left_ty, right);
         }
 
+        // Qualified for-block call: `row |> AccentRow.toModel` or `row |> AccentRow.toModel(args)`
+        if let Some((type_name, func_name)) = member_info
+            && let Some(overloads) = self.for_block_overloads.get(func_name)
+            && let Some((_, fn_type)) = overloads.iter().find(|(tn, _)| tn == type_name)
+        {
+            self.unused.used_names.insert(func_name.to_string());
+            if let Type::Function { return_type, .. } = fn_type {
+                return *return_type.clone();
+            }
+        }
+
         // Extract the bare function name from the right side
         let bare_name = match &right.kind {
             ExprKind::Identifier(name) => Some(name.as_str()),

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -4119,3 +4119,29 @@ const x = pair[i]
         "tuple index must be a numeric literal"
     ));
 }
+
+// ── Qualified for-block pipe ────────────────────────────────────
+
+#[test]
+fn pipe_qualified_for_block_resolves_return_type() {
+    let diags = check(
+        r#"
+type Out { value: number }
+type In { x: number }
+
+for In {
+    fn convert(self) -> Out {
+        Out(value: self.x)
+    }
+}
+
+const input = In(x: 42)
+const _result: Out = input |> In.convert
+"#,
+    );
+    assert!(
+        !has_error(&diags, "E017"),
+        "should not error on qualified for-block pipe"
+    );
+    assert!(!has_error(&diags, "E001"), "return type should match Out");
+}

--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -571,8 +571,28 @@ impl Codegen {
                     self.push(&output);
                     return;
                 }
+                // Qualified for-block: `row |> AccentRow.toModel(args)` → `AccentRow__toModel(row, args)`
+                if let ExprKind::Member { object, field } = &callee.kind
+                    && let ExprKind::Identifier(type_name) = &object.kind
+                    && let Some(mangled) =
+                        self.for_block_fns.get(&(type_name.clone(), field.clone()))
+                {
+                    let name = self
+                        .import_aliases
+                        .get(mangled)
+                        .cloned()
+                        .unwrap_or_else(|| mangled.clone());
+                    self.push(&name);
+                    self.push("(");
+                    self.emit_expr(left);
+                    if !args.is_empty() {
+                        self.push(", ");
+                        self.emit_args(args);
+                    }
+                    self.push(")");
+                    return;
+                }
                 // Fall through to normal call handling below
-                // Use aliased import name if available (avoids TDZ conflicts)
                 let callee_alias = if let ExprKind::Identifier(name) = &callee.kind {
                     self.import_aliases.get(name.as_str()).cloned()
                 } else {
@@ -591,10 +611,26 @@ impl Codegen {
                 }
                 self.push(")");
             }
-            ExprKind::Member { .. } => {
+            ExprKind::Member { object, field } => {
                 // Bare stdlib: `arr |> Array.sort` (no args)
                 if let Some(output) = self.try_emit_stdlib_pipe(left, right, &[]) {
                     self.push(&output);
+                    return;
+                }
+                // Qualified for-block: `row |> AccentRow.toModel` → `AccentRow__toModel(row)`
+                if let ExprKind::Identifier(type_name) = &object.kind
+                    && let Some(mangled) =
+                        self.for_block_fns.get(&(type_name.clone(), field.clone()))
+                {
+                    let name = self
+                        .import_aliases
+                        .get(mangled)
+                        .cloned()
+                        .unwrap_or_else(|| mangled.clone());
+                    self.push(&name);
+                    self.push("(");
+                    self.emit_expr(left);
+                    self.push(")");
                     return;
                 }
                 // Fallback: treat as function call


### PR DESCRIPTION
closes #607

## Summary
- `row |> AccentRow.toModel` now works as a qualified for-block method call
- `row |> AccentRow.toModel(extra_args)` also works with additional arguments
- Checker resolves the for-block overload by type name, same data path as bare `row |> toModel`
- Codegen emits the mangled name (`AccentRow__toModel(row)`) instead of member access

## How it works

The pipe handler already had three resolution stages:
1. Stdlib lookup (`Array.map`, `String.trim`)
2. Type-directed bare name resolution (`arr |> map`)
3. For-block overload resolution (`row |> toModel`)

This adds a new stage between 1 and 2: **qualified for-block lookup**. When `Module.func` fails the stdlib check, we check if `Module` is a type name with a for-block function called `func` in `for_block_overloads`. Same data, explicit disambiguation.

## Test plan
- [x] `cargo fmt`, `cargo clippy -- -D warnings`, `RUSTFLAGS="-D warnings" cargo test` all clean (1062 tests)
- [x] End-to-end: `row |> AccentRow.toModel` compiles to `AccentRow__toModel(row)`
- [x] End-to-end: `row |> EntryRow.toEntry("bonus")` compiles to `EntryRow__toEntry(row, "bonus")`
- [x] Example apps pass fmt, check, build

🤖 Generated with [Claude Code](https://claude.com/claude-code)