### PR TITLE
chore: [#711] Extract checker diagnostic helpers to reduce boilerplate

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -509,6 +509,56 @@ impl Checker {
         (self.diagnostics, self.name_types, self.expr_types)
     }
 
+    // ── Diagnostic helpers ────────────────────────────────────────
+
+    fn emit_error(
+        &mut self,
+        msg: impl Into<String>,
+        span: Span,
+        code: &str,
+        label: impl Into<String>,
+    ) {
+        self.diagnostics.push(
+            Diagnostic::error(msg, span)
+                .with_label(label)
+                .with_code(code),
+        );
+    }
+
+    fn emit_error_with_help(
+        &mut self,
+        msg: impl Into<String>,
+        span: Span,
+        code: &str,
+        label: impl Into<String>,
+        help: impl Into<String>,
+    ) {
+        self.diagnostics.push(
+            Diagnostic::error(msg, span)
+                .with_label(label)
+                .with_help(help)
+                .with_code(code),
+        );
+    }
+
+    fn emit_warning_with_help(
+        &mut self,
+        msg: impl Into<String>,
+        span: Span,
+        code: &str,
+        label: impl Into<String>,
+        help: impl Into<String>,
+    ) {
+        self.diagnostics.push(
+            Diagnostic::warning(msg, span)
+                .with_label(label)
+                .with_help(help)
+                .with_code(code),
+        );
+    }
+
+    // ── Type helpers ────────────────────────────────────────────────
+
     fn fresh_type_var(&mut self) -> Type {
         let id = self.next_var;
         self.next_var += 1;
@@ -565,11 +615,7 @@ impl Checker {
         // duplicate definitions within the same scope.
         if self.env.is_defined_in_current_scope(name) {
             let msg = format!("`{name}` is already defined in this scope");
-            self.diagnostics.push(
-                Diagnostic::error(msg, span)
-                    .with_label("already defined")
-                    .with_code("E016"),
-            );
+            self.emit_error(msg, span, "E016", "already defined");
         }
     }
 
@@ -580,21 +626,19 @@ impl Checker {
         if span.start != 0 || span.end != 0 {
             // Only check local declarations (not imports with dummy spans)
             if decl.name.starts_with(char::is_lowercase) {
-                self.diagnostics.push(
-                    Diagnostic::error(
-                        format!(
-                            "type name `{}` must start with an uppercase letter",
-                            decl.name
-                        ),
-                        span,
-                    )
-                    .with_label("must be uppercase")
-                    .with_help(format!(
+                self.emit_error_with_help(
+                    format!(
+                        "type name `{}` must start with an uppercase letter",
+                        decl.name
+                    ),
+                    span,
+                    "E024",
+                    "must be uppercase",
+                    format!(
                         "rename to `{}{}`",
                         decl.name[..1].to_uppercase(),
                         &decl.name[1..]
-                    ))
-                    .with_code("E024"),
+                    ),
                 );
             }
             match &decl.def {
@@ -806,17 +850,15 @@ impl Checker {
             match entry {
                 RecordEntry::Field(field) => {
                     if seen_names.contains_key(&field.name) {
-                        self.diagnostics.push(
-                            Diagnostic::error(
-                                format!(
-                                    "duplicate field `{}` in record type `{}`",
-                                    field.name, type_name
-                                ),
-                                field.span,
-                            )
-                            .with_label("duplicate field")
-                            .with_help("field was already defined elsewhere in this record type")
-                            .with_code("E030"),
+                        self.emit_error_with_help(
+                            format!(
+                                "duplicate field `{}` in record type `{}`",
+                                field.name, type_name
+                            ),
+                            field.span,
+                            "E030",
+                            "duplicate field",
+                            "field was already defined elsewhere in this record type",
                         );
                     } else {
                         seen_names.insert(field.name.clone(), field.span);
@@ -837,17 +879,15 @@ impl Checker {
                                     .collect();
                                 for field in &spread_fields {
                                     if seen_names.contains_key(&field.name) {
-                                        self.diagnostics.push(
-                                            Diagnostic::error(
-                                                format!(
+                                        self.emit_error_with_help(
+                                            format!(
                                                     "field `{}` from spread `...{}` conflicts with existing field in `{}`",
                                                     field.name, spread.type_name, type_name
                                                 ),
-                                                spread.span,
-                                            )
-                                            .with_label(format!("field `{}` already defined", field.name))
-                                            .with_help("field was already defined elsewhere in this record type")
-                                            .with_code("E031"),
+                                            spread.span,
+                                            "E031",
+                                            format!("field `{}` already defined", field.name),
+                                            "field was already defined elsewhere in this record type",
                                         );
                                     } else {
                                         seen_names.insert(field.name.clone(), spread.span);
@@ -856,16 +896,14 @@ impl Checker {
                                 }
                             }
                             TypeDef::Union(_) => {
-                                self.diagnostics.push(
-                                    Diagnostic::error(
-                                        format!(
-                                            "cannot spread union type `{}` into record type `{}`",
-                                            spread.type_name, type_name
-                                        ),
-                                        spread.span,
-                                    )
-                                    .with_label("spread target must be a record type")
-                                    .with_code("E032"),
+                                self.emit_error(
+                                    format!(
+                                        "cannot spread union type `{}` into record type `{}`",
+                                        spread.type_name, type_name
+                                    ),
+                                    spread.span,
+                                    "E032",
+                                    "spread target must be a record type",
                                 );
                             }
                             TypeDef::Alias(_) | TypeDef::StringLiteralUnion(_) => {
@@ -879,13 +917,11 @@ impl Checker {
                         self.unused.used_names.insert(spread.type_name.clone());
                         preserved_spreads.push(RecordEntry::Spread(spread.clone()));
                     } else {
-                        self.diagnostics.push(
-                            Diagnostic::error(
-                                format!("unknown type `{}` in spread", spread.type_name),
-                                spread.span,
-                            )
-                            .with_label("type not found")
-                            .with_code("E002"),
+                        self.emit_error(
+                            format!("unknown type `{}` in spread", spread.type_name),
+                            spread.span,
+                            "E002",
+                            "type not found",
                         );
                     }
                 }
@@ -915,31 +951,27 @@ impl Checker {
                             seen_default = true;
                             let default_ty = self.check_expr(default_expr);
                             if !self.types_compatible(&field_ty, &default_ty) {
-                                self.diagnostics.push(
-                                    Diagnostic::error(
-                                        format!(
-                                            "default value for `{}`: expected `{}`, found `{}`",
-                                            field.name,
-                                            field_ty.display_name(),
-                                            default_ty.display_name()
-                                        ),
-                                        field.span,
-                                    )
-                                    .with_label(format!("expected `{}`", field_ty.display_name()))
-                                    .with_code("E001"),
+                                self.emit_error(
+                                    format!(
+                                        "default value for `{}`: expected `{}`, found `{}`",
+                                        field.name,
+                                        field_ty.display_name(),
+                                        default_ty.display_name()
+                                    ),
+                                    field.span,
+                                    "E001",
+                                    format!("expected `{}`", field_ty.display_name()),
                                 );
                             }
                         } else if seen_default {
-                            self.diagnostics.push(
-                                Diagnostic::error(
-                                    format!(
-                                        "required field `{}` must come before fields with defaults",
-                                        field.name
-                                    ),
-                                    field.span,
-                                )
-                                .with_label("move this field before defaulted fields")
-                                .with_code("E001"),
+                            self.emit_error(
+                                format!(
+                                    "required field `{}` must come before fields with defaults",
+                                    field.name
+                                ),
+                                field.span,
+                                "E001",
+                                "move this field before defaulted fields",
                             );
                         }
                     }
@@ -978,17 +1010,15 @@ impl Checker {
 
         // deriving only works on record types
         if !matches!(&decl.def, TypeDef::Record(_)) {
-            self.diagnostics.push(
-                Diagnostic::error(
-                    format!(
-                        "`deriving` can only be used on record types, but `{}` is not a record",
-                        decl.name
-                    ),
-                    span,
-                )
-                .with_label("not a record type")
-                .with_help("remove the `deriving` clause or change this to a record type")
-                .with_code("E019"),
+            self.emit_error_with_help(
+                format!(
+                    "`deriving` can only be used on record types, but `{}` is not a record",
+                    decl.name
+                ),
+                span,
+                "E019",
+                "not a record type",
+                "remove the `deriving` clause or change this to a record type",
             );
             return;
         }
@@ -998,14 +1028,12 @@ impl Checker {
         for trait_name in &decl.deriving {
             match trait_name.as_str() {
                 "Eq" => {
-                    self.diagnostics.push(
-                        Diagnostic::error(
-                            "`Eq` cannot be derived — structural equality is built-in for all types via `==`".to_string(),
-                            span,
-                        )
-                        .with_label("not needed")
-                        .with_help("remove `Eq` from the deriving clause — use `==` for equality comparison")
-                        .with_code("E019"),
+                    self.emit_error_with_help(
+                        "`Eq` cannot be derived — structural equality is built-in for all types via `==`".to_string(),
+                        span,
+                        "E019",
+                        "not needed",
+                        "remove `Eq` from the deriving clause — use `==` for equality comparison",
                     );
                 }
                 "Display" => {
@@ -1026,11 +1054,12 @@ impl Checker {
                         .insert((type_name.clone(), "Display".to_string()));
                 }
                 _ => {
-                    self.diagnostics.push(
-                        Diagnostic::error(format!("trait `{trait_name}` cannot be derived"), span)
-                            .with_label("not a derivable trait")
-                            .with_help("only `Display` can be derived")
-                            .with_code("E019"),
+                    self.emit_error_with_help(
+                        format!("trait `{trait_name}` cannot be derived"),
+                        span,
+                        "E019",
+                        "not a derivable trait",
+                        "only `Display` can be derived",
                     );
                 }
             }
@@ -1114,14 +1143,12 @@ impl Checker {
                 if let Some(ty) = self.env.lookup(name) {
                     ty.clone()
                 } else {
-                    self.diagnostics.push(
-                        Diagnostic::error(
-                            format!("cannot use `typeof` on undefined binding `{name}`"),
-                            type_expr.span,
-                        )
-                        .with_label("not defined")
-                        .with_help("typeof can only be used with value bindings (const, fn)")
-                        .with_code("E002"),
+                    self.emit_error_with_help(
+                        format!("cannot use `typeof` on undefined binding `{name}`"),
+                        type_expr.span,
+                        "E002",
+                        "not defined",
+                        "typeof can only be used with value bindings (const, fn)",
                     );
                     Type::Unknown
                 }
@@ -1197,11 +1224,12 @@ impl Checker {
                 {
                     Type::Named(name.to_string())
                 } else {
-                    self.diagnostics.push(
-                        Diagnostic::error(format!("unknown type `{name}`"), span)
-                            .with_label("not defined")
-                            .with_help("check the spelling or import/define this type")
-                            .with_code("E002"),
+                    self.emit_error_with_help(
+                        format!("unknown type `{name}`"),
+                        span,
+                        "E002",
+                        "not defined",
+                        "check the spelling or import/define this type",
                     );
                     Type::Unknown
                 }
@@ -1224,11 +1252,12 @@ impl Checker {
                 let ty = self.check_expr(expr);
                 // Rule 5: No floating Results/Options
                 if ty.is_result() {
-                    self.diagnostics.push(
-                        Diagnostic::error("unhandled `Result` value", expr.span)
-                            .with_label("this `Result` is not used")
-                            .with_help("use `?`, `match`, or assign to `_`")
-                            .with_code("E005"),
+                    self.emit_error_with_help(
+                        "unhandled `Result` value",
+                        expr.span,
+                        "E005",
+                        "this `Result` is not used",
+                        "use `?`, `match`, or assign to `_`",
                     );
                 }
             }
@@ -1539,30 +1568,26 @@ impl Checker {
             tsgo_ty.clone()
         } else if let Some(ref declared) = declared_type {
             if matches!(value_type, Type::Unknown) && !matches!(declared, Type::Unknown) {
-                self.diagnostics.push(
-                    Diagnostic::error(
-                        format!(
-                            "cannot narrow `unknown` to `{}` — use runtime validation instead",
-                            declared.display_name()
-                        ),
-                        span,
-                    )
-                    .with_label("unsafe narrowing from `unknown`")
-                    .with_help("use a validation library like Zod, or match on the value")
-                    .with_code("E019"),
+                self.emit_error_with_help(
+                    format!(
+                        "cannot narrow `unknown` to `{}` — use runtime validation instead",
+                        declared.display_name()
+                    ),
+                    span,
+                    "E019",
+                    "unsafe narrowing from `unknown`",
+                    "use a validation library like Zod, or match on the value",
                 );
             } else if !self.types_compatible(declared, &value_type) {
-                self.diagnostics.push(
-                    Diagnostic::error(
-                        format!(
-                            "expected `{}`, found `{}`",
-                            declared.display_name(),
-                            value_type.display_name()
-                        ),
-                        span,
-                    )
-                    .with_label(format!("expected `{}`", declared.display_name()))
-                    .with_code("E001"),
+                self.emit_error(
+                    format!(
+                        "expected `{}`, found `{}`",
+                        declared.display_name(),
+                        value_type.display_name()
+                    ),
+                    span,
+                    "E001",
+                    format!("expected `{}`", declared.display_name()),
                 );
             }
             declared.clone()
@@ -1657,17 +1682,15 @@ impl Checker {
     fn check_function(&mut self, decl: &FunctionDecl, span: Span) {
         // Rule: Exported functions must declare return types
         if decl.exported && decl.return_type.is_none() {
-            self.diagnostics.push(
-                Diagnostic::error(
-                    format!(
-                        "exported function `{}` must declare a return type",
-                        decl.name
-                    ),
-                    span,
-                )
-                .with_label("missing return type")
-                .with_help("add `-> ReturnType` after the parameter list")
-                .with_code("E010"),
+            self.emit_error_with_help(
+                format!(
+                    "exported function `{}` must declare a return type",
+                    decl.name
+                ),
+                span,
+                "E010",
+                "missing return type",
+                "add `-> ReturnType` after the parameter list",
             );
         }
 
@@ -1767,18 +1790,16 @@ impl Checker {
             if let Some(default_expr) = &param.default {
                 let default_ty = self.check_expr(default_expr);
                 if !self.types_compatible(ty, &default_ty) {
-                    self.diagnostics.push(
-                        Diagnostic::error(
-                            format!(
-                                "default value for `{}`: expected `{}`, found `{}`",
-                                param.name,
-                                ty.display_name(),
-                                default_ty.display_name()
-                            ),
-                            param.span,
-                        )
-                        .with_label(format!("expected `{}`", ty.display_name()))
-                        .with_code("E001"),
+                    self.emit_error(
+                        format!(
+                            "default value for `{}`: expected `{}`, found `{}`",
+                            param.name,
+                            ty.display_name(),
+                            default_ty.display_name()
+                        ),
+                        param.span,
+                        "E001",
+                        format!("expected `{}`", ty.display_name()),
                     );
                 }
             }
@@ -1812,18 +1833,16 @@ impl Checker {
             if !self.types_compatible(&effective_declared, &body_type)
                 && !matches!(body_type, Type::Var(_))
             {
-                self.diagnostics.push(
-                    Diagnostic::error(
-                        format!(
-                            "function `{}`: expected return type `{}`, found `{}`",
-                            decl.name,
-                            resolved.display_name(),
-                            body_type.display_name()
-                        ),
-                        span,
-                    )
-                    .with_label(format!("expected `{}`", resolved.display_name()))
-                    .with_code("E001"),
+                self.emit_error(
+                    format!(
+                        "function `{}`: expected return type `{}`, found `{}`",
+                        decl.name,
+                        resolved.display_name(),
+                        body_type.display_name()
+                    ),
+                    span,
+                    "E001",
+                    format!("expected `{}`", resolved.display_name()),
                 );
             }
 
@@ -1832,18 +1851,16 @@ impl Checker {
                 && matches!(body_type, Type::Unit)
                 && !self.body_has_return(&decl.body)
             {
-                self.diagnostics.push(
-                    Diagnostic::error(
-                        format!(
-                            "function `{}` must return a value of type `{}`",
-                            decl.name,
-                            resolved.display_name()
-                        ),
-                        span,
-                    )
-                    .with_label("missing return value")
-                    .with_help("add a return expression or change return type to `()`")
-                    .with_code("E013"),
+                self.emit_error_with_help(
+                    format!(
+                        "function `{}` must return a value of type `{}`",
+                        decl.name,
+                        resolved.display_name()
+                    ),
+                    span,
+                    "E013",
+                    "missing return value",
+                    "add a return expression or change return type to `()`",
                 );
             }
         }
@@ -1948,18 +1965,16 @@ impl Checker {
                 if let Some(default_expr) = &param.default {
                     let default_ty = self.check_expr(default_expr);
                     if !self.types_compatible(ty, &default_ty) {
-                        self.diagnostics.push(
-                            Diagnostic::error(
-                                format!(
-                                    "default value for `{}`: expected `{}`, found `{}`",
-                                    param.name,
-                                    ty.display_name(),
-                                    default_ty.display_name()
-                                ),
-                                param.span,
-                            )
-                            .with_label(format!("expected `{}`", ty.display_name()))
-                            .with_code("E001"),
+                        self.emit_error(
+                            format!(
+                                "default value for `{}`: expected `{}`, found `{}`",
+                                param.name,
+                                ty.display_name(),
+                                default_ty.display_name()
+                            ),
+                            param.span,
+                            "E001",
+                            format!("expected `{}`", ty.display_name()),
                         );
                     }
                 }
@@ -1972,18 +1987,16 @@ impl Checker {
                 if !self.types_compatible(&resolved, &body_type)
                     && !matches!(body_type, Type::Var(_))
                 {
-                    self.diagnostics.push(
-                        Diagnostic::error(
-                            format!(
-                                "function `{}`: expected return type `{}`, found `{}`",
-                                func.name,
-                                resolved.display_name(),
-                                body_type.display_name()
-                            ),
-                            block.span,
-                        )
-                        .with_label(format!("expected `{}`", resolved.display_name()))
-                        .with_code("E001"),
+                    self.emit_error(
+                        format!(
+                            "function `{}`: expected return type `{}`, found `{}`",
+                            func.name,
+                            resolved.display_name(),
+                            body_type.display_name()
+                        ),
+                        block.span,
+                        "E001",
+                        format!("expected `{}`", resolved.display_name()),
                     );
                 }
             }
@@ -2003,16 +2016,14 @@ impl Checker {
                     let ty = self.check_expr(expr);
                     // Ensure assert expression evaluates to boolean
                     if !matches!(ty, Type::Bool | Type::Unknown | Type::Var(_)) {
-                        self.diagnostics.push(
-                            Diagnostic::error(
-                                format!(
-                                    "assert expression must be boolean, found `{}`",
-                                    ty.display_name()
-                                ),
-                                *span,
-                            )
-                            .with_label("expected boolean expression")
-                            .with_code("E017"),
+                        self.emit_error(
+                            format!(
+                                "assert expression must be boolean, found `{}`",
+                                ty.display_name()
+                            ),
+                            *span,
+                            "E017",
+                            "expected boolean expression",
                         );
                     }
                 }
@@ -2096,11 +2107,12 @@ impl Checker {
         let trait_methods = match self.traits.trait_defs.get(trait_name) {
             Some(methods) => methods.clone(),
             None => {
-                self.diagnostics.push(
-                    Diagnostic::error(format!("unknown trait `{trait_name}`"), span)
-                        .with_label("not defined")
-                        .with_help("check the spelling or define this trait")
-                        .with_code("E017"),
+                self.emit_error_with_help(
+                    format!("unknown trait `{trait_name}`"),
+                    span,
+                    "E017",
+                    "not defined",
+                    "check the spelling or define this trait",
                 );
                 return;
             }
@@ -2111,20 +2123,18 @@ impl Checker {
 
         for method in &trait_methods {
             if !method.has_default && !impl_names.contains(method.name.as_str()) {
-                self.diagnostics.push(
-                    Diagnostic::error(
-                        format!(
+                self.emit_error_with_help(
+                    format!(
                             "trait `{trait_name}` requires method `{}` but it is not implemented for `{type_name}`",
                             method.name
                         ),
-                        span,
-                    )
-                    .with_label(format!("missing method `{}`", method.name))
-                    .with_help(format!(
+                    span,
+                    "E018",
+                    format!("missing method `{}`", method.name),
+                    format!(
                         "add `fn {}(self, ...) {{ ... }}` to the for block",
                         method.name
-                    ))
-                    .with_code("E018"),
+                    ),
                 );
             }
         }
@@ -2148,13 +2158,11 @@ impl Checker {
                 if name.starts_with(|c: char| c.is_uppercase()) {
                     self.unused.used_names.insert(name.clone());
                     if self.env.lookup(name).is_none() {
-                        self.diagnostics.push(
-                            Diagnostic::error(
-                                format!("component `{name}` is not defined"),
-                                element.span,
-                            )
-                            .with_label("not found in scope")
-                            .with_code("E002"),
+                        self.emit_error(
+                            format!("component `{name}` is not defined"),
+                            element.span,
+                            "E002",
+                            "not found in scope",
                         );
                     }
                 }

--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -93,10 +93,11 @@ impl Checker {
                     // Stdlib module names (Array, String, etc.) are valid identifiers
                     Type::Unknown
                 } else {
-                    self.diagnostics.push(
-                        Diagnostic::error(format!("`{name}` is not defined"), expr.span)
-                            .with_label("not found in scope")
-                            .with_code("E002"),
+                    self.emit_error(
+                        format!("`{name}` is not defined"),
+                        expr.span,
+                        "E002",
+                        "not found in scope",
                     );
                     Type::Unknown
                 }
@@ -111,16 +112,14 @@ impl Checker {
                 match op {
                     UnaryOp::Neg => {
                         if !ty.is_numeric() && !matches!(ty, Type::Unknown | Type::Var(_)) {
-                            self.diagnostics.push(
-                                Diagnostic::error(
-                                    format!(
-                                        "cannot negate type `{}`, expected `number`",
-                                        ty.display_name()
-                                    ),
-                                    expr.span,
-                                )
-                                .with_label("expected `number`")
-                                .with_code("E001"),
+                            self.emit_error(
+                                format!(
+                                    "cannot negate type `{}`, expected `number`",
+                                    ty.display_name()
+                                ),
+                                expr.span,
+                                "E001",
+                                "expected `number`",
                             );
                         }
                         Type::Number
@@ -146,28 +145,20 @@ impl Checker {
                     match &self.ctx.current_return_type {
                         Some(ret) if ret.is_result() || ret.is_option() => {}
                         Some(_) => {
-                            self.diagnostics.push(
-                                Diagnostic::error(
-                                    "`?` operator requires function to return `Result` or `Option`",
-                                    expr.span,
-                                )
-                                .with_label(
-                                    "enclosing function does not return `Result` or `Option`",
-                                )
-                                .with_help(
-                                    "change the function's return type to `Result` or `Option`",
-                                )
-                                .with_code("E005"),
+                            self.emit_error_with_help(
+                                "`?` operator requires function to return `Result` or `Option`",
+                                expr.span,
+                                "E005",
+                                "enclosing function does not return `Result` or `Option`",
+                                "change the function's return type to `Result` or `Option`",
                             );
                         }
                         None => {
-                            self.diagnostics.push(
-                                Diagnostic::error(
-                                    "`?` operator can only be used inside a function",
-                                    expr.span,
-                                )
-                                .with_label("not inside a function")
-                                .with_code("E005"),
+                            self.emit_error(
+                                "`?` operator can only be used inside a function",
+                                expr.span,
+                                "E005",
+                                "not inside a function",
                             );
                         }
                     }
@@ -182,16 +173,14 @@ impl Checker {
                     }
                     Type::Option(inner) => *inner,
                     _ => {
-                        self.diagnostics.push(
-                            Diagnostic::error(
-                                format!(
-                                    "`?` can only be used on `Result` or `Option`, found `{}`",
-                                    ty.display_name()
-                                ),
-                                expr.span,
-                            )
-                            .with_label("not a `Result` or `Option`")
-                            .with_code("E005"),
+                        self.emit_error(
+                            format!(
+                                "`?` can only be used on `Result` or `Option`, found `{}`",
+                                ty.display_name()
+                            ),
+                            expr.span,
+                            "E005",
+                            "not a `Result` or `Option`",
                         );
                         Type::Unknown
                     }
@@ -248,16 +237,14 @@ impl Checker {
                     Type::Array(inner) => {
                         // Index must be a number
                         if !matches!(idx_ty, Type::Number | Type::Unknown) {
-                            self.diagnostics.push(
-                                Diagnostic::error(
-                                    format!(
-                                        "array index must be `number`, found `{}`",
-                                        idx_ty.display_name()
-                                    ),
-                                    index.span,
-                                )
-                                .with_label("expected `number`")
-                                .with_code("E017"),
+                            self.emit_error(
+                                format!(
+                                    "array index must be `number`, found `{}`",
+                                    idx_ty.display_name()
+                                ),
+                                index.span,
+                                "E017",
+                                "expected `number`",
                             );
                         }
                         Type::Option(inner.clone())
@@ -293,13 +280,11 @@ impl Checker {
                                 Type::Unknown
                             }
                         } else {
-                            self.diagnostics.push(
-                                Diagnostic::error(
-                                    "tuple index must be a numeric literal",
-                                    index.span,
-                                )
-                                .with_label("dynamic indexing is not allowed on tuples")
-                                .with_code("E017"),
+                            self.emit_error(
+                                "tuple index must be a numeric literal",
+                                index.span,
+                                "E017",
+                                "dynamic indexing is not allowed on tuples",
                             );
                             Type::Unknown
                         }
@@ -312,16 +297,14 @@ impl Checker {
                         {
                             return Type::Unknown;
                         }
-                        self.diagnostics.push(
-                            Diagnostic::error(
-                                format!(
-                                    "cannot use bracket access on type `{}`",
-                                    obj_ty.display_name()
-                                ),
-                                expr.span,
-                            )
-                            .with_label("not an array or tuple type")
-                            .with_code("E017"),
+                        self.emit_error(
+                            format!(
+                                "cannot use bracket access on type `{}`",
+                                obj_ty.display_name()
+                            ),
+                            expr.span,
+                            "E017",
+                            "not an array or tuple type",
                         );
                         Type::Unknown
                     }
@@ -420,17 +403,15 @@ impl Checker {
                             && !matches!(arm_type, Type::Unknown | Type::Var(_))
                             && !matches!(first_type, Type::Unknown | Type::Var(_))
                         {
-                            self.diagnostics.push(
-                                Diagnostic::error(
-                                    format!(
+                            self.emit_error(
+                                format!(
                                         "match arms have incompatible types: first arm returns `{}`, this arm returns `{}`",
                                         first_type.display_name(),
                                         arm_type.display_name()
                                     ),
-                                    arm.body.span,
-                                )
-                                .with_label(format!("expected `{}`", first_type.display_name()))
-                                .with_code("E001"),
+                                arm.body.span,
+                                "E001",
+                                format!("expected `{}`", first_type.display_name()),
                             );
                         }
                         result_type = Some(Self::merge_types(first_type, &arm_type));
@@ -443,14 +424,12 @@ impl Checker {
 
             ExprKind::Await(inner) => {
                 if !self.ctx.inside_async {
-                    self.diagnostics.push(
-                        Diagnostic::error(
-                            "`await` can only be used inside an `async` function",
-                            expr.span,
-                        )
-                        .with_label("not inside an `async` function")
-                        .with_help("add `async` to the enclosing function declaration")
-                        .with_code("E033"),
+                    self.emit_error_with_help(
+                        "`await` can only be used inside an `async` function",
+                        expr.span,
+                        "E033",
+                        "not inside an `async` function",
+                        "add `async` to the enclosing function declaration",
                     );
                 }
                 let ty = self.check_expr(inner);
@@ -542,14 +521,12 @@ impl Checker {
             ExprKind::Unchanged => Type::Settable(Box::new(Type::Unknown)),
 
             ExprKind::Todo => {
-                self.diagnostics.push(
-                    Diagnostic::warning(
-                        "`todo` is a placeholder that will panic at runtime",
-                        expr.span,
-                    )
-                    .with_label("not yet implemented")
-                    .with_help("replace with actual implementation before shipping")
-                    .with_code("W002"),
+                self.emit_warning_with_help(
+                    "`todo` is a placeholder that will panic at runtime",
+                    expr.span,
+                    "W002",
+                    "not yet implemented",
+                    "replace with actual implementation before shipping",
                 );
                 Type::Never
             }
@@ -703,18 +680,16 @@ impl Checker {
             }
 
             if !variadic && arg_count != expected_param_count {
-                self.diagnostics.push(
-                    Diagnostic::error(
-                        format!(
-                            "`{display}` expects {} argument{}, found {}",
-                            expected_param_count,
-                            if expected_param_count == 1 { "" } else { "s" },
-                            arg_count
-                        ),
-                        span,
-                    )
-                    .with_label("wrong number of arguments")
-                    .with_code("E001"),
+                self.emit_error(
+                    format!(
+                        "`{display}` expects {} argument{}, found {}",
+                        expected_param_count,
+                        if expected_param_count == 1 { "" } else { "s" },
+                        arg_count
+                    ),
+                    span,
+                    "E001",
+                    "wrong number of arguments",
                 );
             }
 
@@ -726,16 +701,12 @@ impl Checker {
             && !self.ctx.inside_try
             && self.untrusted_imports.contains(name)
         {
-            self.diagnostics.push(
-                Diagnostic::error(
-                    format!("calling untrusted import `{name}` requires `try`"),
-                    span,
-                )
-                .with_label("untrusted import")
-                .with_help(format!(
-                    "use `try {name}(...)` or mark the import as `trusted`"
-                ))
-                .with_code("E014"),
+            self.emit_error_with_help(
+                format!("calling untrusted import `{name}` requires `try`"),
+                span,
+                "E014",
+                "untrusted import",
+                format!("use `try {name}(...)` or mark the import as `trusted`"),
             );
         }
 
@@ -762,13 +733,11 @@ impl Checker {
         let has_placeholder = placeholder_count > 0;
 
         if placeholder_count > 1 {
-            self.diagnostics.push(
-                Diagnostic::error(
-                    "only one `_` placeholder allowed per call - use `(x, y) => f(x, y)` for multiple parameters",
-                    span,
-                )
-                .with_label("multiple `_` placeholders")
-                .with_code("E023"),
+            self.emit_error(
+                "only one `_` placeholder allowed per call - use `(x, y) => f(x, y)` for multiple parameters",
+                span,
+                "E023",
+                "multiple `_` placeholders",
             );
         }
 
@@ -867,16 +836,14 @@ impl Checker {
                     } else {
                         format!("{} to {} arguments", required_params, params.len())
                     };
-                    self.diagnostics.push(
-                        Diagnostic::error(
-                            format!(
-                                "`{callee_name}` expects {expected_msg}, found {}",
-                                arg_types.len()
-                            ),
-                            span,
-                        )
-                        .with_label("wrong number of arguments")
-                        .with_code("E001"),
+                    self.emit_error(
+                        format!(
+                            "`{callee_name}` expects {expected_msg}, found {}",
+                            arg_types.len()
+                        ),
+                        span,
+                        "E001",
+                        "wrong number of arguments",
                     );
                 }
 
@@ -911,18 +878,16 @@ impl Checker {
                             continue;
                         }
                         if !self.types_compatible(param_ty, arg_ty) {
-                            self.diagnostics.push(
-                                Diagnostic::error(
-                                    format!(
-                                        "argument {} to `{callee_name}`: expected `{}`, found `{}`",
-                                        i + 1,
-                                        param_ty.display_name(),
-                                        arg_ty.display_name()
-                                    ),
-                                    span,
-                                )
-                                .with_label(format!("expected `{}`", param_ty.display_name()))
-                                .with_code("E001"),
+                            self.emit_error(
+                                format!(
+                                    "argument {} to `{callee_name}`: expected `{}`, found `{}`",
+                                    i + 1,
+                                    param_ty.display_name(),
+                                    arg_ty.display_name()
+                                ),
+                                span,
+                                "E001",
+                                format!("expected `{}`", param_ty.display_name()),
                             );
                         }
                     }
@@ -952,18 +917,16 @@ impl Checker {
                     // Normal call: check all argument types
                     for (i, (arg_ty, param_ty)) in arg_types.iter().zip(params.iter()).enumerate() {
                         if !self.types_compatible(param_ty, arg_ty) {
-                            self.diagnostics.push(
-                                Diagnostic::error(
-                                    format!(
-                                        "argument {} to `{callee_name}`: expected `{}`, found `{}`",
-                                        i + 1,
-                                        param_ty.display_name(),
-                                        arg_ty.display_name()
-                                    ),
-                                    span,
-                                )
-                                .with_label(format!("expected `{}`", param_ty.display_name()))
-                                .with_code("E001"),
+                            self.emit_error(
+                                format!(
+                                    "argument {} to `{callee_name}`: expected `{}`, found `{}`",
+                                    i + 1,
+                                    param_ty.display_name(),
+                                    arg_ty.display_name()
+                                ),
+                                span,
+                                "E001",
+                                format!("expected `{}`", param_ty.display_name()),
                             );
                         }
                     }
@@ -978,17 +941,15 @@ impl Checker {
         if !concrete.is_boolean()
             && !matches!(concrete, Type::Unknown | Type::Var(_) | Type::Foreign(_))
         {
-            self.diagnostics.push(
-                Diagnostic::error(
-                    format!(
-                        "expected boolean operand for `{op}`, found `{}`",
-                        ty.display_name()
-                    ),
-                    span,
-                )
-                .with_label("expected `boolean`")
-                .with_help("use `match` for non-boolean conditional logic")
-                .with_code("E001"),
+            self.emit_error_with_help(
+                format!(
+                    "expected boolean operand for `{op}`, found `{}`",
+                    ty.display_name()
+                ),
+                span,
+                "E001",
+                "expected `boolean`",
+                "use `match` for non-boolean conditional logic",
             );
         }
     }
@@ -1006,18 +967,16 @@ impl Checker {
                     && !matches!(left_ty, Type::Unknown | Type::Var(_))
                     && !matches!(right_ty, Type::Unknown | Type::Var(_))
                 {
-                    self.diagnostics.push(
-                        Diagnostic::error(
-                            format!(
-                                "cannot compare `{}` with `{}`",
-                                left_ty.display_name(),
-                                right_ty.display_name()
-                            ),
-                            span,
-                        )
-                        .with_label("mismatched types")
-                        .with_help("both sides of `==` must have the same type")
-                        .with_code("E008"),
+                    self.emit_error_with_help(
+                        format!(
+                            "cannot compare `{}` with `{}`",
+                            left_ty.display_name(),
+                            right_ty.display_name()
+                        ),
+                        span,
+                        "E008",
+                        "mismatched types",
+                        "both sides of `==` must have the same type",
                     );
                 }
                 Type::Bool
@@ -1034,14 +993,12 @@ impl Checker {
             BinOp::Add => {
                 // Rule 12: String concat with + warning
                 if matches!(left_ty, Type::String) || matches!(right_ty, Type::String) {
-                    self.diagnostics.push(
-                        Diagnostic::warning(
-                            "use template literal instead of `+` for string concatenation",
-                            span,
-                        )
-                        .with_label("prefer template literal")
-                        .with_help("use `\"${a}${b}\"` instead")
-                        .with_code("W002"),
+                    self.emit_warning_with_help(
+                        "use template literal instead of `+` for string concatenation",
+                        span,
+                        "W002",
+                        "prefer template literal",
+                        "use `\"${a}${b}\"` instead",
                     );
                 }
                 if matches!(left_ty, Type::Number) && matches!(right_ty, Type::Number) {
@@ -1073,10 +1030,11 @@ impl Checker {
                 .is_some_and(|ty| matches!(ty, Type::Union { .. }));
             let is_known_value = self.env.lookup(type_name).is_some();
             if !is_variant && !is_known_value {
-                self.diagnostics.push(
-                    Diagnostic::error(format!("unknown type `{type_name}`"), span)
-                        .with_label("not defined")
-                        .with_code("E002"),
+                self.emit_error(
+                    format!("unknown type `{type_name}`"),
+                    span,
+                    "E002",
+                    "not defined",
                 );
             }
         }
@@ -1099,16 +1057,12 @@ impl Checker {
         if let Some(ref info) = type_info
             && info.opaque
         {
-            self.diagnostics.push(
-                Diagnostic::error(
-                    format!(
-                        "cannot construct opaque type `{type_name}` outside its defining module"
-                    ),
-                    span,
-                )
-                .with_label("opaque type cannot be constructed directly")
-                .with_help("use the module's exported constructor function instead")
-                .with_code("E003"),
+            self.emit_error_with_help(
+                format!("cannot construct opaque type `{type_name}` outside its defining module"),
+                span,
+                "E003",
+                "opaque type cannot be constructed directly",
+                "use the module's exported constructor function instead",
             );
         }
 
@@ -1162,21 +1116,19 @@ impl Checker {
 
             for label in &named_labels {
                 if !fields.iter().any(|f| f == label) {
-                    self.diagnostics.push(
-                        Diagnostic::error(
-                            format!("unknown field `{label}` on type `{type_name}`"),
-                            span,
-                        )
-                        .with_label(format!("`{label}` is not a field of `{type_name}`"))
-                        .with_help(format!(
+                    self.emit_error_with_help(
+                        format!("unknown field `{label}` on type `{type_name}`"),
+                        span,
+                        "E015",
+                        format!("`{label}` is not a field of `{type_name}`"),
+                        format!(
                             "available fields: {}",
                             fields
                                 .iter()
                                 .map(|f| format!("`{f}`"))
                                 .collect::<Vec<_>>()
                                 .join(", ")
-                        ))
-                        .with_code("E015"),
+                        ),
                     );
                 }
             }
@@ -1209,15 +1161,13 @@ impl Checker {
                     let has_default = has_defaults.contains(field);
 
                     if !provided_by_name && !provided_by_position && !has_default {
-                        self.diagnostics.push(
-                            Diagnostic::error(
-                                format!(
-                                    "missing required field `{field}` in `{type_name}` constructor"
-                                ),
-                                span,
-                            )
-                            .with_label(format!("field `{field}` is required"))
-                            .with_code("E016"),
+                        self.emit_error(
+                            format!(
+                                "missing required field `{field}` in `{type_name}` constructor"
+                            ),
+                            span,
+                            "E016",
+                            format!("field `{field}` is required"),
                         );
                     }
                 }
@@ -1234,16 +1184,12 @@ impl Checker {
                     if let Arg::Named { label, .. } = arg
                         && spread_keys.contains(&label.as_str())
                     {
-                        self.diagnostics.push(
-                            Diagnostic::warning(
-                                format!(
-                                    "field `{label}` from spread is overwritten by explicit field"
-                                ),
-                                span,
-                            )
-                            .with_label(format!("`{label}` exists in the spread source"))
-                            .with_help("the spread value will be replaced by the explicit field")
-                            .with_code("W003"),
+                        self.emit_warning_with_help(
+                            format!("field `{label}` from spread is overwritten by explicit field"),
+                            span,
+                            "W003",
+                            format!("`{label}` exists in the spread source"),
+                            "the spread value will be replaced by the explicit field",
                         );
                     }
                 }
@@ -1288,17 +1234,15 @@ impl Checker {
                         && !self.types_compatible(expected_ty, &arg_ty)
                         && !matches!(arg_ty, Type::Unknown | Type::Var(_))
                     {
-                        self.diagnostics.push(
-                            Diagnostic::error(
-                                format!(
-                                    "field `{label}`: expected `{}`, found `{}`",
-                                    expected_ty.display_name(),
-                                    arg_ty.display_name()
-                                ),
-                                span,
-                            )
-                            .with_label(format!("expected `{}`", expected_ty.display_name()))
-                            .with_code("E001"),
+                        self.emit_error(
+                            format!(
+                                "field `{label}`: expected `{}`, found `{}`",
+                                expected_ty.display_name(),
+                                arg_ty.display_name()
+                            ),
+                            span,
+                            "E001",
+                            format!("expected `{}`", expected_ty.display_name()),
                         );
                     }
                 }
@@ -1431,17 +1375,15 @@ impl Checker {
                     if let Some(first_param) = params.first()
                         && !self.types_compatible(first_param, left_ty)
                     {
-                        self.diagnostics.push(
-                            Diagnostic::error(
-                                format!(
-                                    "argument 1 to `{name}`: expected `{}`, found `{}`",
-                                    first_param.display_name(),
-                                    left_ty.display_name()
-                                ),
-                                right.span,
-                            )
-                            .with_label(format!("expected `{}`", first_param.display_name()))
-                            .with_code("E001"),
+                        self.emit_error(
+                            format!(
+                                "argument 1 to `{name}`: expected `{}`, found `{}`",
+                                first_param.display_name(),
+                                left_ty.display_name()
+                            ),
+                            right.span,
+                            "E001",
+                            format!("expected `{}`", first_param.display_name()),
                         );
                     }
                     return *return_type;
@@ -1450,16 +1392,14 @@ impl Checker {
                 Type::Unknown | Type::Var(_) => {}
                 // Non-function types: error
                 _ => {
-                    self.diagnostics.push(
-                        Diagnostic::error(
-                            format!(
-                                "cannot pipe into `{name}`: expected a function, found `{}`",
-                                right_ty.display_name()
-                            ),
-                            right.span,
-                        )
-                        .with_label("not a function")
-                        .with_code("E001"),
+                    self.emit_error(
+                        format!(
+                            "cannot pipe into `{name}`: expected a function, found `{}`",
+                            right_ty.display_name()
+                        ),
+                        right.span,
+                        "E001",
+                        "not a function",
                     );
                 }
             }
@@ -1480,17 +1420,15 @@ impl Checker {
         if let Some(first_param) = stdlib_fn.params.first()
             && !self.types_compatible(first_param, left_ty)
         {
-            self.diagnostics.push(
-                Diagnostic::error(
-                    format!(
-                        "argument 1 to `{display_name}`: expected `{}`, found `{}`",
-                        first_param.display_name(),
-                        left_ty.display_name()
-                    ),
-                    right.span,
-                )
-                .with_label(format!("expected `{}`", first_param.display_name()))
-                .with_code("E001"),
+            self.emit_error(
+                format!(
+                    "argument 1 to `{display_name}`: expected `{}`, found `{}`",
+                    first_param.display_name(),
+                    left_ty.display_name()
+                ),
+                right.span,
+                "E001",
+                format!("expected `{}`", first_param.display_name()),
             );
         }
         if let Type::Array(elem) = left_ty {
@@ -1768,53 +1706,48 @@ impl Checker {
     fn resolve_member_type(&mut self, obj_ty: &Type, field: &str, span: Span) -> Type {
         // Rule 6: No property access on unnarrowed unions
         if let Type::Result { .. } = obj_ty {
-            self.diagnostics.push(
-                Diagnostic::error(
-                    format!("cannot access `.{field}` on `Result` - use `match` or `?` first"),
-                    span,
-                )
-                .with_label("`Result` must be narrowed first")
-                .with_help("use `match result { Ok(v) -> ..., Err(e) -> ... }`")
-                .with_code("E006"),
+            self.emit_error_with_help(
+                format!("cannot access `.{field}` on `Result` - use `match` or `?` first"),
+                span,
+                "E006",
+                "`Result` must be narrowed first",
+                "use `match result { Ok(v) -> ..., Err(e) -> ... }`",
             );
             return Type::Unknown;
         }
         if let Type::Union { name, .. } = obj_ty {
-            self.diagnostics.push(
-                Diagnostic::error(
-                    format!("cannot access `.{field}` on union `{name}` - use `match` first"),
-                    span,
-                )
-                .with_label("union must be narrowed first")
-                .with_help("use `match` to narrow the union first")
-                .with_code("E006"),
+            self.emit_error_with_help(
+                format!("cannot access `.{field}` on union `{name}` - use `match` first"),
+                span,
+                "E006",
+                "union must be narrowed first",
+                "use `match` to narrow the union first",
             );
             return Type::Unknown;
         }
 
         // Error on member access on Promise — must await first
         if let Type::Promise(_) = obj_ty {
-            self.diagnostics.push(
-                Diagnostic::error(
-                    format!(
-                        "cannot access `.{field}` on `{}` — use `await` first",
-                        obj_ty.display_name()
-                    ),
-                    span,
-                )
-                .with_label("must `await` the Promise before accessing members")
-                .with_code("E021"),
+            self.emit_error(
+                format!(
+                    "cannot access `.{field}` on `{}` — use `await` first",
+                    obj_ty.display_name()
+                ),
+                span,
+                "E021",
+                "must `await` the Promise before accessing members",
             );
             return Type::Unknown;
         }
 
         // Error on member access on `unknown` — must narrow first
         if matches!(obj_ty, Type::Unknown) {
-            self.diagnostics.push(
-                Diagnostic::error(format!("cannot access `.{field}` on `unknown`"), span)
-                    .with_label("`unknown` must be narrowed before member access")
-                    .with_help("use `match`, type validation (e.g. Zod), or pattern matching")
-                    .with_code("E020"),
+            self.emit_error_with_help(
+                format!("cannot access `.{field}` on `unknown`"),
+                span,
+                "E020",
+                "`unknown` must be narrowed before member access",
+                "use `match`, type validation (e.g. Zod), or pattern matching",
             );
             return Type::Unknown;
         }
@@ -1836,18 +1769,19 @@ impl Checker {
             } else {
                 format!("`{}`", obj_ty.display_name())
             };
-            self.diagnostics.push(
-                Diagnostic::error(format!("type {type_name} has no field `{field}`"), span)
-                    .with_label("unknown field")
-                    .with_help(format!(
-                        "available fields: {}",
-                        fields
-                            .iter()
-                            .map(|(n, _)| format!("`{n}`"))
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    ))
-                    .with_code("E017"),
+            self.emit_error_with_help(
+                format!("type {type_name} has no field `{field}`"),
+                span,
+                "E017",
+                "unknown field",
+                format!(
+                    "available fields: {}",
+                    fields
+                        .iter()
+                        .map(|(n, _)| format!("`{n}`"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
             );
             return Type::Unknown;
         }
@@ -1875,16 +1809,14 @@ impl Checker {
         // Error on member access on primitive types
         match obj_ty {
             Type::Number | Type::String | Type::Bool | Type::Unit => {
-                self.diagnostics.push(
-                    Diagnostic::error(
-                        format!(
-                            "cannot access `.{field}` on type `{}`",
-                            obj_ty.display_name()
-                        ),
-                        span,
-                    )
-                    .with_label("not a record type")
-                    .with_code("E017"),
+                self.emit_error(
+                    format!(
+                        "cannot access `.{field}` on type `{}`",
+                        obj_ty.display_name()
+                    ),
+                    span,
+                    "E017",
+                    "not a record type",
                 );
                 return Type::Unknown;
             }
@@ -1909,14 +1841,12 @@ impl Checker {
             if self.env.lookup_type(name).is_none() {
                 return Type::Foreign(format!("{name}.{field}"));
             }
-            self.diagnostics.push(
-                Diagnostic::error(
-                    format!("cannot access `.{field}` on unresolved type `{name}`"),
-                    span,
-                )
-                .with_label("type definition not found")
-                .with_help("ensure the type's source module has a .d.ts file or is a .fl file")
-                .with_code("E020"),
+            self.emit_error_with_help(
+                format!("cannot access `.{field}` on unresolved type `{name}`"),
+                span,
+                "E020",
+                "type definition not found",
+                "ensure the type's source module has a .d.ts file or is a .fl file",
             );
             return Type::Unknown;
         }
@@ -1932,16 +1862,14 @@ impl Checker {
         }
 
         // Fallback: type doesn't support member access
-        self.diagnostics.push(
-            Diagnostic::error(
-                format!(
-                    "cannot access `.{field}` on type `{}`",
-                    obj_ty.display_name()
-                ),
-                span,
-            )
-            .with_label("this type does not support member access")
-            .with_code("E017"),
+        self.emit_error(
+            format!(
+                "cannot access `.{field}` on type `{}`",
+                obj_ty.display_name()
+            ),
+            span,
+            "E017",
+            "this type does not support member access",
         );
         Type::Unknown
     }

--- a/src/checker/match_check.rs
+++ b/src/checker/match_check.rs
@@ -68,14 +68,12 @@ impl Checker {
                     .map(|s| format!("`{s}`"))
                     .collect::<Vec<_>>()
                     .join(", ");
-                self.diagnostics.push(
-                    Diagnostic::error(
-                        format!("non-exhaustive match on `{name}`: missing {missing_str}"),
-                        span,
-                    )
-                    .with_label("not all variants covered")
-                    .with_help("add match arms for the missing variants, or add a `_ ->` catch-all")
-                    .with_code("E004"),
+                self.emit_error_with_help(
+                    format!("non-exhaustive match on `{name}`: missing {missing_str}"),
+                    span,
+                    "E004",
+                    "not all variants covered",
+                    "add match arms for the missing variants, or add a `_ ->` catch-all",
                 );
             }
         }
@@ -100,14 +98,12 @@ impl Checker {
                     .map(|s| format!("`\"{s}\"`"))
                     .collect::<Vec<_>>()
                     .join(", ");
-                self.diagnostics.push(
-                    Diagnostic::error(
-                        format!("non-exhaustive match on `{name}`: missing {missing_str}"),
-                        span,
-                    )
-                    .with_label("not all variants covered")
-                    .with_help("add match arms for the missing variants, or add a `_ ->` catch-all")
-                    .with_code("E004"),
+                self.emit_error_with_help(
+                    format!("non-exhaustive match on `{name}`: missing {missing_str}"),
+                    span,
+                    "E004",
+                    "not all variants covered",
+                    "add match arms for the missing variants, or add a `_ ->` catch-all",
                 );
             }
         }
@@ -134,14 +130,12 @@ impl Checker {
                     (true, false) => "`Err`",
                     _ => unreachable!(),
                 };
-                self.diagnostics.push(
-                    Diagnostic::error(
-                        format!("non-exhaustive match on `Result`: missing {missing}"),
-                        span,
-                    )
-                    .with_label("not all cases covered")
-                    .with_help("add match arms for the missing cases")
-                    .with_code("E004"),
+                self.emit_error_with_help(
+                    format!("non-exhaustive match on `Result`: missing {missing}"),
+                    span,
+                    "E004",
+                    "not all cases covered",
+                    "add match arms for the missing cases",
                 );
             }
         }
@@ -166,14 +160,12 @@ impl Checker {
                     (true, false) => "`None`",
                     _ => unreachable!(),
                 };
-                self.diagnostics.push(
-                    Diagnostic::error(
-                        format!("non-exhaustive match on `Option`: missing {missing}"),
-                        span,
-                    )
-                    .with_label("not all cases covered")
-                    .with_help("add match arms for the missing cases")
-                    .with_code("E004"),
+                self.emit_error_with_help(
+                    format!("non-exhaustive match on `Option`: missing {missing}"),
+                    span,
+                    "E004",
+                    "not all cases covered",
+                    "add match arms for the missing cases",
                 );
             }
         }
@@ -206,17 +198,15 @@ impl Checker {
                 if !has_unchanged {
                     missing.push("`Unchanged`");
                 }
-                self.diagnostics.push(
-                    Diagnostic::error(
-                        format!(
-                            "non-exhaustive match on `Settable`: missing {}",
-                            missing.join(" and ")
-                        ),
-                        span,
-                    )
-                    .with_label("not all cases covered")
-                    .with_help("add match arms for the missing cases")
-                    .with_code("E004"),
+                self.emit_error_with_help(
+                    format!(
+                        "non-exhaustive match on `Settable`: missing {}",
+                        missing.join(" and ")
+                    ),
+                    span,
+                    "E004",
+                    "not all cases covered",
+                    "add match arms for the missing cases",
                 );
             }
         }
@@ -251,16 +241,12 @@ impl Checker {
                     (true, false) => "non-empty array `[_, .._]`",
                     _ => unreachable!(),
                 };
-                self.diagnostics.push(
-                    Diagnostic::error(
-                        format!("non-exhaustive match on array: missing {missing}"),
-                        span,
-                    )
-                    .with_label("not all cases covered")
-                    .with_help(
-                        "add match arms for both `[]` and `[_, ..rest]`, or add a `_ ->` catch-all",
-                    )
-                    .with_code("E004"),
+                self.emit_error_with_help(
+                    format!("non-exhaustive match on array: missing {missing}"),
+                    span,
+                    "E004",
+                    "not all cases covered",
+                    "add match arms for both `[]` and `[_, ..rest]`, or add a `_ ->` catch-all",
                 );
             }
         }
@@ -281,38 +267,35 @@ impl Checker {
                 }
             }
             if !has_true || !has_false {
-                self.diagnostics.push(
-                    Diagnostic::error("non-exhaustive match on `boolean`: missing a case", span)
-                        .with_label("not all cases covered")
-                        .with_help("add match arms for both `true` and `false`")
-                        .with_code("E004"),
+                self.emit_error_with_help(
+                    "non-exhaustive match on `boolean`: missing a case",
+                    span,
+                    "E004",
+                    "not all cases covered",
+                    "add match arms for both `true` and `false`",
                 );
             }
         }
 
         // For number types, require a `_` catch-all (numbers are unbounded)
         if matches!(subject_ty, Type::Number) {
-            self.diagnostics.push(
-                Diagnostic::error(
-                    "non-exhaustive match on `number`: cannot cover all values without a catch-all",
-                    span,
-                )
-                .with_label("number type has infinite values")
-                .with_help("add a `_ ->` catch-all arm")
-                .with_code("E004"),
+            self.emit_error_with_help(
+                "non-exhaustive match on `number`: cannot cover all values without a catch-all",
+                span,
+                "E004",
+                "number type has infinite values",
+                "add a `_ ->` catch-all arm",
             );
         }
 
         // For string types, require a `_` catch-all (strings are unbounded)
         if matches!(subject_ty, Type::String) {
-            self.diagnostics.push(
-                Diagnostic::error(
-                    "non-exhaustive match on `string`: cannot cover all values without a catch-all",
-                    span,
-                )
-                .with_label("string type has infinite values")
-                .with_help("add a `_ ->` catch-all arm")
-                .with_code("E004"),
+            self.emit_error_with_help(
+                "non-exhaustive match on `string`: cannot cover all values without a catch-all",
+                span,
+                "E004",
+                "string type has infinite values",
+                "add a `_ ->` catch-all arm",
             );
         }
 
@@ -320,14 +303,12 @@ impl Checker {
         if let Type::Tuple(elem_types) = subject_ty
             && !self.check_tuple_exhaustiveness(elem_types, arms)
         {
-            self.diagnostics.push(
-                Diagnostic::error(
-                    "non-exhaustive match on tuple: not all combinations are covered",
-                    span,
-                )
-                .with_label("not all cases covered")
-                .with_help("add match arms for the missing combinations, or add a `_ ->` catch-all")
-                .with_code("E004"),
+            self.emit_error_with_help(
+                "non-exhaustive match on tuple: not all combinations are covered",
+                span,
+                "E004",
+                "not all cases covered",
+                "add match arms for the missing combinations, or add a `_ ->` catch-all",
             );
         }
     }
@@ -531,16 +512,14 @@ impl Checker {
             PatternKind::StringPattern { segments } => {
                 // String patterns require the subject to be a string type
                 if !matches!(subject_ty, Type::String | Type::Unknown) {
-                    self.diagnostics.push(
-                        Diagnostic::error(
-                            format!(
-                                "string pattern used on non-string type `{}`",
-                                subject_ty.display_name()
-                            ),
-                            pattern.span,
-                        )
-                        .with_label("expected string type")
-                        .with_code("E005"),
+                    self.emit_error(
+                        format!(
+                            "string pattern used on non-string type `{}`",
+                            subject_ty.display_name()
+                        ),
+                        pattern.span,
+                        "E005",
+                        "expected string type",
                     );
                 }
                 // Bind all captured variables as string


### PR DESCRIPTION
closes #711

## Summary
- Adds `emit_error()`, `emit_error_with_help()`, and `emit_warning_with_help()` methods to Checker
- Replaces 77 instances of the 5-6 line `self.diagnostics.push(Diagnostic::error(...).with_label(...).with_code(...))` pattern with single-line calls
- 12 instances remain as-is (helper bodies themselves, borrow conflicts, edge cases without labels)

## Before
```rust
self.diagnostics.push(
    Diagnostic::error(
        format!("expected `{}`, found `{}`", expected, actual),
        span,
    )
    .with_label(format!("expected `{}`", expected))
    .with_code("E001"),
);
```

## After
```rust
self.emit_error(
    format!("expected `{}`, found `{}`", expected, actual),
    span, "E001",
    format!("expected `{}`", expected),
);
```

## Stats
- 77 replacements across 3 files
- -85 lines net (591 insertions, 676 deletions)
- Zero behavioral changes

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (1146 tests)
- [x] `floe check` on example apps passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)