### PR TITLE
fix: [#915] No error on property access of function type

### DIFF
--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -2135,9 +2135,9 @@ impl Checker {
             return Type::Unknown;
         }
 
-        // Error on member access on primitive types
+        // Error on member access on primitive and function types
         match obj_ty {
-            Type::Number | Type::String | Type::Bool | Type::Unit => {
+            Type::Number | Type::String | Type::Bool | Type::Unit | Type::Function { .. } => {
                 self.emit_error(
                     format!("cannot access `.{field}` on type `{}`", obj_ty),
                     span,

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -1394,6 +1394,21 @@ const _n = x.name
     );
 }
 
+#[test]
+fn member_access_on_function_type_errors() {
+    let diags = check(
+        r#"
+fn myFunc(x: number) -> string { "hi" }
+const _n = myFunc.name
+"#,
+    );
+    assert!(
+        has_error_containing(&diags, "cannot access"),
+        "should error on member access on function type, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
 // ── 3. Constructor field type validation ───────────────────
 
 #[test]


### PR DESCRIPTION
closes #915

## Summary
- Add `Type::Function` to the explicit error check in `resolve_member_type` so `.field` on a function type produces an `InvalidFieldAccess` error
- Previously function types fell through to the generic fallback error, but being explicit is clearer

## Test plan
- [x] cargo clippy/test - all 1233 pass (1 new)
- [x] floe fmt/check/build on example apps - all pass