### PR TITLE
chore: [#839] Consolidate type display formatting into a single module

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -10,7 +10,7 @@ mod type_registration;
 mod type_resolve;
 mod types;
 
-pub use types::Type;
+pub use types::{Type, TypeDisplay};
 
 use std::collections::{HashMap, HashSet};
 
@@ -577,7 +577,7 @@ impl Checker {
             for (name, ty) in scope {
                 self.name_types
                     .entry(name.clone())
-                    .or_insert_with(|| ty.display_name());
+                    .or_insert_with(|| ty.to_string());
             }
         }
 

--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -265,10 +265,7 @@ impl Checker {
             UnaryOp::Neg => {
                 if !ty.is_numeric() && !matches!(ty, Type::Unknown | Type::Var(_)) {
                     self.emit_error(
-                        format!(
-                            "cannot negate type `{}`, expected `number`",
-                            ty.display_name()
-                        ),
+                        format!("cannot negate type `{}`, expected `number`", ty),
                         span,
                         "E001",
                         "expected `number`",
@@ -325,7 +322,7 @@ impl Checker {
                 self.emit_error(
                     format!(
                         "`?` can only be used on `Result` or `Option`, found `{}`",
-                        ty.display_name()
+                        ty
                     ),
                     span,
                     "E005",
@@ -345,7 +342,7 @@ impl Checker {
             for exports in self.dts_imports.values() {
                 if let Some(export) = exports.iter().find(|e| e.name == member_key) {
                     let ty = crate::interop::wrap_boundary_type(&export.ts_type);
-                    self.name_types.insert(member_key, ty.display_name());
+                    self.name_types.insert(member_key, ty.to_string());
                     return ty;
                 }
             }
@@ -375,10 +372,7 @@ impl Checker {
                 // Index must be a number
                 if !matches!(idx_ty, Type::Number | Type::Unknown) {
                     self.emit_error(
-                        format!(
-                            "array index must be `number`, found `{}`",
-                            idx_ty.display_name()
-                        ),
+                        format!("array index must be `number`, found `{}`", idx_ty),
                         index.span,
                         "E017",
                         "expected `number`",
@@ -435,10 +429,7 @@ impl Checker {
                     return Type::Unknown;
                 }
                 self.emit_error(
-                    format!(
-                        "cannot use bracket access on type `{}`",
-                        obj_ty.display_name()
-                    ),
+                    format!("cannot use bracket access on type `{}`", obj_ty),
                     span,
                     "E017",
                     "not an array or tuple type",
@@ -477,7 +468,7 @@ impl Checker {
                 // Persist lambda param type for LSP hover (scope is
                 // popped after the arrow body is checked, so the param
                 // would be lost from the final name_types merge)
-                self.name_types.insert(p.name.clone(), ty.display_name());
+                self.name_types.insert(p.name.clone(), ty.to_string());
                 // For destructured params, also define the field names
                 if let Some(ref destructure) = p.destructure {
                     self.define_destructured_bindings(destructure, &ty, p.span);
@@ -519,12 +510,12 @@ impl Checker {
                     self.emit_error(
                         format!(
                             "match arms have incompatible types: first arm returns `{}`, this arm returns `{}`",
-                            first_type.display_name(),
-                            arm_type.display_name()
+                            first_type,
+                            arm_type
                         ),
                         arm.body.span,
                         "E001",
-                        format!("expected `{}`", first_type.display_name()),
+                        format!("expected `{}`", first_type),
                     );
                 }
                 result_type = Some(Self::merge_types(first_type, &arm_type));
@@ -836,12 +827,12 @@ impl Checker {
                                 format!(
                                     "argument {} to `{callee_name}`: expected `{}`, found `{}`",
                                     i + 1,
-                                    param_ty.display_name(),
-                                    arg_ty.display_name()
+                                    param_ty,
+                                    arg_ty
                                 ),
                                 span,
                                 "E001",
-                                format!("expected `{}`", param_ty.display_name()),
+                                format!("expected `{}`", param_ty),
                             );
                         }
                     }
@@ -911,12 +902,12 @@ impl Checker {
                                 format!(
                                     "argument {} to `{callee_name}`: expected `{}`, found `{}`",
                                     i + 1,
-                                    param_ty.display_name(),
-                                    arg_ty.display_name()
+                                    param_ty,
+                                    arg_ty
                                 ),
                                 span,
                                 "E001",
-                                format!("expected `{}`", param_ty.display_name()),
+                                format!("expected `{}`", param_ty),
                             );
                         }
                     }
@@ -962,10 +953,7 @@ impl Checker {
             && !matches!(concrete, Type::Unknown | Type::Var(_) | Type::Foreign(_))
         {
             self.emit_error_with_help(
-                format!(
-                    "expected boolean operand for `{op}`, found `{}`",
-                    ty.display_name()
-                ),
+                format!("expected boolean operand for `{op}`, found `{}`", ty),
                 span,
                 "E001",
                 "expected `boolean`",
@@ -988,11 +976,7 @@ impl Checker {
                     && !matches!(right_ty, Type::Unknown | Type::Var(_))
                 {
                     self.emit_error_with_help(
-                        format!(
-                            "cannot compare `{}` with `{}`",
-                            left_ty.display_name(),
-                            right_ty.display_name()
-                        ),
+                        format!("cannot compare `{}` with `{}`", left_ty, right_ty),
                         span,
                         "E008",
                         "mismatched types",
@@ -1274,12 +1258,11 @@ impl Checker {
                         self.emit_error(
                             format!(
                                 "field `{label}`: expected `{}`, found `{}`",
-                                expected_ty.display_name(),
-                                arg_ty.display_name()
+                                expected_ty, arg_ty
                             ),
                             span,
                             "E001",
-                            format!("expected `{}`", expected_ty.display_name()),
+                            format!("expected `{}`", expected_ty),
                         );
                     }
                 }
@@ -1294,12 +1277,12 @@ impl Checker {
                             format!(
                                 "argument {}: expected `{}`, found `{}`",
                                 positional_index + 1,
-                                expected_ty.display_name(),
-                                arg_ty.display_name()
+                                expected_ty,
+                                arg_ty
                             ),
                             span,
                             "E001",
-                            format!("expected `{}`", expected_ty.display_name()),
+                            format!("expected `{}`", expected_ty),
                         );
                     }
                     positional_index += 1;
@@ -1508,12 +1491,11 @@ impl Checker {
                         self.emit_error(
                             format!(
                                 "argument 1 to `{name}`: expected `{}`, found `{}`",
-                                first_param.display_name(),
-                                left_ty.display_name()
+                                first_param, left_ty
                             ),
                             right.span,
                             "E001",
-                            format!("expected `{}`", first_param.display_name()),
+                            format!("expected `{}`", first_param),
                         );
                     }
                     return *return_type;
@@ -1525,7 +1507,7 @@ impl Checker {
                     self.emit_error(
                         format!(
                             "cannot pipe into `{name}`: expected a function, found `{}`",
-                            right_ty.display_name()
+                            right_ty
                         ),
                         right.span,
                         "E001",
@@ -1553,12 +1535,11 @@ impl Checker {
             self.emit_error(
                 format!(
                     "argument 1 to `{display_name}`: expected `{}`, found `{}`",
-                    first_param.display_name(),
-                    left_ty.display_name()
+                    first_param, left_ty
                 ),
                 right.span,
                 "E001",
-                format!("expected `{}`", first_param.display_name()),
+                format!("expected `{}`", first_param),
             );
         }
         if let Type::Array(elem) = left_ty {
@@ -1840,7 +1821,7 @@ impl Checker {
         }
         let dispatch_name = match dispatch_ty {
             Type::Named(n) | Type::Foreign(n) => n.as_str(),
-            _ => &dispatch_ty.display_name(),
+            _ => &dispatch_ty.to_string(),
         };
         let (_, fn_type) = overloads
             .iter()
@@ -1904,7 +1885,7 @@ impl Checker {
             self.emit_error(
                 format!(
                     "cannot access `.{field}` on `{}` — use `await` first",
-                    obj_ty.display_name()
+                    obj_ty
                 ),
                 span,
                 "E021",
@@ -1940,7 +1921,7 @@ impl Checker {
             let type_name = if let Type::Named(name) = obj_ty {
                 format!("`{name}`")
             } else {
-                format!("`{}`", obj_ty.display_name())
+                format!("`{}`", obj_ty)
             };
             self.emit_error_with_help(
                 format!("type {type_name} has no field `{field}`"),
@@ -1983,10 +1964,7 @@ impl Checker {
         match obj_ty {
             Type::Number | Type::String | Type::Bool | Type::Unit => {
                 self.emit_error(
-                    format!(
-                        "cannot access `.{field}` on type `{}`",
-                        obj_ty.display_name()
-                    ),
+                    format!("cannot access `.{field}` on type `{}`", obj_ty),
                     span,
                     "E017",
                     "not a record type",
@@ -2038,10 +2016,7 @@ impl Checker {
 
         // Fallback: type doesn't support member access
         self.emit_error(
-            format!(
-                "cannot access `.{field}` on type `{}`",
-                obj_ty.display_name()
-            ),
+            format!("cannot access `.{field}` on type `{}`", obj_ty),
             span,
             "E017",
             "this type does not support member access",
@@ -2077,14 +2052,10 @@ impl Checker {
                             .map(|(_, t)| t.clone())
                             .unwrap_or_else(|| {
                                 self.emit_error(
-                                    format!(
-                                        "field `{}` does not exist on type `{}`",
-                                        f.field,
-                                        ty.display_name()
-                                    ),
+                                    format!("field `{}` does not exist on type `{}`", f.field, ty),
                                     span,
                                     "E001",
-                                    format!("`{}` has no field `{}`", ty.display_name(), f.field),
+                                    format!("`{}` has no field `{}`", ty, f.field),
                                 );
                                 Type::Unknown
                             });
@@ -2100,10 +2071,7 @@ impl Checker {
                     }
                 } else {
                     self.emit_error(
-                        format!(
-                            "cannot destructure parameter of type `{}`",
-                            ty.display_name()
-                        ),
+                        format!("cannot destructure parameter of type `{}`", ty),
                         span,
                         "E001",
                         "destructuring requires a record type".to_string(),
@@ -2125,10 +2093,7 @@ impl Checker {
                     }
                 } else {
                     self.emit_error(
-                        format!(
-                            "cannot array-destructure parameter of type `{}`",
-                            ty.display_name()
-                        ),
+                        format!("cannot array-destructure parameter of type `{}`", ty),
                         span,
                         "E001",
                         "array destructuring requires an array type".to_string(),

--- a/src/checker/items.rs
+++ b/src/checker/items.rs
@@ -152,7 +152,7 @@ impl Checker {
                 self.emit_error_with_help(
                     format!(
                         "cannot narrow `unknown` to `{}` — use runtime validation instead",
-                        declared.display_name()
+                        declared
                     ),
                     span,
                     "E019",
@@ -161,14 +161,10 @@ impl Checker {
                 );
             } else if !self.types_compatible(declared, &value_type) {
                 self.emit_error(
-                    format!(
-                        "expected `{}`, found `{}`",
-                        declared.display_name(),
-                        value_type.display_name()
-                    ),
+                    format!("expected `{}`, found `{}`", declared, value_type),
                     span,
                     "E001",
-                    format!("expected `{}`", declared.display_name()),
+                    format!("expected `{}`", declared),
                 );
             }
             declared.clone()
@@ -204,7 +200,7 @@ impl Checker {
     /// Define a single const binding (handles no-redefinition check, name_types, env, etc.)
     fn define_const_binding(&mut self, name: &str, ty: Type, exported: bool, span: Span) {
         self.check_no_redefinition(name, span);
-        self.name_types.insert(name.to_string(), ty.display_name());
+        self.name_types.insert(name.to_string(), ty.to_string());
         self.env.define(name, ty);
         self.unused
             .defined_sources
@@ -355,13 +351,11 @@ impl Checker {
                     self.emit_error(
                         format!(
                             "default value for `{}`: expected `{}`, found `{}`",
-                            param.name,
-                            ty.display_name(),
-                            default_ty.display_name()
+                            param.name, ty, default_ty
                         ),
                         param.span,
                         "E001",
-                        format!("expected `{}`", ty.display_name()),
+                        format!("expected `{}`", ty),
                     );
                 }
             }
@@ -379,7 +373,7 @@ impl Checker {
             };
             // Update in the name_types map for hover display
             self.name_types
-                .insert(decl.name.clone(), fn_type.display_name());
+                .insert(decl.name.clone(), fn_type.to_string());
             // Mark for updating in outer scope after pop
             self.env.define_in_parent_scope(&decl.name, fn_type);
         }
@@ -399,13 +393,11 @@ impl Checker {
                 self.emit_error(
                     format!(
                         "function `{}`: expected return type `{}`, found `{}`",
-                        decl.name,
-                        resolved.display_name(),
-                        body_type.display_name()
+                        decl.name, resolved, body_type
                     ),
                     span,
                     "E001",
-                    format!("expected `{}`", resolved.display_name()),
+                    format!("expected `{}`", resolved),
                 );
             }
 
@@ -417,8 +409,7 @@ impl Checker {
                 self.emit_error_with_help(
                     format!(
                         "function `{}` must return a value of type `{}`",
-                        decl.name,
-                        resolved.display_name()
+                        decl.name, resolved
                     ),
                     span,
                     "E013",
@@ -443,7 +434,7 @@ impl Checker {
         // If this is a trait impl block, validate the trait contract
         if let Some(ref trait_name) = block.trait_name {
             self.unused.used_names.insert(trait_name.clone());
-            let type_display = for_type.display_name();
+            let type_display = for_type.to_string();
             self.check_trait_impl(&type_display, trait_name, &block.functions, block.span);
         }
 
@@ -533,13 +524,11 @@ impl Checker {
                         self.emit_error(
                             format!(
                                 "default value for `{}`: expected `{}`, found `{}`",
-                                param.name,
-                                ty.display_name(),
-                                default_ty.display_name()
+                                param.name, ty, default_ty
                             ),
                             param.span,
                             "E001",
-                            format!("expected `{}`", ty.display_name()),
+                            format!("expected `{}`", ty),
                         );
                     }
                 }
@@ -555,13 +544,11 @@ impl Checker {
                     self.emit_error(
                         format!(
                             "function `{}`: expected return type `{}`, found `{}`",
-                            func.name,
-                            resolved.display_name(),
-                            body_type.display_name()
+                            func.name, resolved, body_type
                         ),
                         block.span,
                         "E001",
-                        format!("expected `{}`", resolved.display_name()),
+                        format!("expected `{}`", resolved),
                     );
                 }
             }
@@ -582,10 +569,7 @@ impl Checker {
                     // Ensure assert expression evaluates to boolean
                     if !matches!(ty, Type::Bool | Type::Unknown | Type::Var(_)) {
                         self.emit_error(
-                            format!(
-                                "assert expression must be boolean, found `{}`",
-                                ty.display_name()
-                            ),
+                            format!("assert expression must be boolean, found `{}`", ty),
                             *span,
                             "E017",
                             "expected boolean expression",

--- a/src/checker/match_check.rs
+++ b/src/checker/match_check.rs
@@ -116,7 +116,7 @@ impl Checker {
             }
             let missing: Vec<_> = variant_set.difference(&covered).collect();
             if !missing.is_empty() {
-                let type_name = subject_ty.display_name();
+                let type_name = subject_ty.to_string();
                 let missing_str = missing
                     .iter()
                     .map(|s| format!("`\"{s}\"`"))
@@ -438,10 +438,7 @@ impl Checker {
                 // String patterns require the subject to be a string type
                 if !matches!(subject_ty, Type::String | Type::Unknown) {
                     self.emit_error(
-                        format!(
-                            "string pattern used on non-string type `{}`",
-                            subject_ty.display_name()
-                        ),
+                        format!("string pattern used on non-string type `{}`", subject_ty),
                         pattern.span,
                         "E005",
                         "expected string type",
@@ -457,8 +454,7 @@ impl Checker {
             }
             PatternKind::Binding(name) => {
                 self.env.define(name, subject_ty.clone());
-                self.name_types
-                    .insert(name.clone(), subject_ty.display_name());
+                self.name_types.insert(name.clone(), subject_ty.to_string());
             }
             PatternKind::Tuple(patterns) => {
                 if let Type::Tuple(types) = subject_ty {
@@ -511,7 +507,7 @@ impl Checker {
                         Type::Array(Box::new(Type::Unknown))
                     };
                     self.env.define(name, rest_ty.clone());
-                    self.name_types.insert(name.clone(), rest_ty.display_name());
+                    self.name_types.insert(name.clone(), rest_ty.to_string());
                 }
             }
         }

--- a/src/checker/type_registration.rs
+++ b/src/checker/type_registration.rs
@@ -90,7 +90,7 @@ impl Checker {
                         let field_ty = self.resolve_type(&field.type_ann);
                         self.name_types.insert(
                             format!("__field_{}_{}", decl.name, field.name),
-                            field_ty.display_name(),
+                            field_ty.to_string(),
                         );
                     }
                 }
@@ -336,13 +336,11 @@ impl Checker {
                                 self.emit_error(
                                     format!(
                                         "default value for `{}`: expected `{}`, found `{}`",
-                                        field.name,
-                                        field_ty.display_name(),
-                                        default_ty.display_name()
+                                        field.name, field_ty, default_ty
                                     ),
                                     field.span,
                                     "E001",
-                                    format!("expected `{}`", field_ty.display_name()),
+                                    format!("expected `{}`", field_ty),
                                 );
                             }
                         } else if seen_default {

--- a/src/checker/types.rs
+++ b/src/checker/types.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 
 use crate::parser::ast::TypeDef;
 
@@ -218,82 +219,182 @@ impl Type {
         None
     }
 
-    pub(crate) fn display_name(&self) -> String {
-        match self {
-            Type::Number => "number".to_string(),
-            Type::String => "string".to_string(),
-            Type::Bool => "boolean".to_string(),
-            Type::Undefined => "undefined".to_string(),
-            Type::Named(n) | Type::Foreign(n) => n.clone(),
-            Type::Promise(inner) => format!("Promise<{}>", inner.display_name()),
-            Type::Opaque { name, .. } => name.clone(),
-            Type::Settable(inner) => format!("Settable<{}>", inner.display_name()),
-            Type::Function {
-                params,
-                required_params,
-                return_type,
-            } => {
-                let p: Vec<_> = params
-                    .iter()
-                    .enumerate()
-                    .map(|(i, t)| {
-                        if i >= *required_params && *required_params < params.len() {
-                            format!("{} = None", t.display_name())
-                        } else {
-                            t.display_name()
-                        }
-                    })
-                    .collect();
-                format!("({}) -> {}", p.join(", "), return_type.display_name())
-            }
-            Type::Array(inner) => format!("Array<{}>", inner.display_name()),
-            Type::Map { key, value } => {
-                format!("Map<{}, {}>", key.display_name(), value.display_name())
-            }
-            Type::RecordMap { key, value } => {
-                format!("Record<{}, {}>", key.display_name(), value.display_name())
-            }
-            Type::Set { element } => format!("Set<{}>", element.display_name()),
-            Type::Tuple(types) => {
-                let t: Vec<_> = types.iter().map(|t| t.display_name()).collect();
-                format!("({})", t.join(", "))
-            }
-            Type::Record(fields) => {
-                let f: Vec<_> = fields
-                    .iter()
-                    .map(|(n, t)| format!("{n}: {}", t.display_name()))
-                    .collect();
-                format!("{{ {} }}", f.join(", "))
-            }
-            Type::Union { name, .. } => {
-                if name == crate::type_layout::TYPE_OPTION
-                    && let Some(inner) = self.option_inner()
-                {
-                    return format!("Option<{}>", inner.display_name());
-                }
-                if name == crate::type_layout::TYPE_RESULT {
-                    let ok = self
-                        .result_ok()
-                        .map(|t| t.display_name())
-                        .unwrap_or_else(|| "unknown".to_string());
-                    let err = self
-                        .result_err()
-                        .map(|t| t.display_name())
-                        .unwrap_or_else(|| "unknown".to_string());
-                    return format!("Result<{ok}, {err}>");
-                }
-                name.clone()
-            }
-            Type::TsUnion(members) => {
-                let m: Vec<_> = members.iter().map(|t| t.display_name()).collect();
-                m.join(" | ")
-            }
-            Type::StringLiteral(s) => format!("\"{s}\""),
-            Type::Var(id) => format!("?T{id}"),
-            Type::Unknown => "unknown".to_string(),
-            Type::Unit => "()".to_string(),
-            Type::Never => "never".to_string(),
+    /// Return a display wrapper that formats type variables as readable letters
+    /// (T, U, V, ...) instead of internal IDs. Used for stdlib hover/completion display.
+    pub fn display_for_stdlib(&self) -> TypeDisplay<'_> {
+        TypeDisplay {
+            ty: self,
+            style: TypeDisplayStyle::Stdlib,
         }
+    }
+}
+
+// ── Type Display ────────────────────────────────────────────────
+
+/// Controls how types are formatted as strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TypeDisplayStyle {
+    /// Default style used in error messages and LSP hover.
+    /// Type vars shown as `?T0`, tuples as `(a, b)`, optional params shown with `= None`.
+    Default,
+    /// Stdlib style used in stdlib hover/completion display.
+    /// Type vars shown as letter names (`T`, `U`, `V`), tuples as `[a, b]`.
+    Stdlib,
+}
+
+/// A wrapper for displaying a `Type` with a specific style.
+pub struct TypeDisplay<'a> {
+    ty: &'a Type,
+    style: TypeDisplayStyle,
+}
+
+/// Pretty-print a type variable index as a letter (0 -> T, 1 -> U, 2 -> V, ...).
+fn type_var_letter(index: usize) -> &'static str {
+    match index {
+        0 => "T",
+        1 => "U",
+        2 => "V",
+        3 => "W",
+        _ => "T",
+    }
+}
+
+/// Core type formatting logic shared by all display styles.
+fn fmt_type(ty: &Type, style: TypeDisplayStyle, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match ty {
+        Type::Number => f.write_str("number"),
+        Type::String => f.write_str("string"),
+        Type::Bool => f.write_str("boolean"),
+        Type::Undefined => f.write_str("undefined"),
+        Type::Named(n) | Type::Foreign(n) => f.write_str(n),
+        Type::Promise(inner) => {
+            write!(f, "Promise<{}>", TypeDisplay { ty: inner, style })
+        }
+        Type::Opaque { name, .. } => f.write_str(name),
+        Type::Settable(inner) => {
+            write!(f, "Settable<{}>", TypeDisplay { ty: inner, style })
+        }
+        Type::Function {
+            params,
+            required_params,
+            return_type,
+        } => {
+            f.write_str("(")?;
+            for (i, t) in params.iter().enumerate() {
+                if i > 0 {
+                    f.write_str(", ")?;
+                }
+                write!(f, "{}", TypeDisplay { ty: t, style })?;
+                if style == TypeDisplayStyle::Default
+                    && i >= *required_params
+                    && *required_params < params.len()
+                {
+                    f.write_str(" = None")?;
+                }
+            }
+            write!(
+                f,
+                ") -> {}",
+                TypeDisplay {
+                    ty: return_type,
+                    style
+                }
+            )
+        }
+        Type::Array(inner) => {
+            write!(f, "Array<{}>", TypeDisplay { ty: inner, style })
+        }
+        Type::Map { key, value } => {
+            write!(
+                f,
+                "Map<{}, {}>",
+                TypeDisplay { ty: key, style },
+                TypeDisplay { ty: value, style }
+            )
+        }
+        Type::RecordMap { key, value } => {
+            write!(
+                f,
+                "Record<{}, {}>",
+                TypeDisplay { ty: key, style },
+                TypeDisplay { ty: value, style }
+            )
+        }
+        Type::Set { element } => {
+            write!(f, "Set<{}>", TypeDisplay { ty: element, style })
+        }
+        Type::Tuple(types) => {
+            let (open, close) = match style {
+                TypeDisplayStyle::Stdlib => ("[", "]"),
+                TypeDisplayStyle::Default => ("(", ")"),
+            };
+            f.write_str(open)?;
+            for (i, t) in types.iter().enumerate() {
+                if i > 0 {
+                    f.write_str(", ")?;
+                }
+                write!(f, "{}", TypeDisplay { ty: t, style })?;
+            }
+            f.write_str(close)
+        }
+        Type::Record(fields) => {
+            f.write_str("{ ")?;
+            for (i, (n, t)) in fields.iter().enumerate() {
+                if i > 0 {
+                    f.write_str(", ")?;
+                }
+                write!(f, "{n}: {}", TypeDisplay { ty: t, style })?;
+            }
+            f.write_str(" }")
+        }
+        Type::Union { name, .. } => {
+            if name == crate::type_layout::TYPE_OPTION
+                && let Some(inner) = ty.option_inner()
+            {
+                return write!(f, "Option<{}>", TypeDisplay { ty: inner, style });
+            }
+            if name == crate::type_layout::TYPE_RESULT {
+                let ok_display = ty
+                    .result_ok()
+                    .map(|t| format!("{}", TypeDisplay { ty: t, style }))
+                    .unwrap_or_else(|| "unknown".to_string());
+                let err_display = ty
+                    .result_err()
+                    .map(|t| format!("{}", TypeDisplay { ty: t, style }))
+                    .unwrap_or_else(|| "unknown".to_string());
+                return write!(f, "Result<{ok_display}, {err_display}>");
+            }
+            f.write_str(name)
+        }
+        Type::TsUnion(members) => {
+            for (i, t) in members.iter().enumerate() {
+                if i > 0 {
+                    f.write_str(" | ")?;
+                }
+                write!(f, "{}", TypeDisplay { ty: t, style })?;
+            }
+            Ok(())
+        }
+        Type::StringLiteral(s) => write!(f, "\"{s}\""),
+        Type::Var(id) => match style {
+            TypeDisplayStyle::Stdlib => f.write_str(type_var_letter(*id)),
+            TypeDisplayStyle::Default => write!(f, "?T{id}"),
+        },
+        Type::Unknown => f.write_str("unknown"),
+        Type::Unit => f.write_str("()"),
+        Type::Never => f.write_str("never"),
+    }
+}
+
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_type(self, TypeDisplayStyle::Default, f)
+    }
+}
+
+impl fmt::Display for TypeDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt_type(self.ty, self.style, f)
     }
 }
 

--- a/src/interop/wrapper.rs
+++ b/src/interop/wrapper.rs
@@ -62,7 +62,7 @@ pub fn wrap_boundary_type(ts_type: &TsType) -> Type {
                     // Preserve generic args in the display name
                     let args_str: Vec<String> = args
                         .iter()
-                        .map(|a| wrap_boundary_type(a).display_name())
+                        .map(|a| wrap_boundary_type(a).to_string())
                         .collect();
                     Type::Foreign(format!("{}<{}>", name, args_str.join(", ")))
                 }

--- a/src/lsp/hover.rs
+++ b/src/lsp/hover.rs
@@ -65,7 +65,7 @@ impl FloeLsp {
                 return Ok(Some(Hover {
                     contents: HoverContents::Markup(MarkupContent {
                         kind: MarkupKind::Markdown,
-                        value: format!("```floe\n{word}: {}\n```", ty.display_name()),
+                        value: format!("```floe\n{word}: {}\n```", ty),
                     }),
                     range: None,
                 }));
@@ -134,10 +134,7 @@ impl FloeLsp {
                     return Ok(Some(Hover {
                         contents: HoverContents::Markup(MarkupContent {
                             kind: MarkupKind::Markdown,
-                            value: format!(
-                                "```floe\n(property) {word}: {}\n```",
-                                ty.display_name()
-                            ),
+                            value: format!("```floe\n(property) {word}: {}\n```", ty),
                         }),
                         range: None,
                     }));
@@ -187,7 +184,7 @@ impl FloeLsp {
             return Ok(Some(Hover {
                 contents: HoverContents::Markup(MarkupContent {
                     kind: MarkupKind::Markdown,
-                    value: format!("```floe\n{word}: {}\n```", ty.display_name()),
+                    value: format!("```floe\n{word}: {}\n```", ty),
                 }),
                 range: None,
             }));

--- a/src/lsp/stdlib_hover.rs
+++ b/src/lsp/stdlib_hover.rs
@@ -6,85 +6,10 @@
 
 use crate::stdlib::StdlibRegistry;
 
-/// Pretty-print a type variable index as a letter (0 -> T, 1 -> U, 2 -> V, ...).
-fn type_var_name(index: usize) -> &'static str {
-    match index {
-        0 => "T",
-        1 => "U",
-        2 => "V",
-        3 => "W",
-        _ => "T",
-    }
-}
-
-/// Format a checker Type for hover display, using readable type variable names.
+/// Format a checker Type for stdlib hover/completion display, using readable
+/// type variable names (T, U, V) instead of internal IDs.
 pub(super) fn format_type(ty: &crate::checker::Type) -> String {
-    use crate::checker::Type;
-    match ty {
-        Type::Number => "number".to_string(),
-        Type::String => "string".to_string(),
-        Type::Bool => "boolean".to_string(),
-        Type::Undefined => "undefined".to_string(),
-        Type::Unit => "()".to_string(),
-        Type::Unknown => "unknown".to_string(),
-        Type::Named(n) | Type::Foreign(n) => n.clone(),
-        Type::Promise(inner) => format!("Promise<{}>", format_type(inner)),
-        Type::Var(id) => type_var_name(*id).to_string(),
-        Type::Array(inner) => format!("Array<{}>", format_type(inner)),
-        Type::Map { key, value } => {
-            format!("Map<{}, {}>", format_type(key), format_type(value))
-        }
-        Type::RecordMap { key, value } => {
-            format!("Record<{}, {}>", format_type(key), format_type(value))
-        }
-        Type::Set { element } => format!("Set<{}>", format_type(element)),
-        _ if ty.is_option() => {
-            if let Some(inner) = ty.option_inner() {
-                format!("Option<{}>", format_type(inner))
-            } else {
-                "Option<unknown>".to_string()
-            }
-        }
-        _ if ty.is_result() => {
-            let ok = ty
-                .result_ok()
-                .map(format_type)
-                .unwrap_or_else(|| "unknown".to_string());
-            let err = ty
-                .result_err()
-                .map(format_type)
-                .unwrap_or_else(|| "unknown".to_string());
-            format!("Result<{ok}, {err}>")
-        }
-        Type::Settable(inner) => format!("Settable<{}>", format_type(inner)),
-        Type::Tuple(types) => {
-            let t: Vec<_> = types.iter().map(format_type).collect();
-            format!("[{}]", t.join(", "))
-        }
-        Type::Function {
-            params,
-            return_type,
-            ..
-        } => {
-            let p: Vec<_> = params.iter().map(format_type).collect();
-            format!("({}) -> {}", p.join(", "), format_type(return_type))
-        }
-        Type::Record(fields) => {
-            let f: Vec<_> = fields
-                .iter()
-                .map(|(n, t)| format!("{n}: {}", format_type(t)))
-                .collect();
-            format!("{{ {} }}", f.join(", "))
-        }
-        Type::Opaque { name, .. } => name.clone(),
-        Type::Union { name, .. } => name.clone(),
-        Type::TsUnion(members) => {
-            let m: Vec<_> = members.iter().map(format_type).collect();
-            m.join(" | ")
-        }
-        Type::StringLiteral(s) => format!("\"{s}\""),
-        Type::Never => "never".to_string(),
-    }
+    ty.display_for_stdlib().to_string()
 }
 
 /// Format a stdlib function's parameter list for display.


### PR DESCRIPTION
closes #839

## Summary
- Replace duplicate `display_name()` method on `Type` and `format_type()` in `stdlib_hover.rs` with a unified `Display` impl on `Type`
- Add `TypeDisplay` wrapper with `Stdlib` style for type-variable letter names (T, U, V) used in stdlib hover/completions
- All 9 affected files updated to use the unified formatter, reducing ~80 lines of duplicated formatting logic

## Test plan
- [x] `cargo fmt` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `RUSTFLAGS="-D warnings" cargo test` passes (all tests pass)
- [x] `floe check` and `floe build` pass on example apps
- [x] LSP tests pass (230/230)

🤖 Generated with [Claude Code](https://claude.com/claude-code)