### PR TITLE
fix: [#804] Suggest try await instead of await try when Result wraps Promise

### DIFF
--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -101,9 +101,19 @@ impl Checker {
                     );
                 }
                 let ty = self.check_expr(inner);
-                match ty {
-                    Type::Promise(inner) => *inner,
-                    other => other,
+                match &ty {
+                    Type::Promise(inner) => *inner.clone(),
+                    _ if ty.is_result() && matches!(ty.result_ok(), Some(Type::Promise(_))) => {
+                        self.emit_error_with_help(
+                            "`await try` wraps the Promise in a Result before awaiting",
+                            expr.span,
+                            "E034",
+                            "wrong order",
+                            "use `try await` instead — await the Promise first, then wrap in Result",
+                        );
+                        ty
+                    }
+                    _ => ty,
                 }
             }
             ExprKind::Try(inner) => {

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -4845,3 +4845,43 @@ const _r = find(users, .name == "a")
     );
     assert!(diags.is_empty(), "expected no errors, got: {diags:?}");
 }
+
+// ── Bug #804: Suggest try await instead of await try ────────
+
+#[test]
+fn await_try_suggests_try_await() {
+    let diags = check(
+        r#"
+async fn fetchData() -> Promise<string> {
+    "hello"
+}
+async fn handler() {
+    const _result = await try fetchData()
+}
+"#,
+    );
+    assert!(
+        has_error_containing(&diags, "await try"),
+        "should warn about await try order, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn try_await_no_error() {
+    let diags = check(
+        r#"
+async fn fetchData() -> Promise<string> {
+    "hello"
+}
+async fn handler() {
+    const _result = try await fetchData()
+}
+"#,
+    );
+    assert!(
+        !has_error_containing(&diags, "await try"),
+        "try await should not produce the hint, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
closes #804

## Summary
- When the checker detects `await try expr` producing `Result<Promise<T>, E>`, it emits a new E034 diagnostic suggesting to flip to `try await`
- The hint explains: await the Promise first, then wrap in Result for error handling

## Test plan
- [x] `await_try_suggests_try_await` — `await try fetchData()` triggers E034
- [x] `try_await_no_error` — `try await fetchData()` does not trigger the hint
- [x] All 1185 tests pass
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)