### PR TITLE
chore: [#831] Migrate site deploy from GitHub Pages to Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,4 +1,4 @@
-name: Deploy Docs
+name: Deploy Site
 
 on:
   push:
@@ -7,16 +7,14 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: pages
+  group: deploy-site
   cancel-in-progress: false
 
 jobs:
-  build:
-    name: Build
+  deploy:
+    name: Build & Deploy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -50,19 +48,9 @@ jobs:
         working-directory: docs/site
         run: npx astro build
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
         with:
-          path: docs/site/dist
-
-  deploy:
-    name: Deploy
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy docs/site/dist --project-name=floe


### PR DESCRIPTION
closes #831

## Summary
- Replace GitHub Pages deploy with Cloudflare Pages via `wrangler pages deploy`
- Merge build and deploy into a single job
- Remove unused `pages: write` and `id-token: write` permissions

## Setup required
- `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` must be added as GitHub repo secrets
- Custom domain (`floe-lang.dev`) must be configured in Cloudflare Pages dashboard
- Disable GitHub Pages in repo settings after verifying Cloudflare deploy works

🤖 Generated with [Claude Code](https://claude.com/claude-code)