### PR TITLE
fix: [#806] Object literals with variant values inferred as unknown

### DIFF
--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -183,10 +183,11 @@ impl Checker {
             }
             ExprKind::Spread(inner) => self.check_expr(inner),
             ExprKind::Object(fields) => {
-                for (_key, value) in fields {
-                    self.check_expr(value);
-                }
-                Type::Unknown
+                let field_types: Vec<(String, Type)> = fields
+                    .iter()
+                    .map(|(key, value)| (key.clone(), self.check_expr(value)))
+                    .collect();
+                Type::Record(field_types)
             }
             ExprKind::DotShorthand { predicate, .. } => {
                 if let Some((_op, rhs)) = predicate {


### PR DESCRIPTION
closes #806

## Summary
- Object literal expressions (`{ key: value, ... }`) now infer as `Type::Record` with actual field types instead of always returning `Type::Unknown`
- Fixes `found unknown` when passing object literals with Settable variants or any other typed values

## Test plan
- [x] All 1183 tests pass
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)