### PR TITLE
fix: [#898] Use resolve_type_to_concrete for object destructured bindings

### DIFF
--- a/src/checker/items.rs
+++ b/src/checker/items.rs
@@ -236,9 +236,7 @@ impl Checker {
         has_tsgo: bool,
         span: Span,
     ) {
-        let concrete = self
-            .env
-            .resolve_to_concrete(final_type, &expr::simple_resolve_type_expr);
+        let concrete = self.resolve_type_to_concrete(final_type);
 
         let field_map: Option<std::collections::HashMap<&str, &Type>> = match &concrete {
             Type::Record(rec_fields) => {


### PR DESCRIPTION
closes #898

## Summary
- `define_object_destructured_bindings` used `env.resolve_to_concrete` which only checks `type_defs`
- Switched to `resolve_type_to_concrete` which also checks the value env and `dts_imports`
- This allows Record types from npm package interfaces (like `DropResult` with its resolved `extends` chain) to properly resolve their fields during destructuring
- `const { destination, source, draggableId } = dragResult` now correctly types all fields

**Remaining 3 errors** in kanban-board.fl are type alias resolution issues (`DraggableId<TId>` should resolve to `string` since `TId` defaults to `string`) and the `useMemo` free variable cascade.

## Test plan
- [x] All 1225 unit tests pass
- [x] `floe check` passes on todo-app and store examples
- [x] `cargo clippy -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)