### PR TITLE
fix: [#781] Imported TS union types resolve to unknown instead of strict union

### DIFF
--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -3069,6 +3069,160 @@ const _x = doStuff("hi", 1, true)
     );
 }
 
+// ── Bug #781: Imported TS union types should be strict ──
+
+#[test]
+fn ts_union_accepts_compatible_member() {
+    use crate::interop::{DtsExport, FunctionParam, TsType};
+    use std::collections::HashMap;
+
+    // format(date: Date | number | string, fmt: string): string
+    let program = crate::parser::Parser::new(
+        r#"
+import trusted { format } from "date-fns"
+const _x = format("2024-01-01", "PPpp")
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+
+    let export = DtsExport {
+        name: "format".to_string(),
+        ts_type: TsType::Function {
+            params: vec![
+                FunctionParam {
+                    ty: TsType::Union(vec![
+                        TsType::Named("Date".to_string()),
+                        TsType::Primitive("number".to_string()),
+                        TsType::Primitive("string".to_string()),
+                    ]),
+                    optional: false,
+                },
+                FunctionParam {
+                    ty: TsType::Primitive("string".to_string()),
+                    optional: false,
+                },
+            ],
+            return_type: Box::new(TsType::Primitive("string".to_string())),
+        },
+    };
+    let mut dts_imports = HashMap::new();
+    dts_imports.insert("date-fns".to_string(), vec![export]);
+
+    let checker = Checker::with_all_imports(HashMap::new(), dts_imports);
+    let (diags, _, _) = checker.check_with_types(&program);
+
+    assert!(
+        !has_error_containing(&diags, "expected"),
+        "passing string to Date | number | string should be accepted, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn ts_union_rejects_incompatible_type() {
+    use crate::interop::{DtsExport, FunctionParam, TsType};
+    use std::collections::HashMap;
+
+    // doStuff(x: number | string): void
+    let program = crate::parser::Parser::new(
+        r#"
+import trusted { doStuff } from "some-lib"
+const _x = doStuff(true)
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+
+    let export = DtsExport {
+        name: "doStuff".to_string(),
+        ts_type: TsType::Function {
+            params: vec![FunctionParam {
+                ty: TsType::Union(vec![
+                    TsType::Primitive("number".to_string()),
+                    TsType::Primitive("string".to_string()),
+                ]),
+                optional: false,
+            }],
+            return_type: Box::new(TsType::Primitive("void".to_string())),
+        },
+    };
+    let mut dts_imports = HashMap::new();
+    dts_imports.insert("some-lib".to_string(), vec![export]);
+
+    let checker = Checker::with_all_imports(HashMap::new(), dts_imports);
+    let (diags, _, _) = checker.check_with_types(&program);
+
+    assert!(
+        has_error_containing(&diags, "expected"),
+        "passing boolean to number | string should error, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn ts_union_compatible_with_itself() {
+    use crate::interop::{DtsExport, FunctionParam, TsType};
+    use std::collections::HashMap;
+
+    // identity(x: number | string): number | string
+    // calling with return value of same type should work
+    let program = crate::parser::Parser::new(
+        r#"
+import trusted { identity, consume } from "some-lib"
+const x = identity()
+const _y = consume(x)
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+
+    let union_params = || {
+        vec![FunctionParam {
+            ty: TsType::Union(vec![
+                TsType::Primitive("number".to_string()),
+                TsType::Primitive("string".to_string()),
+            ]),
+            optional: false,
+        }]
+    };
+    let union_ret = || {
+        Box::new(TsType::Union(vec![
+            TsType::Primitive("number".to_string()),
+            TsType::Primitive("string".to_string()),
+        ]))
+    };
+
+    let identity_export = DtsExport {
+        name: "identity".to_string(),
+        ts_type: TsType::Function {
+            params: vec![],
+            return_type: union_ret(),
+        },
+    };
+    let consume_export = DtsExport {
+        name: "consume".to_string(),
+        ts_type: TsType::Function {
+            params: union_params(),
+            return_type: Box::new(TsType::Primitive("void".to_string())),
+        },
+    };
+    let mut dts_imports = HashMap::new();
+    dts_imports.insert(
+        "some-lib".to_string(),
+        vec![identity_export, consume_export],
+    );
+
+    let checker = Checker::with_all_imports(HashMap::new(), dts_imports);
+    let (diags, _, _) = checker.check_with_types(&program);
+
+    assert!(
+        !has_error_containing(&diags, "expected"),
+        "TsUnion should be compatible with itself, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
 // ── Bug #334: Object literal keys should not be resolved as variables ──
 
 #[test]

--- a/src/checker/type_compat.rs
+++ b/src/checker/type_compat.rs
@@ -229,6 +229,16 @@ impl Checker {
                         .all(|(x, y)| self.types_compatible(x, y))
                     && self.types_compatible(r1, r2)
             }
+            // TsUnion vs TsUnion: every actual member must match at least one expected member
+            (Type::TsUnion(exp_members), Type::TsUnion(act_members)) => act_members
+                .iter()
+                .all(|a| exp_members.iter().any(|e| self.types_compatible(e, a))),
+            // TsUnion as expected: actual must match at least one member
+            (Type::TsUnion(members), _) => members.iter().any(|m| self.types_compatible(m, actual)),
+            // TsUnion as actual: every member must be compatible with expected
+            (_, Type::TsUnion(members)) => {
+                members.iter().all(|m| self.types_compatible(expected, m))
+            }
             // Structural record compatibility: { a: T, b: U } matches { a: T, b: U }
             (Type::Record(fields_a), Type::Record(fields_b)) => {
                 fields_a.len() == fields_b.len()

--- a/src/checker/types.rs
+++ b/src/checker/types.rs
@@ -70,6 +70,9 @@ pub enum Type {
         name: String,
         variants: Vec<String>,
     },
+    /// Untagged union from TypeScript interop: `Date | number | string`
+    /// Compatible if the value matches any member type.
+    TsUnion(Vec<Type>),
     /// Type variable (for inference)
     Var(usize),
     /// The unknown/any escape hatch
@@ -148,6 +151,10 @@ impl Type {
             }
             Type::Union { name, .. } => name.clone(),
             Type::StringLiteralUnion { name, .. } => name.clone(),
+            Type::TsUnion(members) => {
+                let m: Vec<_> = members.iter().map(|t| t.display_name()).collect();
+                m.join(" | ")
+            }
             Type::Var(id) => format!("?T{id}"),
             Type::Unknown => "unknown".to_string(),
             Type::Unit => "()".to_string(),

--- a/src/interop/tests.rs
+++ b/src/interop/tests.rs
@@ -180,14 +180,14 @@ fn wrap_null_undefined_union_becomes_option() {
 }
 
 #[test]
-fn wrap_plain_union_stays_non_option() {
-    // string | number -> Unknown (multi-type union without null)
+fn wrap_plain_union_becomes_ts_union() {
+    // string | number -> TsUnion([String, Number])
     let ts = TsType::Union(vec![
         TsType::Primitive("string".to_string()),
         TsType::Primitive("number".to_string()),
     ]);
     let wrapped = wrap_boundary_type(&ts);
-    assert_eq!(wrapped, Type::Unknown);
+    assert_eq!(wrapped, Type::TsUnion(vec![Type::String, Type::Number]));
 }
 
 #[test]

--- a/src/interop/wrapper.rs
+++ b/src/interop/wrapper.rs
@@ -153,9 +153,13 @@ fn wrap_union_boundary(parts: &[TsType]) -> Type {
         // All union members are objects — merge common fields for destructuring
         merged
     } else {
-        // Multi-type union without null/undefined: stay as Unknown for now
-        // A full implementation would create proper union types
-        Type::Unknown
+        // Multi-type union: preserve as TsUnion for strict type checking
+        Type::TsUnion(
+            non_null_parts
+                .iter()
+                .map(|p| wrap_boundary_type(p))
+                .collect(),
+        )
     };
 
     if nullable {

--- a/src/lsp/stdlib_hover.rs
+++ b/src/lsp/stdlib_hover.rs
@@ -61,6 +61,10 @@ pub(super) fn format_type(ty: &crate::checker::Type) -> String {
         Type::Opaque { name, .. } => name.clone(),
         Type::Union { name, .. } => name.clone(),
         Type::StringLiteralUnion { name, .. } => name.clone(),
+        Type::TsUnion(members) => {
+            let m: Vec<_> = members.iter().map(format_type).collect();
+            m.join(" | ")
+        }
         Type::Never => "never".to_string(),
     }
 }


### PR DESCRIPTION
closes #781

Depends on #783 (optional params — merge that first)

## Summary
- Added `Type::TsUnion(Vec<Type>)` variant for imported TypeScript union types (e.g. `Date | number | string`)
- Checker validates arguments against union members: accepted if compatible with at least one member, rejected otherwise
- Handles TsUnion-vs-TsUnion correctly (every actual member must match at least one expected member)
- Previously these unions silently became `Type::Unknown`, losing all type safety

Also includes #779 changes (optional params) since it builds on that branch.

## Test plan
- [x] `ts_union_accepts_compatible_member` — passing `string` to `Date | number | string` is accepted
- [x] `ts_union_rejects_incompatible_type` — passing `boolean` to `number | string` is rejected
- [x] `ts_union_compatible_with_itself` — return value of `number | string` can be passed where `number | string` is expected
- [x] `wrap_plain_union_becomes_ts_union` — wrapper produces `TsUnion` instead of `Unknown`
- [x] All 1166 tests pass
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)