### PR TITLE
fix: [#919] LSP hover shows type var instead of resolved type for render prop params

### DIFF
--- a/src/lsp/symbols.rs
+++ b/src/lsp/symbols.rs
@@ -509,6 +509,9 @@ impl SymbolIndex {
             ExprKind::Collect(items) => {
                 Self::collect_items(items, symbols);
             }
+            ExprKind::Jsx(element) => {
+                Self::collect_jsx(element, symbols);
+            }
             _ => {}
         }
     }
@@ -648,6 +651,31 @@ impl SymbolIndex {
                 Arg::Positional(e) | Arg::Named { value: e, .. } => {
                     Self::collect_expr(e, symbols);
                 }
+            }
+        }
+    }
+
+    fn collect_jsx(element: &JsxElement, symbols: &mut Vec<Symbol>) {
+        if let JsxElementKind::Element { props, .. } = &element.kind {
+            for prop in props {
+                match prop {
+                    JsxProp::Named { value: Some(e), .. } | JsxProp::Spread { expr: e, .. } => {
+                        Self::collect_expr(e, symbols);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        let children = match &element.kind {
+            JsxElementKind::Element { children, .. } | JsxElementKind::Fragment { children } => {
+                children
+            }
+        };
+        for child in children {
+            match child {
+                JsxChild::Expr(e) => Self::collect_expr(e, symbols),
+                JsxChild::Element(el) => Self::collect_jsx(el, symbols),
+                JsxChild::Text(_) => {}
             }
         }
     }

--- a/tests/lsp/fixtures.py
+++ b/tests/lsp/fixtures.py
@@ -837,6 +837,25 @@ fn _test(x: Option<User>) -> string {
 }
 """
 
+LAMBDA_PARAM = """\
+const items = [1, 2, 3]
+const _result = items |> map((item) => item + 1)
+"""
+
+JSX_RENDER_PROP_PARAM = """\
+import trusted { Draggable } from "@hello-pangea/dnd"
+
+type Props { id: string }
+
+export fn Card(props: Props) -> JSX.Element {
+    <Draggable draggableId={props.id} index={0}>
+        {(provided, snapshot) =>
+            <div />
+        }
+    </Draggable>
+}
+"""
+
 MATCH_PATTERN_LITERAL = """\
 fn _test(x: boolean) -> string {
     match x {

--- a/tests/lsp/test_hover.py
+++ b/tests/lsp/test_hover.py
@@ -349,6 +349,20 @@ class TestHoverRecordSpread:
         assert h is not None, f"Expected hover for pattern binding u, got None"
         assert "User" in h, f"Expected User type for pattern binding, got: {h}"
 
+    def test_lambda_param_shows_type(self, lsp):
+        open_doc(lsp, URI, F.LAMBDA_PARAM)
+        # Hover on 'item' in lambda param (line 1, col 30)
+        h = hover_text(lsp.hover(URI, 1, 30))
+        assert h is not None, f"Expected hover for lambda param item, got None"
+        assert "number" in h, f"Expected number type for lambda param, got: {h}"
+
+    def test_jsx_render_prop_param_shows_type(self, lsp):
+        open_doc(lsp, URI, F.JSX_RENDER_PROP_PARAM)
+        # Hover on 'provided' (line 6, col 10)
+        h = hover_text(lsp.hover(URI, 6, 10))
+        assert h is not None, f"Expected hover for render prop param provided, got None"
+        assert "?T" not in h, f"Render prop param should not show type var, got: {h}"
+
     def test_match_pattern_literal_shows_boolean(self, lsp):
         open_doc(lsp, URI, F.MATCH_PATTERN_LITERAL)
         # Hover on 'true' in match pattern (line 2, col 8)


### PR DESCRIPTION
closes #919

## Summary
The symbol collector didn't traverse into JSX elements, so arrow function params inside JSX children (render props like `{(provided, snapshot) => ...}`) were never indexed. Hover fell through to the typed AST path which showed the arrow's own function type (`(?T0, ?T1) -> JSX.Element`) instead of the parameter's resolved type (`DraggableProvided`).

- Add `collect_jsx` to walk JSX props and children in the symbol collector
- Uses or-pattern for shared Element/Fragment children iteration (matches `walk_jsx_mut` style)

## Test plan
- [x] All 233 LSP tests pass (2 new: lambda param hover, JSX render prop param hover)
- [x] All 1233 lib tests pass
- [x] floe fmt/check/build on example apps - all pass