### PR TITLE
fix: [#887] Treat type-only TS exports as Foreign instead of Unknown

### DIFF
--- a/src/checker/imports.rs
+++ b/src/checker/imports.rs
@@ -22,7 +22,18 @@ impl Checker {
                                 .insert(effective_name.to_string(), required);
                         }
                     }
-                    interop::wrap_boundary_type(&dts_export.ts_type)
+                    let ty = interop::wrap_boundary_type(&dts_export.ts_type);
+                    // Type-only TS exports (interfaces, type aliases) resolve
+                    // to Any/Unknown through the probe since they have no runtime
+                    // value. Treat them as Foreign so they're usable as type
+                    // annotations (e.g. `fn f(x: DropResult)`).
+                    if matches!(ty, Type::Unknown)
+                        && matches!(dts_export.ts_type, interop::TsType::Any)
+                    {
+                        Type::Foreign(spec.name.clone())
+                    } else {
+                        ty
+                    }
                 } else {
                     Type::Foreign(spec.name.clone())
                 }


### PR DESCRIPTION
closes #887

## Summary
- Type-only TS exports (interfaces like `DropResult`, type aliases) have no runtime value, so the tsgo probe resolves them as `any`
- This was converted to `Type::Unknown`, making them unusable as type annotations (`fn f(x: DropResult)` errored with "is a value, not a type")
- Now detects when a DTS export resolves to `Any` (indicating a type-only export) and registers it as `Foreign` instead, so it works in type position

## Test plan
- [x] All 1225 unit tests pass
- [x] `floe check` passes on todo-app and store examples
- [x] `cargo clippy -- -D warnings` passes
- [x] `DropResult` usable as type annotation in kanban-board.fl

🤖 Generated with [Claude Code](https://claude.com/claude-code)