### PR TITLE
fix: [#849] Probe generator misses consts inside use <- callbacks

### DIFF
--- a/src/interop/tsgo/probe_gen.rs
+++ b/src/interop/tsgo/probe_gen.rs
@@ -50,6 +50,9 @@ pub(super) fn collect_all_consts(program: &Program) -> Vec<&ConstDecl> {
 }
 
 /// Recursively collect const declarations from an expression (function body, block, etc.)
+///
+/// Also follows `use <-` desugaring: `use x <- f(arg)` becomes `f(arg, |x| { rest })`,
+/// so we recurse into Arrow callback arguments of statement-level Calls.
 fn collect_consts_from_expr<'a>(expr: &'a Expr, consts: &mut Vec<&'a ConstDecl>) {
     let items = match &expr.kind {
         ExprKind::Block(stmts) | ExprKind::Collect(stmts) => stmts,
@@ -59,6 +62,20 @@ fn collect_consts_from_expr<'a>(expr: &'a Expr, consts: &mut Vec<&'a ConstDecl>)
         match &stmt.kind {
             ItemKind::Const(decl) => consts.push(decl),
             ItemKind::Function(func) => collect_consts_from_expr(&func.body, consts),
+            ItemKind::Expr(inner) => {
+                // Follow `use <-` desugaring: the remaining body is wrapped in
+                // an Arrow callback passed as an argument to the guard function.
+                // Only recurse into Arrow args of Calls to avoid picking up
+                // consts from map callbacks, event handlers, etc.
+                if let ExprKind::Call { args, .. } = &inner.kind {
+                    for arg in args {
+                        let (Arg::Positional(e) | Arg::Named { value: e, .. }) = arg;
+                        if let ExprKind::Arrow { body, .. } = &e.kind {
+                            collect_consts_from_expr(body, consts);
+                        }
+                    }
+                }
+            }
             _ => {}
         }
     }
@@ -509,7 +526,9 @@ pub(super) fn generate_probe(
 
         for reexport in &probe_reexports {
             if called_names.contains(reexport.name.as_str()) {
-                // Already has call probes — keep plain re-export
+                // Already has call probes — keep plain re-export so tsgo
+                // resolves the type naturally (typeof annotation causes tsgo
+                // to emit `typeof X` literally which the DTS parser can't resolve)
                 lines.push(format!(
                     "export const _r{} = {};",
                     reexport.index, reexport.name,


### PR DESCRIPTION
closes #849

## Summary
- `collect_consts_from_expr` in `probe_gen.rs` only recursed into `Block`/`Collect` and named functions
- The `use <-` desugaring wraps remaining body items in an Arrow callback passed as a Call argument, making consts after `use <-` invisible to the probe generator
- Functions like `useState` got no call probes, fell through to `_expand`, which collapsed overloaded function types to the wrong (no-arg) overload
- Added `ItemKind::Expr` handling that follows `Call -> Arrow -> Block` patterns to find consts inside `use <-` continuations
- Narrowed to only Arrow arguments of Calls to avoid picking up consts from map callbacks or event handlers

## Test plan
- [x] All 1213 unit tests pass
- [x] `floe check` passes on todo-app and store example apps
- [x] `useState` errors resolved in jira-2pac kanban-card-detail.fl (from "BILLION" errors to 12 unrelated ones)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)