### PR TITLE
chore: [#773] Update syntax highlighting and snippets for positional variants

### DIFF
--- a/editors/neovim/queries/floe/highlights.scm
+++ b/editors/neovim/queries/floe/highlights.scm
@@ -24,11 +24,7 @@
 (self) @variable.builtin
 
 ; ── Built-in constructors ────────────────────────────────
-"Ok" @constructor
-"Err" @constructor
-"Some" @constructor
 "Value" @constructor
-(none) @constant.builtin
 (clear) @constant.builtin
 (unchanged) @constant.builtin
 (todo) @keyword

--- a/editors/tree-sitter-floe/grammar.js
+++ b/editors/tree-sitter-floe/grammar.js
@@ -175,7 +175,11 @@ module.exports = grammar({
       seq("deriving", "(", commaSep1($.type_identifier), ")"),
 
     _type_definition: ($) =>
-      choice($.union_type_definition, $.record_type, $._type_expression),
+      choice($.union_type_definition, $.newtype_definition, $.record_type, $._type_expression),
+
+    // Newtype with paren syntax: type UserId(string)
+    newtype_definition: ($) =>
+      seq("(", commaSep1($._type_expression), ")"),
 
     union_type_definition: ($) =>
       prec.right(seq("|", $.variant, repeat(seq("|", $.variant)))),
@@ -183,7 +187,10 @@ module.exports = grammar({
     variant: ($) =>
       prec.right(1, seq(
         field("name", $.type_identifier),
-        optional(seq("{", commaSep1($.variant_field), "}")),
+        optional(choice(
+          seq("{", commaSep1($.variant_field), "}"),
+          seq("(", commaSep1($._type_expression), ")"),
+        )),
       )),
 
     variant_field: ($) =>
@@ -305,7 +312,6 @@ module.exports = grammar({
         $.array_literal,
         $.parenthesized_expression,
         $.unit_value,
-        $.none,
         $.clear,
         $.unchanged,
         $.todo,
@@ -352,7 +358,7 @@ module.exports = grammar({
 
     unit_value: ($) => prec(2, seq("(", ")")),
 
-    none: ($) => "None",
+    // None is now a regular identifier, not a keyword
 
     clear: ($) => "Clear",
 
@@ -537,10 +543,7 @@ module.exports = grammar({
           ".",
           field("variant", $.type_identifier),
         )),
-        // Built-in constructors
-        seq("Ok", "(", field("value", $._expression), ")"),
-        seq("Err", "(", field("value", $._expression), ")"),
-        seq("Some", "(", field("value", $._expression), ")"),
+        // Built-in constructor (Settable)
         seq("Value", "(", field("value", $._expression), ")"),
       ),
 

--- a/editors/tree-sitter-floe/queries/highlights.scm
+++ b/editors/tree-sitter-floe/queries/highlights.scm
@@ -24,11 +24,7 @@
 (self) @variable.builtin
 
 ; ── Built-in constructors ────────────────────────────────
-"Ok" @constructor
-"Err" @constructor
-"Some" @constructor
 "Value" @constructor
-(none) @constant.builtin
 (clear) @constant.builtin
 (unchanged) @constant.builtin
 (todo) @keyword

--- a/editors/vscode/snippets/floe.json
+++ b/editors/vscode/snippets/floe.json
@@ -110,14 +110,14 @@
   "Newtype": {
     "prefix": "newtype",
     "body": [
-      "type ${1:Name} { ${2:string} }"
+      "type ${1:Name}(${2:string})"
     ],
     "description": "Newtype wrapper"
   },
   "Opaque Type": {
     "prefix": "opaque",
     "body": [
-      "opaque type ${1:Name} = ${2:BaseType}"
+      "opaque type ${1:Name}(${2:string})"
     ],
     "description": "Opaque type"
   },

--- a/editors/vscode/syntaxes/floe.tmLanguage.json
+++ b/editors/vscode/syntaxes/floe.tmLanguage.json
@@ -100,7 +100,7 @@
         },
         {
           "name": "variable.language.floe",
-          "match": "\\b(Ok|Err|Some|None|Value|Clear|Unchanged|self)\\b"
+          "match": "\\b(Value|Clear|Unchanged|self)\\b"
         },
         {
           "name": "constant.language.boolean.floe",


### PR DESCRIPTION
closes #773

## Summary

- **Tree-sitter grammar**: Add positional variant field syntax `( )` alongside named `{ }`, add `newtype_definition` rule for `type Name(Type)`, remove `None` as a grammar rule, remove `Ok`/`Err`/`Some` from hardcoded `variant_expression`
- **Tree-sitter + Neovim highlights**: Remove `Ok`/`Err`/`Some`/`None` keyword highlights (they're regular identifiers now)
- **TextMate grammar**: Remove `Ok`/`Err`/`Some`/`None` from keyword pattern
- **VSCode snippets**: Update newtype and opaque type snippets to use paren syntax

## Test plan

- [x] All compiler tests pass (1173 + 30 + 18)
- [x] Grammar changes match the compiler's parser behavior
- [x] No tree-sitter CLI available to run `tree-sitter test` locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)