### PR TITLE
fix: [#755] [#756] Support destructured parameters with type annotations and error on unsupported syntax

### DIFF
--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -485,24 +485,60 @@ impl Checker {
                 self.name_types.insert(p.name.clone(), ty.display_name());
                 // For destructured params, also define the field names
                 if let Some(ref destructure) = p.destructure {
+                    let concrete_ty = self.resolve_type_to_concrete(&ty);
                     match destructure {
                         ParamDestructure::Object(fields) => {
-                            for f in fields {
-                                let name = f.bound_name();
-                                let field_ty = match f.field.as_str() {
-                                    "error" => Type::Named(type_layout::TYPE_ERROR.to_string()),
-                                    _ => Type::Unknown,
-                                };
-                                self.env.define(name, field_ty);
+                            if let Type::Record(ref rec_fields) = concrete_ty {
+                                for f in fields {
+                                    let name = f.bound_name();
+                                    let field_ty = rec_fields
+                                        .iter()
+                                        .find(|(n, _)| n == &f.field)
+                                        .map(|(_, t)| t.clone())
+                                        .unwrap_or_else(|| {
+                                            self.emit_error(
+                                                format!(
+                                                    "field `{}` does not exist on type `{}`",
+                                                    f.field,
+                                                    ty.display_name()
+                                                ),
+                                                p.span,
+                                                "E001",
+                                                format!(
+                                                    "`{}` has no field `{}`",
+                                                    ty.display_name(),
+                                                    f.field
+                                                ),
+                                            );
+                                            Type::Unknown
+                                        });
+                                    self.env.define(name, field_ty);
+                                }
+                            } else {
+                                // No type annotation resolved to a record — try special cases
+                                for f in fields {
+                                    let name = f.bound_name();
+                                    let field_ty = match f.field.as_str() {
+                                        "error" => Type::Named(type_layout::TYPE_ERROR.to_string()),
+                                        _ => Type::Unknown,
+                                    };
+                                    self.env.define(name, field_ty);
+                                }
                             }
                         }
                         ParamDestructure::Array(fields) => {
-                            for field in fields {
-                                let field_ty = match field.as_str() {
-                                    "error" => Type::Named(type_layout::TYPE_ERROR.to_string()),
-                                    _ => Type::Unknown,
-                                };
-                                self.env.define(field, field_ty);
+                            if let Type::Array(inner) = &concrete_ty {
+                                for field in fields {
+                                    self.env.define(field, *inner.clone());
+                                }
+                            } else {
+                                for field in fields {
+                                    let field_ty = match field.as_str() {
+                                        "error" => Type::Named(type_layout::TYPE_ERROR.to_string()),
+                                        _ => Type::Unknown,
+                                    };
+                                    self.env.define(field, field_ty);
+                                }
                             }
                         }
                     }
@@ -1848,7 +1884,7 @@ impl Checker {
     }
 
     /// Resolve a type to its concrete definition, following Named type lookups.
-    fn resolve_type_to_concrete(&mut self, ty: &Type) -> Type {
+    pub(crate) fn resolve_type_to_concrete(&mut self, ty: &Type) -> Type {
         let resolved = self.env.resolve_to_concrete(ty, &simple_resolve_type_expr);
         // If still Named after type_defs resolution, check if it's a known
         // value (e.g. built-in Response, Error) that has a concrete type

--- a/src/checker/items.rs
+++ b/src/checker/items.rs
@@ -342,23 +342,67 @@ impl Checker {
 
             // For destructured params, define the individual field names in scope
             if let Some(ref destructure) = param.destructure {
+                let concrete_ty = self.resolve_type_to_concrete(ty);
                 match destructure {
                     ParamDestructure::Object(fields) => {
-                        for f in fields {
-                            let field_ty = match ty {
-                                Type::Record(rec_fields) => rec_fields
+                        if let Type::Record(ref rec_fields) = concrete_ty {
+                            for f in fields {
+                                let field_ty = rec_fields
                                     .iter()
                                     .find(|(n, _)| n == &f.field)
                                     .map(|(_, t)| t.clone())
-                                    .unwrap_or(Type::Unknown),
-                                _ => Type::Unknown,
-                            };
-                            self.env.define(f.bound_name(), field_ty);
+                                    .unwrap_or_else(|| {
+                                        self.emit_error(
+                                            format!(
+                                                "field `{}` does not exist on type `{}`",
+                                                f.field,
+                                                ty.display_name()
+                                            ),
+                                            param.span,
+                                            "E001",
+                                            format!(
+                                                "`{}` has no field `{}`",
+                                                ty.display_name(),
+                                                f.field
+                                            ),
+                                        );
+                                        Type::Unknown
+                                    });
+                                self.env.define(f.bound_name(), field_ty);
+                            }
+                        } else {
+                            self.emit_error(
+                                format!(
+                                    "cannot destructure parameter of type `{}`",
+                                    ty.display_name()
+                                ),
+                                param.span,
+                                "E001",
+                                "destructuring requires a record type".to_string(),
+                            );
+                            for f in fields {
+                                self.env.define(f.bound_name(), Type::Unknown);
+                            }
                         }
                     }
                     ParamDestructure::Array(fields) => {
-                        for field in fields {
-                            self.env.define(field, Type::Unknown);
+                        if let Type::Array(inner) = &concrete_ty {
+                            for field in fields {
+                                self.env.define(field, *inner.clone());
+                            }
+                        } else {
+                            self.emit_error(
+                                format!(
+                                    "cannot array-destructure parameter of type `{}`",
+                                    ty.display_name()
+                                ),
+                                param.span,
+                                "E001",
+                                "array destructuring requires an array type".to_string(),
+                            );
+                            for field in fields {
+                                self.env.define(field, Type::Unknown);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
closes #755
closes #756

## Summary

- Destructured function parameters with type annotations (e.g., `{ name, age }: Props`) now correctly resolve field types by following `Named` → `Record` type lookups via `resolve_type_to_concrete()`
- Previously, the checker matched `ty` directly against `Type::Record(...)`, but `resolve_type()` returns `Type::Named("Props")` for user-defined types, causing all destructured fields to silently resolve as `unknown`
- Fixed in both named functions (`check_function`) and arrow functions (`check_arrow`)
- Added proper error diagnostics instead of silent `Unknown` fallback:
  - "cannot destructure parameter of type `X`" when destructuring a non-record type
  - "field `X` does not exist on type `Y`" when a destructured field doesn't exist on the type

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `RUSTFLAGS="-D warnings" cargo test` passes
- [x] `floe check` passes on both example apps
- [x] Verified `{ name, age }: Props` resolves fields correctly
- [x] Verified error on destructuring non-record type (`number`)
- [x] Verified error on nonexistent field in destructured pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)