### PR TITLE
chore: [#785] Replace StringLiteralUnion with TsUnion + StringLiteral

### DIFF
--- a/src/checker/match_check.rs
+++ b/src/checker/match_check.rs
@@ -104,8 +104,8 @@ impl Checker {
         }
 
         // String literal unions: check all string variants covered
-        if let Type::StringLiteralUnion { name, variants } = subject_ty {
-            let variant_set: HashSet<&str> = variants.iter().map(|s| s.as_str()).collect();
+        if let Some(string_variants) = subject_ty.as_string_literal_variants() {
+            let variant_set: HashSet<&str> = string_variants.into_iter().collect();
             let mut covered: HashSet<&str> = HashSet::new();
             for arm in arms {
                 if arm.guard.is_none()
@@ -116,13 +116,14 @@ impl Checker {
             }
             let missing: Vec<_> = variant_set.difference(&covered).collect();
             if !missing.is_empty() {
+                let type_name = subject_ty.display_name();
                 let missing_str = missing
                     .iter()
                     .map(|s| format!("`\"{s}\"`"))
                     .collect::<Vec<_>>()
                     .join(", ");
                 self.emit_error_with_help(
-                    format!("non-exhaustive match on `{name}`: missing {missing_str}"),
+                    format!("non-exhaustive match on `{type_name}`: missing {missing_str}"),
                     span,
                     "E004",
                     "not all variants covered",
@@ -350,12 +351,15 @@ impl Checker {
                     .map(|(name, _)| TupleSlotValue::Variant(name.clone()))
                     .collect(),
             ),
-            Type::StringLiteralUnion { variants, .. } => Some(
-                variants
-                    .iter()
-                    .map(|s| TupleSlotValue::StringLiteral(s.clone()))
-                    .collect(),
-            ),
+            _ if ty.as_string_literal_variants().is_some() => {
+                let variants = ty.as_string_literal_variants().unwrap();
+                Some(
+                    variants
+                        .into_iter()
+                        .map(|s| TupleSlotValue::StringLiteral(s.to_string()))
+                        .collect(),
+                )
+            }
             _ => None, // number, string, etc. are unbounded
         }
     }

--- a/src/checker/type_compat.rs
+++ b/src/checker/type_compat.rs
@@ -199,6 +199,8 @@ impl Checker {
             | (Type::Bool, Type::Bool)
             | (Type::Unit, Type::Unit)
             | (Type::Undefined, Type::Undefined) => true,
+            (Type::String, Type::StringLiteral(_)) => true,
+            (Type::StringLiteral(a), Type::StringLiteral(b)) => a == b,
             (Type::Named(a), Type::Named(b)) => a == b,
             (Type::Named(a), Type::Union { name: b, .. })
             | (Type::Union { name: a, .. }, Type::Named(b)) => a == b,

--- a/src/checker/type_registration.rs
+++ b/src/checker/type_registration.rs
@@ -132,10 +132,12 @@ impl Checker {
                 }
             }
             TypeDef::StringLiteralUnion(variants) => {
-                let ty = Type::StringLiteralUnion {
-                    name: decl.name.clone(),
-                    variants: variants.clone(),
-                };
+                let ty = Type::TsUnion(
+                    variants
+                        .iter()
+                        .map(|s| Type::StringLiteral(s.clone()))
+                        .collect(),
+                );
                 self.env.define(&decl.name, ty);
             }
             TypeDef::Alias(type_expr) => {

--- a/src/checker/types.rs
+++ b/src/checker/types.rs
@@ -62,14 +62,11 @@ pub enum Type {
         name: String,
         variants: Vec<(String, Vec<Type>)>,
     },
-    /// String literal union: `"GET" | "POST" | "PUT" | "DELETE"`
-    StringLiteralUnion {
-        name: String,
-        variants: Vec<String>,
-    },
-    /// Untagged union from TypeScript interop: `Date | number | string`
+    /// Untagged union: `Date | number | string` or `"GET" | "POST"`
     /// Compatible if the value matches any member type.
     TsUnion(Vec<Type>),
+    /// String literal type: `"GET"`, `"POST"`, etc.
+    StringLiteral(String),
     /// Type variable (for inference)
     Var(usize),
     /// The unknown/any escape hatch
@@ -190,8 +187,33 @@ impl Type {
     pub(crate) fn is_primitive(&self) -> bool {
         matches!(
             self,
-            Type::Number | Type::String | Type::Bool | Type::Unit | Type::Undefined
+            Type::Number
+                | Type::String
+                | Type::Bool
+                | Type::Unit
+                | Type::Undefined
+                | Type::StringLiteral(_)
         )
+    }
+
+    /// If this is a TsUnion of all StringLiterals, return the string values.
+    pub(crate) fn as_string_literal_variants(&self) -> Option<Vec<&str>> {
+        if let Type::TsUnion(members) = self {
+            let strings: Vec<&str> = members
+                .iter()
+                .filter_map(|m| {
+                    if let Type::StringLiteral(s) = m {
+                        Some(s.as_str())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            if strings.len() == members.len() && !strings.is_empty() {
+                return Some(strings);
+            }
+        }
+        None
     }
 
     pub(crate) fn display_name(&self) -> String {
@@ -246,11 +268,11 @@ impl Type {
                 }
                 name.clone()
             }
-            Type::StringLiteralUnion { name, .. } => name.clone(),
             Type::TsUnion(members) => {
                 let m: Vec<_> = members.iter().map(|t| t.display_name()).collect();
                 m.join(" | ")
             }
+            Type::StringLiteral(s) => format!("\"{s}\""),
             Type::Var(id) => format!("?T{id}"),
             Type::Unknown => "unknown".to_string(),
             Type::Unit => "()".to_string(),
@@ -395,10 +417,12 @@ impl TypeEnv {
                     variants: var_types,
                 }
             }
-            crate::parser::ast::TypeDef::StringLiteralUnion(variants) => Type::StringLiteralUnion {
-                name: name.to_string(),
-                variants: variants.clone(),
-            },
+            crate::parser::ast::TypeDef::StringLiteralUnion(variants) => Type::TsUnion(
+                variants
+                    .iter()
+                    .map(|s| Type::StringLiteral(s.clone()))
+                    .collect(),
+            ),
             crate::parser::ast::TypeDef::Alias(type_expr) => {
                 // For typeof aliases, use the pre-resolved env binding
                 // (simple_resolve_type_expr can't resolve typeof without env context)

--- a/src/lsp/stdlib_hover.rs
+++ b/src/lsp/stdlib_hover.rs
@@ -74,11 +74,11 @@ pub(super) fn format_type(ty: &crate::checker::Type) -> String {
         }
         Type::Opaque { name, .. } => name.clone(),
         Type::Union { name, .. } => name.clone(),
-        Type::StringLiteralUnion { name, .. } => name.clone(),
         Type::TsUnion(members) => {
             let m: Vec<_> = members.iter().map(format_type).collect();
             m.join(" | ")
         }
+        Type::StringLiteral(s) => format!("\"{s}\""),
         Type::Never => "never".to_string(),
     }
 }


### PR DESCRIPTION
closes #785

## Summary
- Removed `Type::StringLiteralUnion { name, variants }` — one less special-case type variant
- Added `Type::StringLiteral(String)` for individual string literal types (e.g. `"GET"`)
- String literal unions now use `TsUnion([StringLiteral("GET"), StringLiteral("POST")])` like all other unions
- `StringLiteral` is compatible with `String` (widening) and included in `is_primitive()`
- Match exhaustiveness checking updated to extract `StringLiteral` members from `TsUnion`

## Test plan
- [x] All 1175 tests pass (including string literal union exhaustiveness tests)
- [x] `floe check examples/todo-app/src/` — 0 errors
- [x] `floe check examples/store/src/` — 0 errors
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)