### PR TITLE
fix: [#853] Propagate async context through use <- desugaring

### DIFF
--- a/src/lower.rs
+++ b/src/lower.rs
@@ -15,6 +15,7 @@ pub fn lower_program(root: &SyntaxNode, source: &str) -> Result<Program, Vec<Par
         source,
         errors: Vec::new(),
         id_gen: ExprIdGen::new(),
+        inside_async_fn: false,
     };
     let program = lowerer.lower_root(root);
     if lowerer.errors.is_empty() {
@@ -32,6 +33,7 @@ pub fn lower_program_lossy(root: &SyntaxNode, source: &str) -> (Program, Vec<Par
         source,
         errors: Vec::new(),
         id_gen: ExprIdGen::new(),
+        inside_async_fn: false,
     };
     let program = lowerer.lower_root(root);
     (program, lowerer.errors)
@@ -41,6 +43,9 @@ struct Lowerer<'src> {
     source: &'src str,
     errors: Vec<ParseError>,
     id_gen: ExprIdGen,
+    /// Whether we're inside an async function body — used by `use <-`
+    /// desugaring so the callback inherits the enclosing async context.
+    inside_async_fn: bool,
 }
 
 impl<'src> Lowerer<'src> {
@@ -239,6 +244,7 @@ impl<'src> Lowerer<'src> {
             source,
             errors: Vec::new(),
             id_gen: ExprIdGen::new(),
+            inside_async_fn: false,
         };
         let program = lowerer.lower_root(&root);
 

--- a/src/lower/expr.rs
+++ b/src/lower/expr.rs
@@ -880,7 +880,7 @@ impl<'src> Lowerer<'src> {
 
         let lambda = self.expr(
             ExprKind::Arrow {
-                async_fn: false,
+                async_fn: self.inside_async_fn,
                 params,
                 body: Box::new(body),
             },

--- a/src/lower/items.rs
+++ b/src/lower/items.rs
@@ -225,7 +225,10 @@ impl<'src> Lowerer<'src> {
                     }
                 }
                 SyntaxKind::BLOCK_EXPR if !is_binding => {
+                    let prev_async = self.inside_async_fn;
+                    self.inside_async_fn = async_fn;
                     body = self.lower_expr_node(&child);
+                    self.inside_async_fn = prev_async;
                 }
                 _ if is_binding && body.is_none() => {
                     // For `fn name = expr`, the body is the expression after `=`
@@ -473,7 +476,10 @@ impl<'src> Lowerer<'src> {
                     }
                 }
                 SyntaxKind::BLOCK_EXPR => {
+                    let prev_async = self.inside_async_fn;
+                    self.inside_async_fn = async_fn;
                     body = self.lower_expr_node(&child);
+                    self.inside_async_fn = prev_async;
                 }
                 _ => {}
             }


### PR DESCRIPTION
closes #853

## Summary
- `use <-` desugaring created a non-async Arrow callback, so `await` inside `use <-` in an `async fn` failed with E035 ("await can only be used inside an async function")
- Added `inside_async_fn` tracking to the `Lowerer` — set when entering a function body, used by `use <-` desugaring to mark the callback as async when the enclosing function is async
- Reduces jira-2pac kanban-card-detail.fl errors from 4 to 3 (remaining 3 are a separate issue with `try await` Result destructuring)

## Test plan
- [x] All 1213 unit tests pass
- [x] `floe check` passes on todo-app and store example apps
- [x] `cargo clippy -- -D warnings` passes
- [x] `await` inside `use <-` in async functions no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)