### PR TITLE
fix: [#927] LSP completions missing for resolved Foreign types

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -554,6 +554,22 @@ impl Checker {
             }
         }
 
+        // Generate __field_ entries for DTS Object types (npm interfaces/types)
+        // so dot-completions work for Foreign types like DraggableProvided.
+        for exports in self.dts_imports.values() {
+            for export in exports {
+                if let interop::TsType::Object(fields) = &export.ts_type {
+                    for field in fields {
+                        let field_ty = interop::wrap_boundary_type(&field.ty);
+                        self.name_types.insert(
+                            format!("__field_{}_{}", export.name, field.name),
+                            field_ty.to_string(),
+                        );
+                    }
+                }
+            }
+        }
+
         // Second pass: check all items
         for item in &program.items {
             self.check_item(item);


### PR DESCRIPTION
closes #927

## Summary
Generate `__field_` entries in `name_types` for DTS Object types (npm interfaces) so dot-completions suggest their fields. When `dts_imports` contains types like `DraggableProvided { draggableProps, dragHandleProps, innerRef }`, the checker now creates `__field_DraggableProvided_draggableProps` etc., which the completion engine already knows how to use.

## Test plan
- [x] All 1234 lib tests pass
- [x] All 233 LSP tests pass (including 6 dot-completion tests)
- [x] floe fmt/check/build on example apps - all pass