### PR TITLE
chore: [#841] Centralize codegen runtime error templates

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -17,6 +17,23 @@ use crate::stdlib::StdlibRegistry;
 use crate::type_layout;
 use crate::type_layout::{ERROR_FIELD, OK_FIELD, TAG_FIELD, VALUE_FIELD};
 
+// ── Runtime codegen constants ───────────────────────────────────
+
+/// Runtime deep-equality helper function name.
+const DEEP_EQUAL_FN: &str = "__floeEq";
+
+/// `todo` expression — throws "not implemented" at runtime.
+const THROW_NOT_IMPLEMENTED: &str = "(() => { throw new Error(\"not implemented\"); })()";
+
+/// `unreachable` expression — throws "unreachable" at runtime.
+const THROW_UNREACHABLE: &str = "(() => { throw new Error(\"unreachable\"); })()";
+
+/// Fallback for non-exhaustive match — throws at runtime.
+const THROW_NON_EXHAUSTIVE: &str = "(() => { throw new Error(\"non-exhaustive match\"); })()";
+
+/// Mock placeholder for function types — throws when called.
+const THROW_MOCK_FUNCTION: &str = "(() => { throw new Error(\"mock function\"); })";
+
 /// Produce a mangled name for a for-block function: `TypeName__funcName`.
 /// Generic types are flattened: `Array<User>` → `Array_User`, `Map<string, number>` → `Map_string_number`.
 pub fn for_block_fn_name(type_expr: &TypeExpr, fn_name: &str) -> String {

--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -1,9 +1,5 @@
 use super::*;
 
-const DEEP_EQUAL_FN: &str = "__floeEq";
-const THROW_NOT_IMPLEMENTED: &str = "(() => { throw new Error(\"not implemented\"); })()";
-const THROW_UNREACHABLE: &str = "(() => { throw new Error(\"unreachable\"); })()";
-
 impl Codegen {
     // ── Expressions ──────────────────────────────────────────────
 

--- a/src/codegen/match_emit.rs
+++ b/src/codegen/match_emit.rs
@@ -4,9 +4,7 @@ use crate::parser::ast::*;
 
 use crate::type_layout;
 
-use super::Codegen;
-
-const THROW_NON_EXHAUSTIVE: &str = "(() => { throw new Error(\"non-exhaustive match\"); })()";
+use super::{Codegen, THROW_NON_EXHAUSTIVE};
 
 impl Codegen {
     // ── Match Lowering ───────────────────────────────────────────

--- a/src/codegen/parse_mock.rs
+++ b/src/codegen/parse_mock.rs
@@ -263,7 +263,7 @@ impl Codegen {
             TypeExprKind::Function { .. }
             | TypeExprKind::TypeOf(_)
             | TypeExprKind::Intersection(_) => {
-                self.push("(() => { throw new Error(\"mock function\"); })");
+                self.push(THROW_MOCK_FUNCTION);
             }
         }
     }


### PR DESCRIPTION
closes #841

## Summary
- Move scattered runtime error constants (`DEEP_EQUAL_FN`, `THROW_NOT_IMPLEMENTED`, `THROW_UNREACHABLE`, `THROW_NON_EXHAUSTIVE`) from `codegen/expr.rs` and `codegen/match_emit.rs` to `codegen.rs` module root
- Extract inline `THROW_MOCK_FUNCTION` string from `codegen/parse_mock.rs` into a named constant
- Pure refactor - identical TypeScript output

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (all 18 tests)
- [x] `floe check` and `floe build` pass on both example apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)