### PR TITLE
fix: [#914] Render prop callback params get wrong types from tsgo

### DIFF
--- a/src/interop/tsgo.rs
+++ b/src/interop/tsgo.rs
@@ -1050,9 +1050,9 @@ fn page() {
             probe.contains("__jsxc_Draggable_1"),
             "probe should contain children probe for param 1, got:\n{probe}"
         );
-        // Should reference the children prop
+        // Should reference the children prop via helper pattern
         assert!(
-            probe.contains("[\"children\"]"),
+            probe.contains(".children"),
             "probe should extract from children prop, got:\n{probe}"
         );
     }

--- a/src/interop/tsgo/probe_gen.rs
+++ b/src/interop/tsgo/probe_gen.rs
@@ -648,13 +648,28 @@ pub(super) fn generate_probe(
         }
     }
     // Emit children render prop probes: extract each parameter type individually.
+    // Use a helper function + intermediate declares so tsgo fully resolves the types
+    // (tsgo doesn't resolve Parameters<T> in standalone type declarations).
+    if !collector.children_probes.is_empty() {
+        lines.push(
+            "declare function _extract<T extends (...args: any[]) => any>(fn: T): Parameters<T>;"
+                .to_string(),
+        );
+    }
     for probe in &collector.children_probes {
+        let comp = &probe.component;
+        lines.push(format!(
+            "declare const _jcProps_{comp}: Parameters<typeof {comp}>[0];"
+        ));
+        lines.push(format!(
+            "declare const _jcChild_{comp}: NonNullable<typeof _jcProps_{comp}.children>;"
+        ));
+        lines.push(format!(
+            "const _jcParams_{comp} = _extract(_jcChild_{comp});"
+        ));
         for i in 0..probe.param_count {
             lines.push(format!(
-                "export declare const __jsxc_{comp}_{i}:\
-                 Parameters<NonNullable<Parameters<typeof {comp}>[0][\"children\"]>>[{i}];",
-                comp = probe.component,
-                i = i,
+                "export const __jsxc_{comp}_{i} = _jcParams_{comp}[{i}];",
             ));
         }
     }


### PR DESCRIPTION
closes #914

## Summary
tsgo couldn't resolve deeply nested utility types like:
```ts
Parameters<NonNullable<Parameters<typeof Draggable>[0]["children"]>>[0]
```

Changed the probe generation to use a helper function pattern that tsgo can evaluate step-by-step:
```ts
declare function _extract<T extends (...args: any[]) => any>(fn: T): Parameters<T>;
declare const _jcProps_Draggable: Parameters<typeof Draggable>[0];
declare const _jcChild_Draggable: NonNullable<typeof _jcProps_Draggable.children>;
const _jcParams_Draggable = _extract(_jcChild_Draggable);
export const __jsxc_Draggable_0 = _jcParams_Draggable[0];  // DraggableProvided
export const __jsxc_Draggable_1 = _jcParams_Draggable[1];  // DraggableStateSnapshot
```

## Test plan
- [x] cargo clippy/test - all 1233 pass
- [x] floe fmt/check/build on example apps - all pass
- [x] Verified with real @hello-pangea/dnd Draggable component