### PR TITLE
fix: [#870] LSP hover shows wrong type for literal patterns in match

### DIFF
--- a/src/lsp/symbols.rs
+++ b/src/lsp/symbols.rs
@@ -513,9 +513,27 @@ impl SymbolIndex {
         }
     }
 
-    /// Walk match patterns to index binding names for hover.
+    /// Walk match patterns to index binding names and literals for hover.
     fn collect_pattern_bindings(pattern: &crate::parser::ast::Pattern, symbols: &mut Vec<Symbol>) {
         match &pattern.kind {
+            PatternKind::Literal(lit) => {
+                let (name, ty) = match lit {
+                    LiteralPattern::Bool(b) => (b.to_string(), "boolean"),
+                    LiteralPattern::Number(n) => (n.clone(), "number"),
+                    LiteralPattern::String(s) => (format!("\"{s}\""), "string"),
+                };
+                symbols.push(Symbol {
+                    name,
+                    kind: SymbolKind::CONSTANT,
+                    start: pattern.span.start,
+                    end: pattern.span.end,
+                    import_source: None,
+                    detail: format!("(pattern) {ty}"),
+                    first_param_type: None,
+                    return_type_str: None,
+                    owner_type: None,
+                });
+            }
             PatternKind::Binding(name) if name != "_" => {
                 symbols.push(Symbol {
                     name: name.clone(),

--- a/tests/lsp/fixtures.py
+++ b/tests/lsp/fixtures.py
@@ -836,3 +836,12 @@ fn _test(x: Option<User>) -> string {
     }
 }
 """
+
+MATCH_PATTERN_LITERAL = """\
+fn _test(x: boolean) -> string {
+    match x {
+        true -> "yes",
+        false -> "no",
+    }
+}
+"""

--- a/tests/lsp/test_hover.py
+++ b/tests/lsp/test_hover.py
@@ -349,6 +349,13 @@ class TestHoverRecordSpread:
         assert h is not None, f"Expected hover for pattern binding u, got None"
         assert "User" in h, f"Expected User type for pattern binding, got: {h}"
 
+    def test_match_pattern_literal_shows_boolean(self, lsp):
+        open_doc(lsp, URI, F.MATCH_PATTERN_LITERAL)
+        # Hover on 'true' in match pattern (line 2, col 8)
+        h = hover_text(lsp.hover(URI, 2, 8))
+        assert h is not None, f"Expected hover for true literal pattern, got None"
+        assert "boolean" in h, f"Expected boolean type for true pattern, got: {h}"
+
     def test_pipe_into_match_fn(self, lsp):
         open_doc(lsp, URI,F.PIPE_INTO_MATCH)
         h = hover_text(lsp.hover(URI, 0, 3))


### PR DESCRIPTION
closes #870

## Summary
- Register literal patterns (true/false, numbers, strings) in the LSP symbol index
- Hovering over true/false now shows boolean, numbers show number, strings show string
- Previously fell through to incorrect fallback types

## Test plan
- [x] All 231 LSP tests pass (1 new hover test for literal patterns)
- [x] cargo clippy/test - clean
- [x] floe fmt/check/build on example apps - all pass