### PR TITLE
chore: [#840] Use type_layout constants instead of hardcoded field name strings

### DIFF
--- a/src/codegen/parse_mock.rs
+++ b/src/codegen/parse_mock.rs
@@ -346,7 +346,10 @@ impl Codegen {
                     } else {
                         self.push(&format!("{{ {TAG_FIELD}: \"{}\" as const", variant.name));
                         for field in &variant.fields {
-                            let fname = field.name.clone().unwrap_or_else(|| "value".to_string());
+                            let fname = field
+                                .name
+                                .clone()
+                                .unwrap_or_else(|| VALUE_FIELD.to_string());
                             self.push(&format!(", {fname}: "));
                             self.emit_mock_for_type(&field.type_ann, &[], counter, &fname);
                         }

--- a/src/interop/wrapper.rs
+++ b/src/interop/wrapper.rs
@@ -1,6 +1,7 @@
 //! Boundary type wrapping: converts TypeScript types to Floe types at the import boundary.
 
 use super::*;
+use crate::type_layout;
 
 /// Converts a TypeScript type to a Floe type, applying boundary wrapping:
 /// - `T | null` -> `Option<T>`
@@ -263,9 +264,9 @@ fn try_parse_result_union(parts: &[&TsType]) -> Option<Type> {
 
     for part in parts {
         if let TsType::Object(fields) = part {
-            let ok_field = fields.iter().find(|f| f.name == "ok");
-            let value_field = fields.iter().find(|f| f.name == "value");
-            let error_field = fields.iter().find(|f| f.name == "error");
+            let ok_field = fields.iter().find(|f| f.name == type_layout::OK_FIELD);
+            let value_field = fields.iter().find(|f| f.name == type_layout::VALUE_FIELD);
+            let error_field = fields.iter().find(|f| f.name == type_layout::ERROR_FIELD);
 
             if value_field.is_some() && ok_field.is_some() {
                 ok_type = value_field.map(|f| wrap_boundary_type(&f.ty));


### PR DESCRIPTION
closes #840

## Summary
- Replace hardcoded `"ok"`, `"value"`, `"error"` string literals with `type_layout::OK_FIELD`, `type_layout::VALUE_FIELD`, `type_layout::ERROR_FIELD` constants in:
  - `src/interop/wrapper.rs` - Result union detection comparing field names
  - `src/codegen/parse_mock.rs` - default field name for unnamed variant fields
- Skipped `src/checker.rs` lines 194/211 since those are Web API fields (`Response.ok`, `event.target.value`), not Floe type layout fields
- Pure mechanical refactor, no behavior changes

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] `floe check` and `floe build` pass on example apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)