### PR TITLE
fix: [#877] Emit async IIFEs for match arms containing await

### DIFF
--- a/src/codegen/match_emit.rs
+++ b/src/codegen/match_emit.rs
@@ -306,7 +306,12 @@ impl Codegen {
         );
         let needs_iife = !bindings.is_empty() || matches!(body.kind, ExprKind::Block(_));
         if needs_iife {
-            self.push("(() => { ");
+            let has_await = super::expr::expr_contains_await(body);
+            if has_await {
+                self.push("await (async () => { ");
+            } else {
+                self.push("(() => { ");
+            }
             for (name, access) in &bindings {
                 self.push(&format!("const {name} = {access}; "));
             }


### PR DESCRIPTION
closes #877

## Summary
- Match arm bodies compiled to IIFEs were always synchronous `(() => { ... })()`
- When the body contained `await` (e.g. `Ok(_) -> { await queryClient.invalidateQueries(...) }`), this produced invalid JS
- Now detects `await` in the body and emits `await (async () => { ... })()` when needed
- Triggered by `await` inside match arms in async functions, especially after `use <-` desugaring

## Test plan
- [x] All 1216 unit tests pass
- [x] `floe check` and `floe build` pass on todo-app and store examples
- [x] kanban-card-detail.fl compiles successfully — generated TS has correct `async` IIFEs
- [x] `cargo clippy -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)