### PR TITLE
fix: [#701] Dot-access completions fall through to global symbols

### DIFF
--- a/src/lsp/handlers.rs
+++ b/src/lsp/handlers.rs
@@ -347,9 +347,9 @@ impl LanguageServer for FloeLsp {
             && !registry.is_module(obj_name)
         {
             let items = dot_access_completions(obj_name, &prefix, &doc.type_map, &doc.index);
-            if !items.is_empty() {
-                return Ok(Some(CompletionResponse::Array(items)));
-            }
+            // Always return here — never fall through to global completions in dot context.
+            // If we can't resolve fields, returning empty is better than dumping every symbol.
+            return Ok(Some(CompletionResponse::Array(items)));
         }
 
         // ── Stdlib module method completions (Array., String., etc.) ──


### PR DESCRIPTION
closes #701

## Summary
- When `dot_access_completions` returned empty (unresolved type), the handler fell through to normal completions, dumping every symbol in scope into the dot-access suggestion list
- Now always early-returns in dot context — empty results are better than garbage like `poop`, `setPoop`, `fn`, `const` showing up on `record.`

## Test plan
- [ ] Type `someRecord.` where the record type is known — should show fields
- [ ] Type `someRecord.` where the type is unresolved — should show empty, not global symbols
- [ ] Existing completion tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)