### PR TITLE
chore: [#866/#875] Add GitHub stars badge to docs site

### DIFF
--- a/docs/site/src/pages/index.astro
+++ b/docs/site/src/pages/index.astro
@@ -215,6 +215,15 @@ import floeLang from "../../../../editors/vscode/syntaxes/floe.tmLanguage.json";
         border-color: var(--text-faint);
       }
 
+      .btn-stars {
+        gap: 6px;
+      }
+
+      .btn-stars svg {
+        width: 14px;
+        height: 14px;
+      }
+
       /* ============ Section ============ */
       .section {
         position: relative;
@@ -443,6 +452,10 @@ import floeLang from "../../../../editors/vscode/syntaxes/floe.tmLanguage.json";
       <div class="btns">
         <a href="/docs/guide/introduction/" class="btn btn-accent">Get Started</a>
         <a href="/playground/" class="btn btn-outline">Playground</a>
+        <a href="https://github.com/floeorg/floe" class="btn btn-outline btn-stars">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" /></svg>
+          Star on GitHub
+        </a>
       </div>
     </section>
 


### PR DESCRIPTION
closes #875

## Summary
- Add "Star on GitHub" button with star icon to the homepage hero section, next to Get Started and Playground buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)