### PR TITLE
fix: use mangled name for bare for-block function calls

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -131,6 +131,22 @@ impl Codegen {
         self
     }
 
+    /// Look up a for-block function by bare name (without type qualifier).
+    /// Returns the mangled name if found (e.g., "toChar" → "Icon__toChar").
+    fn lookup_for_block_fn_by_name(&self, name: &str) -> Option<String> {
+        for ((_, fn_name), mangled) in &self.for_block_fns {
+            if fn_name == name {
+                return Some(
+                    self.import_aliases
+                        .get(mangled)
+                        .cloned()
+                        .unwrap_or_else(|| mangled.clone()),
+                );
+            }
+        }
+        None
+    }
+
     /// Create a codegen with resolved import info.
     pub fn with_imports(resolved: &HashMap<String, ResolvedImports>) -> Self {
         let mut codegen = Self::new();

--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -41,6 +41,8 @@ impl Codegen {
                     // Non-unit variant as function value:
                     // `Validation` → `(value) => ({ tag: "Validation", value })`
                     self.emit_variant_constructor_fn(name, &field_names);
+                } else if let Some(mangled) = self.lookup_for_block_fn_by_name(name) {
+                    self.push(&mangled);
                 } else {
                     self.push(name);
                 }

--- a/src/codegen/pipes.rs
+++ b/src/codegen/pipes.rs
@@ -165,6 +165,20 @@ impl Codegen {
                 {
                     return;
                 }
+                // Bare for-block: `x |> toChar(args)` → `Icon__toChar(x, args)`
+                if let ExprKind::Identifier(name) = &callee.kind
+                    && let Some(mangled) = self.lookup_for_block_fn_by_name(name)
+                {
+                    self.push(&mangled);
+                    self.push("(");
+                    self.emit_expr(left);
+                    if !args.is_empty() {
+                        self.push(", ");
+                        self.emit_args(args);
+                    }
+                    self.push(")");
+                    return;
+                }
                 // Fall through to normal call handling below
                 let callee_alias = if let ExprKind::Identifier(name) = &callee.kind {
                     self.import_aliases.get(name.as_str()).cloned()
@@ -243,6 +257,14 @@ impl Codegen {
             ExprKind::Identifier(name) => {
                 if let Some(output) = self.try_emit_bare_stdlib_pipe(left, right, &[]) {
                     self.push(&output);
+                    return;
+                }
+                // For-block function: `item.icon |> toChar` → `Icon__toChar(item.icon)`
+                if let Some(mangled) = self.lookup_for_block_fn_by_name(name) {
+                    self.push(&mangled);
+                    self.push("(");
+                    self.emit_expr(left);
+                    self.push(")");
                     return;
                 }
                 // Use aliased import name if available (avoids TDZ conflicts)

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -1865,3 +1865,51 @@ fn _test(props: Props) -> JSX.Element {
         "should emit JSX spread prop, got: {result}"
     );
 }
+
+// ── For-block function call namespacing ────────────────────
+
+#[test]
+fn for_block_bare_pipe_uses_mangled_name() {
+    let result = emit(
+        r#"
+type Icon { | Grid | Columns }
+
+for Icon {
+    fn toChar(self) -> string {
+        match self { Grid -> "G", Columns -> "C" }
+    }
+}
+
+const _x = Grid |> toChar
+"#,
+    );
+    assert!(
+        result.contains("Icon__toChar("),
+        "bare pipe call should use mangled name, got: {result}"
+    );
+    assert!(
+        !result.replace("Icon__toChar(", "").contains("toChar("),
+        "should not emit bare toChar call, got: {result}"
+    );
+}
+
+#[test]
+fn for_block_bare_identifier_uses_mangled_name() {
+    let result = emit(
+        r#"
+type Icon { | Grid | Columns }
+
+for Icon {
+    fn toChar(self) -> string {
+        match self { Grid -> "G", Columns -> "C" }
+    }
+}
+
+const _f = toChar
+"#,
+    );
+    assert!(
+        result.contains("Icon__toChar"),
+        "bare identifier should use mangled name, got: {result}"
+    );
+}


### PR DESCRIPTION
Fixes #746

## Summary

For-block functions are emitted with namespaced definitions (e.g., `Icon__toChar`) but call sites were still emitting the bare name (`toChar`), causing a runtime `ReferenceError: Can't find variable: toChar`.

Fixed in three codegen paths:
- Bare identifier: `toChar` → `Icon__toChar`
- Bare pipe: `x |> toChar` → `Icon__toChar(x)`
- Pipe with args: `x |> toChar(extra)` → `Icon__toChar(x, extra)`

## Test plan

- [x] New codegen test for bare pipe call namespacing
- [x] All 1201 tests pass
- [x] `floe build --emit-stdout sidebar.fl` shows matching definition and call names

🤖 Generated with [Claude Code](https://claude.com/claude-code)