### PR TITLE
chore: [#607] Simplify for-block pipe codegen

### DIFF
--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -1355,9 +1355,10 @@ impl Checker {
             && let Some((_, fn_type)) = overloads.iter().find(|(tn, _)| tn == type_name)
         {
             self.unused.used_names.insert(func_name.to_string());
-            if let Type::Function { return_type, .. } = fn_type {
-                return *return_type.clone();
-            }
+            return match fn_type {
+                Type::Function { return_type, .. } => *return_type.clone(),
+                _ => Type::Unknown,
+            };
         }
 
         // Extract the bare function name from the right side

--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -553,6 +553,38 @@ impl Codegen {
         }
     }
 
+    /// Try to emit a qualified for-block call in pipe context.
+    /// `row |> AccentRow.toModel(args)` → `AccentRow__toModel(row, args)`
+    fn try_emit_for_block_pipe(
+        &mut self,
+        left: &Expr,
+        type_name: &str,
+        field: &str,
+        args: &[Arg],
+    ) -> bool {
+        if let Some(mangled) = self
+            .for_block_fns
+            .get(&(type_name.to_string(), field.to_string()))
+        {
+            let name = self
+                .import_aliases
+                .get(mangled)
+                .cloned()
+                .unwrap_or_else(|| mangled.clone());
+            self.push(&name);
+            self.push("(");
+            self.emit_expr(left);
+            if !args.is_empty() {
+                self.push(", ");
+                self.emit_args(args);
+            }
+            self.push(")");
+            true
+        } else {
+            false
+        }
+    }
+
     /// Try to resolve a bare function name in pipe context via type-directed stdlib lookup.
     /// Uses the checker's type map to determine which stdlib module to use.
     /// e.g., `arr |> length` → left is Array → use Array.length template.
@@ -609,22 +641,8 @@ impl Codegen {
                 // Qualified for-block: `row |> AccentRow.toModel(args)` → `AccentRow__toModel(row, args)`
                 if let ExprKind::Member { object, field } = &callee.kind
                     && let ExprKind::Identifier(type_name) = &object.kind
-                    && let Some(mangled) =
-                        self.for_block_fns.get(&(type_name.clone(), field.clone()))
+                    && self.try_emit_for_block_pipe(left, type_name, field, args)
                 {
-                    let name = self
-                        .import_aliases
-                        .get(mangled)
-                        .cloned()
-                        .unwrap_or_else(|| mangled.clone());
-                    self.push(&name);
-                    self.push("(");
-                    self.emit_expr(left);
-                    if !args.is_empty() {
-                        self.push(", ");
-                        self.emit_args(args);
-                    }
-                    self.push(")");
                     return;
                 }
                 // Fall through to normal call handling below
@@ -654,18 +672,8 @@ impl Codegen {
                 }
                 // Qualified for-block: `row |> AccentRow.toModel` → `AccentRow__toModel(row)`
                 if let ExprKind::Identifier(type_name) = &object.kind
-                    && let Some(mangled) =
-                        self.for_block_fns.get(&(type_name.clone(), field.clone()))
+                    && self.try_emit_for_block_pipe(left, type_name, field, &[])
                 {
-                    let name = self
-                        .import_aliases
-                        .get(mangled)
-                        .cloned()
-                        .unwrap_or_else(|| mangled.clone());
-                    self.push(&name);
-                    self.push("(");
-                    self.emit_expr(left);
-                    self.push(")");
                     return;
                 }
                 // Fallback: treat as function call


### PR DESCRIPTION
Follow-up cleanup for #700.

## Summary
- Extract `try_emit_for_block_pipe` helper in codegen, deduplicating the two inline blocks (matches existing `try_emit_stdlib_pipe` pattern)
- Fix checker silent fall-through: when a for-block overload entry isn't a `Function` type, explicitly return `Unknown` instead of silently continuing

🤖 Generated with [Claude Code](https://claude.com/claude-code)