### PR TITLE
fix: [#869] Checker does not type-check literal patterns in match

### DIFF
--- a/examples/store/src/product.fl
+++ b/examples/store/src/product.fl
@@ -48,8 +48,8 @@ for Array<CartItem> {
         const existing = self |> Array.findIndex((item) => item.product.id == product.id)
 
         existing |> match {
-            -1 -> self |> Array.append(CartItem(product: product, quantity: qty)),
-            _ -> self |> Array.map((item) =>
+            None -> self |> Array.append(CartItem(product: product, quantity: qty)),
+            Some(_) -> self |> Array.map((item) =>
                 match item.product.id == product.id {
                     true -> CartItem(..item, quantity: item.quantity + qty),
                     false -> item,

--- a/src/checker/error_codes.rs
+++ b/src/checker/error_codes.rs
@@ -99,6 +99,8 @@ pub enum ErrorCode {
     TuplePatternArity,
     /// Variant pattern field count mismatch in match.
     VariantPatternArity,
+    /// Literal pattern type mismatch (e.g. `true` on a string).
+    LiteralPatternMismatch,
 
     // ── Warnings ─────────────────────────────────────────────────────
     /// `todo` placeholder will panic at runtime.
@@ -152,6 +154,7 @@ impl ErrorCode {
             Self::StringPatternOnNonString => "E037",
             Self::TuplePatternArity => "E038",
             Self::VariantPatternArity => "E039",
+            Self::LiteralPatternMismatch => "E040",
             Self::TodoPlaceholder => "W002",
             Self::SpreadFieldOverwritten => "W003",
             Self::UncheckedArguments => "W004",

--- a/src/checker/match_check.rs
+++ b/src/checker/match_check.rs
@@ -402,7 +402,33 @@ impl Checker {
         };
 
         match &pattern.kind {
-            PatternKind::Literal(_) | PatternKind::Range { .. } | PatternKind::Wildcard => {}
+            PatternKind::Wildcard | PatternKind::Range { .. } => {}
+            PatternKind::Literal(lit) => {
+                if !matches!(subject_ty, Type::Unknown) {
+                    let compatible = match lit {
+                        LiteralPattern::Bool(_) => matches!(subject_ty, Type::Bool),
+                        LiteralPattern::Number(_) => matches!(subject_ty, Type::Number),
+                        LiteralPattern::String(_) => {
+                            matches!(subject_ty, Type::String | Type::StringLiteral(_))
+                                || subject_ty.as_string_literal_variants().is_some()
+                        }
+                    };
+                    if !compatible {
+                        let lit_desc = match lit {
+                            LiteralPattern::Bool(_) => "boolean",
+                            LiteralPattern::Number(_) => "number",
+                            LiteralPattern::String(_) => "string",
+                        };
+                        self.emit_error_with_help(
+                            format!("{lit_desc} literal pattern used on type `{subject_ty}`",),
+                            pattern.span,
+                            ErrorCode::LiteralPatternMismatch,
+                            format!("expected `{subject_ty}`, found {lit_desc}"),
+                            format!("use a `{subject_ty}` pattern or a `_` catch-all"),
+                        );
+                    }
+                }
+            }
             PatternKind::Variant { name, fields } => {
                 let mut handled = false;
                 if let Type::Union { variants, .. } = subject_ty

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -2029,6 +2029,96 @@ fn variant_pattern_correct_arity() {
     );
 }
 
+// ── Literal pattern type checking ────────────────────────────
+
+#[test]
+fn bool_literal_on_string_type_errors() {
+    let source = r#"
+        const _s = "hello"
+        match _s {
+            true -> "yes",
+            false -> "no",
+        }
+    "#;
+    let diags = check(source);
+    assert!(
+        has_error(&diags, ErrorCode::LiteralPatternMismatch),
+        "boolean literal on string type should produce E040, got: {diags:?}"
+    );
+}
+
+#[test]
+fn number_literal_on_string_type_errors() {
+    let source = r#"
+        const _s = "hello"
+        match _s {
+            42 -> "the answer",
+            _ -> "something else",
+        }
+    "#;
+    let diags = check(source);
+    assert!(
+        has_error(&diags, ErrorCode::LiteralPatternMismatch),
+        "number literal on string type should produce E040, got: {diags:?}"
+    );
+}
+
+#[test]
+fn string_literal_on_bool_type_errors() {
+    let source = r#"
+        const _b = true
+        match _b {
+            "yes" -> 1,
+            _ -> 0,
+        }
+    "#;
+    let diags = check(source);
+    assert!(
+        has_error(&diags, ErrorCode::LiteralPatternMismatch),
+        "string literal on bool type should produce E040, got: {diags:?}"
+    );
+}
+
+#[test]
+fn bool_literal_on_bool_type_ok() {
+    let source = r#"
+        const _b = true
+        match _b {
+            true -> "yes",
+            false -> "no",
+        }
+    "#;
+    let diags = check(source);
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "boolean literal on boolean type should not error: {errors:?}"
+    );
+}
+
+#[test]
+fn string_literal_on_string_type_ok() {
+    let source = r#"
+        const _s = "hello"
+        match _s {
+            "hello" -> "greeting",
+            _ -> "other",
+        }
+    "#;
+    let diags = check(source);
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "string literal on string type should not error: {errors:?}"
+    );
+}
+
 // ── Pipe: tap ───────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
closes #869

## Summary
- Emit E040 (LiteralPatternMismatch) when a literal pattern type does not match the match subject
- Fix store example: Array.findIndex returns Option, not number - the -1 pattern was wrong, now uses Some/None

## Test plan
- [x] cargo clippy -- -D warnings - clean
- [x] RUSTFLAGS="-D warnings" cargo test - all 1221 pass (5 new)
- [x] floe fmt/check/build on example apps - all pass