### PR TITLE
feat: [#805] Settable and Option fields default when omitted from object literals

### DIFF
--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -4885,3 +4885,38 @@ async fn handler() {
         diags.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+// ── Bug #805: Settable/Option fields default when omitted ───
+
+#[test]
+fn option_fields_can_be_omitted() {
+    // Option fields in a record should allow omission (default to None)
+    let diags = check(
+        r#"
+type Config { name: string, nickname: Option<string> }
+fn _take(c: Config) { c }
+const _x = _take({ name: "Alice" })
+"#,
+    );
+    assert!(
+        !has_error_containing(&diags, "expected"),
+        "omitting Option fields should be allowed, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn required_fields_cannot_be_omitted() {
+    let diags = check(
+        r#"
+type Config { name: string, email: string }
+fn _take(c: Config) { c }
+const _x = _take({ name: "Alice" })
+"#,
+    );
+    assert!(
+        has_error_containing(&diags, "expected"),
+        "omitting required fields should error, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}

--- a/src/checker/type_compat.rs
+++ b/src/checker/type_compat.rs
@@ -94,6 +94,24 @@ impl Checker {
         }
     }
 
+    /// Check if an actual record is compatible with an expected record.
+    /// Fields with Settable or Option types can be omitted (default to Unchanged/None).
+    fn records_compatible(&self, expected: &[(String, Type)], actual: &[(String, Type)]) -> bool {
+        // Every expected field must either match an actual field or be omittable
+        expected.iter().all(|(name, ty)| {
+            if let Some((_, act_ty)) = actual.iter().find(|(n, _)| n == name) {
+                self.types_compatible(ty, act_ty)
+            } else {
+                // Field omitted — OK if it's Settable or Option
+                ty.is_settable() || ty.is_option()
+            }
+        })
+        // No extra fields in actual that aren't in expected
+        && actual.iter().all(|(name, _)| {
+            expected.iter().any(|(n, _)| n == name)
+        })
+    }
+
     pub(crate) fn types_compatible(&self, expected: &Type, actual: &Type) -> bool {
         // Unknown/Var as EXPECTED: anything can be assigned to unknown (widening)
         if matches!(expected, Type::Unknown | Type::Var(_)) {
@@ -176,22 +194,12 @@ impl Checker {
         if let Some(Type::Record(ref exp_fields)) = expected_concrete
             && let Type::Record(act_fields) = actual
         {
-            return exp_fields.len() == act_fields.len()
-                && exp_fields.iter().all(|(name, ty)| {
-                    act_fields
-                        .iter()
-                        .any(|(n, t)| n == name && self.types_compatible(ty, t))
-                });
+            return self.records_compatible(exp_fields, act_fields);
         }
         if let Some(Type::Record(ref act_fields)) = actual_concrete
             && let Type::Record(exp_fields) = expected
         {
-            return exp_fields.len() == act_fields.len()
-                && exp_fields.iter().all(|(name, ty)| {
-                    act_fields
-                        .iter()
-                        .any(|(n, t)| n == name && self.types_compatible(ty, t))
-                });
+            return self.records_compatible(exp_fields, act_fields);
         }
 
         match (expected, actual) {
@@ -284,14 +292,9 @@ impl Checker {
             (_, Type::TsUnion(members)) => {
                 members.iter().all(|m| self.types_compatible(expected, m))
             }
-            // Structural record compatibility: { a: T, b: U } matches { a: T, b: U }
+            // Structural record compatibility
             (Type::Record(fields_a), Type::Record(fields_b)) => {
-                fields_a.len() == fields_b.len()
-                    && fields_a.iter().all(|(name_a, ty_a)| {
-                        fields_b.iter().any(|(name_b, ty_b)| {
-                            name_a == name_b && self.types_compatible(ty_a, ty_b)
-                        })
-                    })
+                self.records_compatible(fields_a, fields_b)
             }
             _ => false,
         }


### PR DESCRIPTION
closes #805

## Summary
- Record compatibility now allows omitting fields whose expected type is `Settable<T>` or `Option<T>`
- Omitted `Settable` fields default to `Unchanged`, omitted `Option` fields default to `None`
- Extracted `records_compatible` helper to deduplicate three identical record comparison blocks
- Extra fields in actual that aren't in expected still error

## Example
```floe
// Before — had to specify every field
updateIssueFields(key, { summary: Unchanged, description: Set(draft), labels: Unchanged, storyPoints: Unchanged })

// After — omit fields you don't want to change
updateIssueFields(key, { description: Set(draft) })
```

## Test plan
- [x] `option_fields_can_be_omitted` — omitting `Option<string>` field is accepted
- [x] `required_fields_cannot_be_omitted` — omitting required `string` field still errors
- [x] All 1187 tests pass
- [x] `cargo clippy -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)