### PR TITLE
fix: [#867] Wrap tsgo probe type in Result when expression has try

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -99,6 +99,15 @@ pub fn expr_has_await(expr: &Expr) -> bool {
     }
 }
 
+/// Check if an expression is wrapped in `try` (possibly through `await`).
+pub fn expr_has_try(expr: &Expr) -> bool {
+    match &expr.kind {
+        ExprKind::Try(_) => true,
+        ExprKind::Await(inner) => expr_has_try(inner),
+        _ => false,
+    }
+}
+
 // ── Checker ──────────────────────────────────────────────────────
 
 /// The Floe type checker.

--- a/src/checker/items.rs
+++ b/src/checker/items.rs
@@ -42,14 +42,22 @@ impl Checker {
             self.expr_types.insert(decl.value.id, declared.clone());
         }
         let tsgo_type = self.find_and_consume_tsgo_probe(&decl.binding).map(|ty| {
-            // The tsgo probe generates the raw call expression without `await`,
-            // so if the Floe code has `await`, unwrap Promise from the probe type.
-            if Self::expr_has_await(&decl.value)
+            // The tsgo probe generates the raw call expression without `try`/`await`,
+            // so adjust the probe type to match the Floe expression:
+            // - `await`: unwrap Promise<T> → T
+            // - `try`: wrap T → Result<T, Error>
+            let ty = if Self::expr_has_await(&decl.value)
                 && let Type::Promise(inner) = ty
             {
-                return *inner;
+                *inner
+            } else {
+                ty
+            };
+            if expr_has_try(&decl.value) {
+                Type::result_of(ty, Type::Named(crate::type_layout::TYPE_ERROR.to_string()))
+            } else {
+                ty
             }
-            ty
         });
         let final_type = self.resolve_const_type(value_type, declared_type, &tsgo_type, span);
 


### PR DESCRIPTION
closes #867

## Summary
- The tsgo probe generates raw call expressions without `try`/`await` wrappers
- `await` unwrapping was already handled (unwrap `Promise<T>` → `T`), but `try` wrapping was missing
- This caused `const result = try await f(x)` to get the probe's unwrapped type (e.g. `Transition[]`) instead of `Result<Transition[], Error>`
- `Ok(data)` and `Err(e)` match arm bindings resolved to `unknown` because the subject wasn't a `Result` union
- Added `expr_has_try` helper and `Result` wrapping in the probe type resolution

**This was the last remaining error in kanban-card-detail.fl — the file now checks with zero errors.**

## Test plan
- [x] All 1216 unit tests pass
- [x] `floe check` passes on todo-app and store example apps
- [x] `cargo clippy -- -D warnings` passes
- [x] kanban-card-detail.fl: 0 errors (down from "a BILLION")

🤖 Generated with [Claude Code](https://claude.com/claude-code)