### PR TITLE
fix: [#705] Dot-access completions do not resolve record type fields

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -659,6 +659,17 @@ impl Checker {
                 } else {
                     self.env.define(&decl.name, Type::Named(decl.name.clone()));
                 }
+
+                // Populate __field_ entries for dot-access completions
+                for entry in entries {
+                    if let RecordEntry::Field(field) = entry {
+                        let field_ty = self.resolve_type(&field.type_ann);
+                        self.name_types.insert(
+                            format!("__field_{}_{}", decl.name, field.name),
+                            field_ty.display_name(),
+                        );
+                    }
+                }
             }
             TypeDef::Union(variants) => {
                 let var_types: Vec<_> = variants

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -288,7 +288,9 @@ impl FloeLsp {
                 let (program, parse_errors) = Parser::parse_lossy(source);
                 let floe_diags = floe_diag::from_parse_errors(&parse_errors);
                 let index = SymbolIndex::build(&program);
-                let type_map = HashMap::new();
+                // Run the checker on the partial AST to populate the type_map
+                // (e.g. __field_ entries for record types, variable types).
+                let (_, type_map, _) = Checker::new().check_with_types(&program);
                 (
                     self.convert_diagnostics(source, &floe_diags),
                     index,

--- a/src/lsp/tests.rs
+++ b/src/lsp/tests.rs
@@ -1003,3 +1003,46 @@ fn goto_def_union_variant_in_match() {
         "go-to-def on union variant in match arm should find definition"
     );
 }
+
+#[test]
+fn type_map_has_field_entries_for_records() {
+    let source = r#"
+type User { name: string, age: number }
+const u = User(name: "a", age: 1)
+"#;
+    let (_, type_map) = build_index_and_types(source);
+    assert_eq!(
+        type_map.get("__field_User_name").map(String::as_str),
+        Some("string"),
+        "type_map should have __field_User_name"
+    );
+    assert_eq!(
+        type_map.get("__field_User_age").map(String::as_str),
+        Some("number"),
+        "type_map should have __field_User_age"
+    );
+    assert_eq!(
+        type_map.get("u").map(String::as_str),
+        Some("User"),
+        "type_map should have u -> User"
+    );
+}
+
+#[test]
+fn dot_access_completions_for_record_type() {
+    let source = r#"
+type User { name: string, age: number }
+const u = User(name: "a", age: 1)
+"#;
+    let (index, type_map) = build_index_and_types(source);
+    let items = dot_access_completions("u", "", &type_map, &index);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"name"),
+        "should suggest 'name', got: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"age"),
+        "should suggest 'age', got: {labels:?}"
+    );
+}

--- a/tests/lsp/test_completion.py
+++ b/tests/lsp/test_completion.py
@@ -1,7 +1,5 @@
 """Tests for textDocument/completion."""
 
-import pytest
-
 from .conftest import URI, completion_labels, open_doc
 from . import fixtures as F
 
@@ -95,11 +93,17 @@ class TestCompletionAdvanced:
 class TestCompletionDotAccess:
     """Dot-access should return only fields of the accessed type, never global symbols."""
 
-    @pytest.mark.xfail(reason="dot-access field resolution not yet working for record types")
     def test_record_fields(self, lsp):
         open_doc(lsp, URI, DOT_ACCESS_SOURCE)
         labels = completion_labels(lsp.completion(URI, 2, 13))
-        assert "name" in labels or "age" in labels, f"Labels: {labels[:15]}"
+        assert "name" in labels, f"Labels: {labels[:15]}"
+        assert "age" in labels, f"Labels: {labels[:15]}"
+
+    def test_no_unrelated_fields(self, lsp):
+        source = 'type User { name: string, age: number }\ntype Item { title: string }\nconst u = User(name: "a", age: 1)\nconst n = u.\n'
+        open_doc(lsp, URI, source)
+        labels = completion_labels(lsp.completion(URI, 3, 13))
+        assert "title" not in labels, f"Item field 'title' leaked into User dot-access: {labels[:15]}"
 
     def test_no_keywords_in_dot_access(self, lsp):
         open_doc(lsp, URI, DOT_ACCESS_SOURCE)
@@ -122,6 +126,13 @@ class TestCompletionDotAccess:
         assert "foo" not in labels, f"Global var leaked into unresolved dot-access: {labels[:15]}"
         for kw in KEYWORDS:
             assert kw not in labels, f"Keyword '{kw}' leaked into unresolved dot-access: {labels[:15]}"
+
+    def test_spread_record_fields(self, lsp):
+        source = 'type Base { id: string }\ntype Extended { ...Base, extra: number }\nconst e = Extended(id: "1", extra: 42)\nconst n = e.\n'
+        open_doc(lsp, URI, source)
+        labels = completion_labels(lsp.completion(URI, 3, 13))
+        assert "id" in labels, f"Spread field 'id' missing: {labels[:15]}"
+        assert "extra" in labels, f"Field 'extra' missing: {labels[:15]}"
 
 
 # ── Suppression tests ───────────────────────────────────────


### PR DESCRIPTION
closes #705

## Summary
- Populate `__field_{Type}_{field}` entries in the type_map when record types are defined, so the completion engine knows each record's fields and their types
- Run the checker on lossy-parsed ASTs so the type_map is available even when the document has parse errors (e.g. the trailing dot in `user.`)
- Works for spread records too (`...Base` fields show up)

## Test plan
- [x] New unit tests: `type_map_has_field_entries_for_records`, `dot_access_completions_for_record_type`
- [x] New LSP integration tests: record fields, spread fields, no unrelated fields, no keywords, no globals
- [x] Full LSP suite passes (221 tests)
- [x] Floe example quality gate passes (fmt, check, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)