### PR TITLE
fix: [#779] Imported TS functions with optional params incorrectly require all arguments

### DIFF
--- a/src/checker/imports.rs
+++ b/src/checker/imports.rs
@@ -14,11 +14,18 @@ impl Checker {
                 self.lookup_resolved_symbol(&spec.name, resolved)
             } else if let Some(ref exports) = dts_exports {
                 // Look up in .d.ts exports
-                exports
-                    .iter()
-                    .find(|e| e.name == spec.name)
-                    .map(|e| interop::wrap_boundary_type(&e.ts_type))
-                    .unwrap_or_else(|| Type::Foreign(spec.name.clone()))
+                if let Some(dts_export) = exports.iter().find(|e| e.name == spec.name) {
+                    if let interop::TsType::Function { params, .. } = &dts_export.ts_type {
+                        let required = params.iter().filter(|p| !p.optional).count();
+                        if required < params.len() {
+                            self.fn_required_params
+                                .insert(effective_name.to_string(), required);
+                        }
+                    }
+                    interop::wrap_boundary_type(&dts_export.ts_type)
+                } else {
+                    Type::Foreign(spec.name.clone())
+                }
             } else {
                 // No .fl resolution and no .d.ts — type is foreign to Floe
                 Type::Foreign(spec.name.clone())

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -391,7 +391,7 @@ const _x = greet(User(name: "Ryan"), "Hello")
 
 #[test]
 fn call_site_type_args_infer_return() {
-    use crate::interop::{DtsExport, TsType};
+    use crate::interop::{DtsExport, FunctionParam, TsType};
     use std::collections::HashMap;
 
     let program = crate::parser::Parser::new(
@@ -409,11 +409,17 @@ const _x = todos
     let use_state_export = DtsExport {
         name: "useState".to_string(),
         ts_type: TsType::Function {
-            params: vec![TsType::Named("S".to_string())],
+            params: vec![FunctionParam {
+                ty: TsType::Named("S".to_string()),
+                optional: false,
+            }],
             return_type: Box::new(TsType::Tuple(vec![
                 TsType::Named("S".to_string()),
                 TsType::Function {
-                    params: vec![TsType::Named("S".to_string())],
+                    params: vec![FunctionParam {
+                        ty: TsType::Named("S".to_string()),
+                        optional: false,
+                    }],
                     return_type: Box::new(TsType::Primitive("void".to_string())),
                 },
             ])),
@@ -1370,7 +1376,7 @@ fn handler() {
 #[test]
 fn dispatch_generic_converts_to_function() {
     // The REAL tsgo output: Dispatch<SetStateAction<Todo[]>> should become a function type
-    use crate::interop::{DtsExport, TsType};
+    use crate::interop::{DtsExport, FunctionParam, TsType};
 
     let program = crate::parser::Parser::new(
         r#"
@@ -1402,7 +1408,10 @@ fn handler() {
     let use_state_export = DtsExport {
         name: "useState".to_string(),
         ts_type: TsType::Function {
-            params: vec![TsType::Named("S".to_string())],
+            params: vec![FunctionParam {
+                ty: TsType::Named("S".to_string()),
+                optional: false,
+            }],
             return_type: Box::new(TsType::Tuple(vec![
                 TsType::Named("S".to_string()),
                 TsType::Named("S".to_string()),
@@ -1442,8 +1451,7 @@ fn calling_dispatch_type_is_callable() {
     // The REAL problem: setTodos has type Named("Dispatch<SetStateAction<...>>")
     // which is NOT Type::Function. Calling it returns Unknown.
     // This test demonstrates the gap.
-    use crate::interop::DtsExport;
-    use crate::interop::TsType;
+    use crate::interop::{DtsExport, FunctionParam, TsType};
 
     let program = crate::parser::Parser::new(
         r#"
@@ -1464,7 +1472,10 @@ fn handler() {
         ts_type: TsType::Tuple(vec![
             TsType::Array(Box::new(TsType::Named("Todo".to_string()))),
             TsType::Function {
-                params: vec![TsType::Named("Todo[]".to_string())],
+                params: vec![FunctionParam {
+                    ty: TsType::Named("Todo[]".to_string()),
+                    optional: false,
+                }],
                 return_type: Box::new(TsType::Primitive("void".to_string())),
             },
         ]),
@@ -1472,11 +1483,17 @@ fn handler() {
     let use_state_export = DtsExport {
         name: "useState".to_string(),
         ts_type: TsType::Function {
-            params: vec![TsType::Named("S".to_string())],
+            params: vec![FunctionParam {
+                ty: TsType::Named("S".to_string()),
+                optional: false,
+            }],
             return_type: Box::new(TsType::Tuple(vec![
                 TsType::Named("S".to_string()),
                 TsType::Function {
-                    params: vec![TsType::Named("S".to_string())],
+                    params: vec![FunctionParam {
+                        ty: TsType::Named("S".to_string()),
+                        optional: false,
+                    }],
                     return_type: Box::new(TsType::Primitive("void".to_string())),
                 },
             ])),
@@ -2964,6 +2981,90 @@ const x = greet("Ryan")
     assert!(
         !has_error_containing(&diags, "expects"),
         "should not produce argument count error, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+// ── Bug #779: Imported TS functions with optional params ──
+
+#[test]
+fn imported_optional_params_allow_omission() {
+    use crate::interop::{DtsExport, FunctionParam, TsType};
+    use std::collections::HashMap;
+
+    // useQueryClient(queryClient?: QueryClient): QueryClient
+    let program = crate::parser::Parser::new(
+        r#"
+import trusted { useQueryClient } from "@tanstack/react-query"
+const _client = useQueryClient()
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+
+    let export = DtsExport {
+        name: "useQueryClient".to_string(),
+        ts_type: TsType::Function {
+            params: vec![FunctionParam {
+                ty: TsType::Named("QueryClient".to_string()),
+                optional: true,
+            }],
+            return_type: Box::new(TsType::Named("QueryClient".to_string())),
+        },
+    };
+    let mut dts_imports = HashMap::new();
+    dts_imports.insert("@tanstack/react-query".to_string(), vec![export]);
+
+    let checker = Checker::with_all_imports(HashMap::new(), dts_imports);
+    let (diags, _, _) = checker.check_with_types(&program);
+
+    assert!(
+        !has_error_containing(&diags, "expects"),
+        "calling with 0 args should be allowed when param is optional, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn imported_optional_params_still_validates_max_args() {
+    use crate::interop::{DtsExport, FunctionParam, TsType};
+    use std::collections::HashMap;
+
+    // fn(a: string, b?: number): void — max 2 args
+    let program = crate::parser::Parser::new(
+        r#"
+import trusted { doStuff } from "some-lib"
+const _x = doStuff("hi", 1, true)
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+
+    let export = DtsExport {
+        name: "doStuff".to_string(),
+        ts_type: TsType::Function {
+            params: vec![
+                FunctionParam {
+                    ty: TsType::Primitive("string".to_string()),
+                    optional: false,
+                },
+                FunctionParam {
+                    ty: TsType::Primitive("number".to_string()),
+                    optional: true,
+                },
+            ],
+            return_type: Box::new(TsType::Primitive("void".to_string())),
+        },
+    };
+    let mut dts_imports = HashMap::new();
+    dts_imports.insert("some-lib".to_string(), vec![export]);
+
+    let checker = Checker::with_all_imports(HashMap::new(), dts_imports);
+    let (diags, _, _) = checker.check_with_types(&program);
+
+    assert!(
+        has_error_containing(&diags, "expects"),
+        "calling with 3 args should error when max is 2, got: {:?}",
         diags.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -26,7 +26,7 @@ use crate::checker::Type;
 
 // Re-export public API
 pub use dts::{DtsExport, parse_dts_exports};
-pub use ts_types::{ObjectField, TsType, ts_type_to_string};
+pub use ts_types::{FunctionParam, ObjectField, TsType, ts_type_to_string};
 pub use tsgo::TsgoResolver;
 pub use wrapper::wrap_boundary_type;
 

--- a/src/interop/dts.rs
+++ b/src/interop/dts.rs
@@ -333,29 +333,37 @@ fn extract_from_namespace_body(body: &Option<TSModuleDeclarationBody<'_>>) -> Ve
 
 // ── Type conversion helpers ─────────────────────────────────────
 
+/// Convert oxc formal parameters to our FunctionParam list.
+fn convert_formal_params(params: &FormalParameters<'_>) -> Vec<FunctionParam> {
+    params
+        .items
+        .iter()
+        .map(|p| {
+            let ty = p
+                .type_annotation
+                .as_ref()
+                .map(|ta| convert_oxc_type(&ta.type_annotation))
+                .unwrap_or(TsType::Any);
+            FunctionParam {
+                ty,
+                optional: p.optional,
+            }
+        })
+        .collect()
+}
+
 /// Convert an oxc function declaration to our TsType::Function.
 fn convert_function(
     params: &FormalParameters<'_>,
     return_type: &Option<oxc_allocator::Box<'_, oxc_ast::ast::TSTypeAnnotation<'_>>>,
 ) -> TsType {
-    let param_types: Vec<TsType> = params
-        .items
-        .iter()
-        .map(|p| {
-            p.type_annotation
-                .as_ref()
-                .map(|ta| convert_oxc_type(&ta.type_annotation))
-                .unwrap_or(TsType::Any)
-        })
-        .collect();
-
     let ret = return_type
         .as_ref()
         .map(|ta| convert_oxc_type(&ta.type_annotation))
         .unwrap_or(TsType::Primitive("void".to_string()));
 
     TsType::Function {
-        params: param_types,
+        params: convert_formal_params(params),
         return_type: Box::new(ret),
     }
 }
@@ -449,20 +457,9 @@ macro_rules! convert_shared_type_arms {
 
             // Function type: (params) => ReturnType
             $prefix::TSFunctionType(func) => {
-                let param_types: Vec<TsType> = func
-                    .params
-                    .items
-                    .iter()
-                    .map(|p| {
-                        p.type_annotation
-                            .as_ref()
-                            .map(|ta| convert_oxc_type(&ta.type_annotation))
-                            .unwrap_or(TsType::Any)
-                    })
-                    .collect();
                 let ret = convert_oxc_type(&func.return_type.type_annotation);
                 TsType::Function {
-                    params: param_types,
+                    params: convert_formal_params(&func.params),
                     return_type: Box::new(ret),
                 }
             }
@@ -644,7 +641,10 @@ pub(super) fn parse_function_export(rest: &str) -> Option<DtsExport> {
     Some(DtsExport {
         name,
         ts_type: TsType::Function {
-            params,
+            params: params
+                .into_iter()
+                .map(|(ty, optional)| FunctionParam { ty, optional })
+                .collect(),
             return_type: Box::new(return_type),
         },
     })

--- a/src/interop/tests.rs
+++ b/src/interop/tests.rs
@@ -113,7 +113,10 @@ fn parse_function_type() {
     assert_eq!(
         ty,
         TsType::Function {
-            params: vec![TsType::Primitive("string".to_string())],
+            params: vec![FunctionParam {
+                ty: TsType::Primitive("string".to_string()),
+                optional: false,
+            }],
             return_type: Box::new(TsType::Primitive("void".to_string())),
         }
     );
@@ -191,10 +194,10 @@ fn wrap_plain_union_stays_non_option() {
 fn wrap_function_wraps_params_and_return() {
     // (x: string | null) => any
     let ts = TsType::Function {
-        params: vec![TsType::Union(vec![
-            TsType::Primitive("string".to_string()),
-            TsType::Null,
-        ])],
+        params: vec![FunctionParam {
+            ty: TsType::Union(vec![TsType::Primitive("string".to_string()), TsType::Null]),
+            optional: false,
+        }],
         return_type: Box::new(TsType::Any),
     };
     let wrapped = wrap_boundary_type(&ts);
@@ -203,6 +206,32 @@ fn wrap_function_wraps_params_and_return() {
         Type::Function {
             params: vec![Type::Option(Box::new(Type::String))],
             return_type: Box::new(Type::Unknown),
+        }
+    );
+}
+
+#[test]
+fn wrap_function_optional_params_become_option() {
+    // (x: string, y?: number) => void
+    let ts = TsType::Function {
+        params: vec![
+            FunctionParam {
+                ty: TsType::Primitive("string".to_string()),
+                optional: false,
+            },
+            FunctionParam {
+                ty: TsType::Primitive("number".to_string()),
+                optional: true,
+            },
+        ],
+        return_type: Box::new(TsType::Primitive("void".to_string())),
+    };
+    let wrapped = wrap_boundary_type(&ts);
+    assert_eq!(
+        wrapped,
+        Type::Function {
+            params: vec![Type::String, Type::Option(Box::new(Type::Number))],
+            return_type: Box::new(Type::Unit),
         }
     );
 }
@@ -309,7 +338,10 @@ fn parse_dts_function_export() {
     assert_eq!(
         export.ts_type,
         TsType::Function {
-            params: vec![TsType::Primitive("string".to_string())],
+            params: vec![FunctionParam {
+                ty: TsType::Primitive("string".to_string()),
+                optional: false,
+            }],
             return_type: Box::new(TsType::Union(vec![
                 TsType::Named("Element".to_string()),
                 TsType::Null,

--- a/src/interop/ts_types.rs
+++ b/src/interop/ts_types.rs
@@ -8,6 +8,13 @@ pub struct ObjectField {
     pub optional: bool,
 }
 
+/// A parameter in a TypeScript function type, tracking optionality.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FunctionParam {
+    pub ty: TsType,
+    pub optional: bool,
+}
+
 impl TsType {
     /// Returns true if this type contains null or undefined (directly or in a union).
     pub fn is_nullable(&self) -> bool {
@@ -42,7 +49,7 @@ pub enum TsType {
     Union(Vec<TsType>),
     /// Function: `(params) => ReturnType`
     Function {
-        params: Vec<TsType>,
+        params: Vec<FunctionParam>,
         return_type: Box<TsType>,
     },
     /// Array shorthand: `T[]`
@@ -74,7 +81,7 @@ pub fn ts_type_to_string(ty: &TsType) -> String {
             params,
             return_type,
         } => {
-            let params_str: Vec<String> = params.iter().map(ts_type_to_string).collect();
+            let params_str: Vec<String> = params.iter().map(|p| ts_type_to_string(&p.ty)).collect();
             format!(
                 "({}) => {}",
                 params_str.join(", "),
@@ -142,7 +149,10 @@ pub(super) fn parse_type_str(s: &str) -> TsType {
             let params = parse_param_types(params_str);
             let return_type = parse_type_str(ret_str.trim());
             return TsType::Function {
-                params,
+                params: params
+                    .into_iter()
+                    .map(|(ty, optional)| FunctionParam { ty, optional })
+                    .collect(),
                 return_type: Box::new(return_type),
             };
         }
@@ -207,9 +217,10 @@ pub(super) fn parse_type_str(s: &str) -> TsType {
     }
 }
 
-/// Parse parameter types from a param string like "x: string, y: number".
+/// Parse parameter types from a param string like "x: string, y?: number".
+/// Returns (type, optional) pairs.
 #[cfg(test)]
-pub(super) fn parse_param_types(params_str: &str) -> Vec<TsType> {
+pub(super) fn parse_param_types(params_str: &str) -> Vec<(TsType, bool)> {
     if params_str.trim().is_empty() {
         return Vec::new();
     }
@@ -223,10 +234,12 @@ pub(super) fn parse_param_types(params_str: &str) -> Vec<TsType> {
             }
             // "name: Type" or "name?: Type" or "...name: Type"
             if let Some(colon) = part.find(':') {
-                Some(parse_type_str(part[colon + 1..].trim()))
+                let before_colon = part[..colon].trim();
+                let optional = before_colon.ends_with('?');
+                Some((parse_type_str(part[colon + 1..].trim()), optional))
             } else {
                 // Bare type (rare in .d.ts but handle it)
-                Some(parse_type_str(part))
+                Some((parse_type_str(part), false))
             }
         })
         .collect()

--- a/src/interop/wrapper.rs
+++ b/src/interop/wrapper.rs
@@ -76,7 +76,17 @@ pub fn wrap_boundary_type(ts_type: &TsType) -> Type {
             params,
             return_type,
         } => {
-            let wrapped_params: Vec<Type> = params.iter().map(wrap_boundary_type).collect();
+            let wrapped_params: Vec<Type> = params
+                .iter()
+                .map(|p| {
+                    let ty = wrap_boundary_type(&p.ty);
+                    if p.optional {
+                        Type::Option(Box::new(ty))
+                    } else {
+                        ty
+                    }
+                })
+                .collect();
             let wrapped_return = wrap_boundary_type(return_type);
             Type::Function {
                 params: wrapped_params,

--- a/src/lsp/resolution.rs
+++ b/src/lsp/resolution.rs
@@ -168,7 +168,8 @@ pub(super) fn enrich_from_imports(
                 } = &dts_export.ts_type
                 {
                     sym.kind = tower_lsp::lsp_types::SymbolKind::FUNCTION;
-                    sym.first_param_type = params.first().map(interop::ts_type_to_string);
+                    sym.first_param_type =
+                        params.first().map(|p| interop::ts_type_to_string(&p.ty));
                     sym.return_type_str = Some(interop::ts_type_to_string(return_type));
                 }
             }


### PR DESCRIPTION
closes #779

## Summary
- Added `FunctionParam` struct (paralleling `ObjectField`) to track parameter optionality in `TsType::Function`
- Updated oxc parsing (`convert_function` and `TSFunctionType` macro) to read the `optional` flag from formal parameters
- Optional params are now wrapped as `Option<T>` at the import boundary, and `fn_required_params` is populated so the checker allows omitting them
- Extracted shared `convert_formal_params()` helper to deduplicate param conversion logic

## Test plan
- [x] New test: `imported_optional_params_allow_omission` — verifies `useQueryClient()` with 0 args is accepted when param is optional
- [x] New test: `imported_optional_params_still_validates_max_args` — verifies too many args still errors
- [x] New test: `wrap_function_optional_params_become_option` — verifies wrapper converts optional params to `Option<T>`
- [x] All 1163 existing tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `RUSTFLAGS="-D warnings" cargo test` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)