### PR TITLE
fix: [#842] Checker does not validate variant pattern field count in match

### DIFF
--- a/src/checker/error_codes.rs
+++ b/src/checker/error_codes.rs
@@ -97,6 +97,8 @@ pub enum ErrorCode {
     StringPatternOnNonString,
     /// Tuple pattern arity mismatch in match.
     TuplePatternArity,
+    /// Variant pattern field count mismatch in match.
+    VariantPatternArity,
 
     // ── Warnings ─────────────────────────────────────────────────────
     /// `todo` placeholder will panic at runtime.
@@ -149,6 +151,7 @@ impl ErrorCode {
             Self::AwaitTryOrder => "E036",
             Self::StringPatternOnNonString => "E037",
             Self::TuplePatternArity => "E038",
+            Self::VariantPatternArity => "E039",
             Self::TodoPlaceholder => "W002",
             Self::SpreadFieldOverwritten => "W003",
             Self::UncheckedArguments => "W004",

--- a/src/checker/match_check.rs
+++ b/src/checker/match_check.rs
@@ -408,7 +408,24 @@ impl Checker {
                 if let Type::Union { variants, .. } = subject_ty
                     && let Some((_, field_types)) = variants.iter().find(|(n, _)| n == name)
                 {
-                    for (pat, ty) in fields.iter().zip(field_types.iter()) {
+                    if fields.len() != field_types.len() {
+                        self.emit_error_with_help(
+                            format!(
+                                "variant `{name}` pattern has {} field(s), but the variant has {}",
+                                fields.len(),
+                                field_types.len()
+                            ),
+                            pattern.span,
+                            ErrorCode::VariantPatternArity,
+                            "wrong number of fields",
+                            format!(
+                                "adjust the pattern to match all {} field(s) of `{name}`",
+                                field_types.len()
+                            ),
+                        );
+                    }
+                    for (i, pat) in fields.iter().enumerate() {
+                        let ty = field_types.get(i).unwrap_or(&Type::Unknown);
                         self.check_pattern(pat, ty);
                     }
                     handled = true;

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -1972,6 +1972,63 @@ fn tuple_pattern_correct_arity() {
     );
 }
 
+// ── Variant pattern arity ────────────────────────────────────
+
+#[test]
+fn variant_pattern_too_few_fields() {
+    let source = r#"
+        type Pair { | Both(number, string) | Neither }
+        const _p: Pair = Both(1, "a")
+        match _p {
+            Both(x) -> x
+            Neither -> 0
+        }
+    "#;
+    let diags = check(source);
+    assert!(
+        has_error(&diags, ErrorCode::VariantPatternArity),
+        "variant pattern with too few fields should produce E039, got: {diags:?}"
+    );
+}
+
+#[test]
+fn variant_pattern_too_many_fields() {
+    let source = r#"
+        type Shape { | Circle(number) | Square(number) }
+        const _s: Shape = Circle(5)
+        match _s {
+            Circle(r, extra) -> r
+            Square(s) -> s
+        }
+    "#;
+    let diags = check(source);
+    assert!(
+        has_error(&diags, ErrorCode::VariantPatternArity),
+        "variant pattern with too many fields should produce E039, got: {diags:?}"
+    );
+}
+
+#[test]
+fn variant_pattern_correct_arity() {
+    let source = r#"
+        type Shape { | Circle(number) | Square(number) }
+        const _s: Shape = Circle(5)
+        match _s {
+            Circle(r) -> r
+            Square(s) -> s
+        }
+    "#;
+    let diags = check(source);
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "variant pattern with correct arity should not produce errors: {errors:?}"
+    );
+}
+
 // ── Pipe: tap ───────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
closes #842

## Summary
- Emit **E039** (`VariantPatternArity`) when a variant pattern has a different number of fields than the variant type declares
- Same fix pattern as #834 (tuple arity): indexed iteration with `Unknown` fallback for error recovery
- Added `VariantPatternArity` to the `ErrorCode` enum

## Test plan
- [x] `cargo clippy -- -D warnings` — clean
- [x] `RUSTFLAGS="-D warnings" cargo test` — all 1218 pass (3 new)
- [x] `floe fmt/check/build` on example apps — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)