### PR TITLE
fix: [#888] Resolve non-exported TS interfaces referenced in probe output

### DIFF
--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -2273,11 +2273,23 @@ impl Checker {
             Type::Named(n) | Type::Foreign(n) => Some(n.as_str()),
             _ => None,
         };
-        if let Some(name) = name
-            && let Some(val_ty) = self.env.lookup(name).cloned()
-            && matches!(val_ty, Type::Record(_))
-        {
-            return val_ty;
+        if let Some(name) = name {
+            // Check env first (built-in types, previous imports)
+            if let Some(val_ty) = self.env.lookup(name).cloned()
+                && matches!(val_ty, Type::Record(_))
+            {
+                return val_ty;
+            }
+            // Check DTS imports for type/interface definitions (e.g. non-exported
+            // interfaces like IssueFilters that are referenced in probe output)
+            for exports in self.dts_imports.values() {
+                if let Some(export) = exports.iter().find(|e| e.name == name) {
+                    let ty = crate::interop::wrap_boundary_type(&export.ts_type);
+                    if matches!(ty, Type::Record(_)) {
+                        return ty;
+                    }
+                }
+            }
         }
         resolved
     }

--- a/src/interop/dts.rs
+++ b/src/interop/dts.rs
@@ -219,6 +219,62 @@ pub(super) fn parse_dts_exports_from_str(content: &str) -> Result<Vec<DtsExport>
     parse_dts_content(content).map(|r| r.exports)
 }
 
+/// Parse ALL type/interface declarations from a source file, including non-exported ones.
+/// Used to resolve type references like `IssueFilters` that appear in probe output
+/// but aren't exported from the source module.
+pub(super) fn parse_all_types_from_str(content: &str) -> Result<Vec<DtsExport>, String> {
+    let allocator = Allocator::default();
+    let source_type = SourceType::tsx();
+    let ret = Parser::new(&allocator, content, source_type).parse();
+
+    if ret.panicked {
+        return Err("failed to parse file".to_string());
+    }
+
+    let mut types = Vec::new();
+    let mut seen_names: HashSet<String> = HashSet::new();
+
+    for stmt in &ret.program.body {
+        // Interface declarations (exported or not)
+        if let Statement::TSInterfaceDeclaration(iface) = stmt {
+            let name = iface.id.name.to_string();
+            if seen_names.insert(name.clone()) {
+                let ts_type = convert_interface_body(&iface.body.body);
+                types.push(DtsExport { name, ts_type });
+            }
+        }
+        // Type alias declarations (exported or not)
+        if let Statement::TSTypeAliasDeclaration(type_decl) = stmt {
+            let name = type_decl.id.name.to_string();
+            if seen_names.insert(name.clone()) {
+                let ts_type = convert_oxc_type(&type_decl.type_annotation);
+                types.push(DtsExport { name, ts_type });
+            }
+        }
+        // Also check inside export declarations
+        if let Statement::ExportNamedDeclaration(export_decl) = stmt
+            && let Some(ref decl) = export_decl.declaration
+        {
+            if let Declaration::TSInterfaceDeclaration(iface) = decl {
+                let name = iface.id.name.to_string();
+                if seen_names.insert(name.clone()) {
+                    let ts_type = convert_interface_body(&iface.body.body);
+                    types.push(DtsExport { name, ts_type });
+                }
+            }
+            if let Declaration::TSTypeAliasDeclaration(type_decl) = decl {
+                let name = type_decl.id.name.to_string();
+                if seen_names.insert(name.clone()) {
+                    let ts_type = convert_oxc_type(&type_decl.type_annotation);
+                    types.push(DtsExport { name, ts_type });
+                }
+            }
+        }
+    }
+
+    Ok(types)
+}
+
 /// Extract exports from an `export` declaration (export function/const/type/interface).
 fn extract_from_export_named(
     export_decl: &ExportNamedDeclaration<'_>,

--- a/src/interop/tsgo.rs
+++ b/src/interop/tsgo.rs
@@ -149,6 +149,20 @@ impl TsgoResolver {
                         entry.push(ts_export);
                     }
                 }
+
+                // Also parse non-exported types referenced in probe output.
+                // E.g. `IssueFilters` is used as a type in the probe but not
+                // exported from jira-store.ts.
+                let all_types = match super::dts::parse_all_types_from_str(&ts_content) {
+                    Ok(types) => types,
+                    Err(_) => continue,
+                };
+                let entry = result.entry(specifier.clone()).or_default();
+                for type_def in all_types {
+                    if !entry.iter().any(|e| e.name == type_def.name) {
+                        entry.push(type_def);
+                    }
+                }
             }
 
             result


### PR DESCRIPTION
closes #888

## Summary
- When tsgo probe output references a type like `IssueFilters` that's defined but not exported from a `.ts` file, the checker couldn't resolve its fields — member access like `filters.search` returned `Foreign("IssueFilters.search")` instead of `string`
- Added `parse_all_types_from_str` to extract ALL type/interface declarations (exported or not) from `.ts` files
- These are registered in `dts_imports` so the checker can resolve `Foreign` types against them
- `resolve_type_to_concrete` now checks `dts_imports` for Record definitions when env lookup fails

## Test plan
- [x] All 1225 unit tests pass
- [x] `floe check` passes on todo-app and store examples
- [x] `cargo clippy -- -D warnings` passes
- [x] `filters.search` resolves to `string` instead of `IssueFilters.search`

🤖 Generated with [Claude Code](https://claude.com/claude-code)