### PR TITLE
fix: [#893] Prefer checker inference over Unknown probes and register npm type defs

### DIFF
--- a/src/checker/items.rs
+++ b/src/checker/items.rs
@@ -154,7 +154,16 @@ impl Checker {
         span: Span,
     ) -> Type {
         if let Some(tsgo_ty) = tsgo_type {
-            tsgo_ty.clone()
+            if matches!(tsgo_ty, Type::Unknown)
+                && !matches!(value_type, Type::Unknown | Type::Var(_))
+            {
+                // Probe resolved to Unknown (e.g. useMemo callback with free
+                // variables) but the checker inferred a concrete type via
+                // generic inference — prefer the checker's type.
+                value_type
+            } else {
+                tsgo_ty.clone()
+            }
         } else if let Some(ref declared) = declared_type {
             if matches!(value_type, Type::Unknown) && !matches!(declared, Type::Unknown) {
                 self.emit_error_with_help(

--- a/src/interop/tsgo/typeof_resolve.rs
+++ b/src/interop/tsgo/typeof_resolve.rs
@@ -79,6 +79,50 @@ pub(super) fn resolve_typeof_types(
             entry.ts_type = found.ts_type.clone();
         }
     }
+
+    // Parse npm packages for type-only imports (Any/Foreign) so the checker
+    // can resolve their fields (e.g. DropResult.droppableId from @hello-pangea/dnd).
+    // Also parse packages that have Named type references in the probe output.
+    for (name, source) in &import_sources {
+        // Only parse npm packages (not relative imports — those are handled separately)
+        if source.starts_with("./") || source.starts_with("../") {
+            continue;
+        }
+        // Check if this import has an Any export (type-only) that needs resolution
+        let needs_parsing = result.get(source.as_str()).is_some_and(|exports| {
+            exports
+                .iter()
+                .any(|e| e.name == *name && matches!(e.ts_type, TsType::Any))
+        });
+        if needs_parsing {
+            module_cache.entry(source.clone()).or_insert_with(|| {
+                if let Some(dts_path) = find_package_dts(project_dir, source)
+                    && let Ok(exports) = super::super::dts::parse_dts_exports(&dts_path)
+                {
+                    return exports;
+                }
+                Vec::new()
+            });
+        }
+    }
+
+    // Register type/interface definitions from ALL parsed npm packages so the
+    // checker can resolve Foreign type member access (e.g. DropResult.droppableId).
+    for (module_source, module_exports) in &module_cache {
+        let specifier = import_sources
+            .iter()
+            .find(|(_, src)| *src == module_source)
+            .map(|(_, src)| src.clone())
+            .unwrap_or_else(|| module_source.clone());
+        let entry = result.entry(specifier).or_default();
+        for export in module_exports {
+            if matches!(export.ts_type, TsType::Object(_))
+                && !entry.iter().any(|e| e.name == export.name)
+            {
+                entry.push(export.clone());
+            }
+        }
+    }
 }
 
 /// Find the main .d.ts file for an npm package by reading its package.json.


### PR DESCRIPTION
closes #893

## Summary

1. **resolve_const_type**: when the tsgo probe resolves to `Unknown` (e.g. `useMemo` callback with free variables) but the checker inferred a concrete type via generic inference, prefer the checker's type. This fixes `filteredIssues`, `boardColumns`, `columnIssues` all being `unknown`.

2. **typeof_resolve**: parse npm package `.d.ts` files for type-only imports (`Any` exports) and register interface definitions in the specifier map. This enables the checker to resolve Foreign type member access for types like `DropResult` from `@hello-pangea/dnd`. (Note: full inheritance chain resolution for `extends` isn't implemented yet, so deeply inherited fields still won't resolve.)

## Test plan
- [x] All 1225 unit tests pass
- [x] `floe check` passes on todo-app and store examples
- [x] `cargo clippy -- -D warnings` passes
- [x] `useMemo(() => expr, deps)` correctly infers return type from callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)