### PR TITLE
fix: [#802] Resolve TS interface/type fields from .ts imports

### DIFF
--- a/src/interop/tsgo.rs
+++ b/src/interop/tsgo.rs
@@ -119,6 +119,38 @@ impl TsgoResolver {
             let mut result = build_specifier_map(program, &exports, &ts_imports);
             resolve_typeof_types(&mut result, &self.project_dir, program);
 
+            // Parse .ts files directly to resolve type/interface definitions
+            // that the probe doesn't fully resolve (e.g. `interface IssueDto { ... }`)
+            for (specifier, ts_path) in &ts_imports {
+                let ts_content = match std::fs::read_to_string(ts_path) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("[floe] tsgo: failed to read {}: {e}", ts_path.display());
+                        continue;
+                    }
+                };
+                let ts_exports = match parse_dts_exports_from_str(&ts_content) {
+                    Ok(exports) => exports,
+                    Err(e) => {
+                        eprintln!("[floe] tsgo: failed to parse {}: {e}", ts_path.display());
+                        continue;
+                    }
+                };
+                let entry = result.entry(specifier.clone()).or_default();
+                for ts_export in ts_exports {
+                    // Replace probe exports that resolved to Any with the richer .ts definition
+                    if let Some(existing) = entry.iter_mut().find(|e| e.name == ts_export.name) {
+                        if matches!(existing.ts_type, TsType::Any)
+                            && !matches!(ts_export.ts_type, TsType::Any | TsType::Unknown)
+                        {
+                            existing.ts_type = ts_export.ts_type;
+                        }
+                    } else {
+                        entry.push(ts_export);
+                    }
+                }
+            }
+
             result
         }
     }


### PR DESCRIPTION
closes #802
closes #806

## Summary
- **#802:** When importing from `.ts` files, the tsgo probe resolves function signatures but leaves type/interface definitions as `Any`. Now also parses `.ts` files directly with oxc to extract interface and type definitions, replacing `Any` placeholders with the actual structure. Fixes `expected 'string', found 'IssueDto.key'`.
- **#806:** Object literal expressions now infer as `Type::Record` with actual field types instead of always returning `Type::Unknown`. Fixes `found unknown` when passing object literals with Settable variants.

## Test plan
- [x] Tested on real project (jira-2pac) — `IssueDto.key` resolves to `string`, object literals show correct types
- [x] `floe check examples/todo-app/src/` — 0 errors
- [x] `floe check examples/store/src/` — 0 errors
- [x] All 1181 tests pass
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)