### PR TITLE
fix: [#933] Formatter destroys object destructuring rename syntax

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -310,6 +310,52 @@ impl<'src> Formatter<'src> {
         self.collect_idents_until(node, |k| k == SyntaxKind::L_PAREN)
     }
 
+    /// Collect destructuring fields before `=`, preserving `field: alias` renames.
+    /// Returns e.g. `["data: issues", "isLoading: loading"]` or `["name", "age"]`.
+    pub(crate) fn collect_destructure_fields(&self, node: &SyntaxNode) -> Vec<String> {
+        let mut fields = Vec::new();
+        let mut current_field: Option<String> = None;
+        let mut saw_colon = false;
+
+        for t in node.children_with_tokens() {
+            if let Some(tok) = t.as_token() {
+                match tok.kind() {
+                    SyntaxKind::EQUAL => break,
+                    SyntaxKind::IDENT => {
+                        if saw_colon {
+                            // This is the alias after ':'
+                            if let Some(ref mut field) = current_field {
+                                field.push_str(": ");
+                                field.push_str(tok.text());
+                            }
+                            saw_colon = false;
+                        } else {
+                            // Push previous field if any
+                            if let Some(field) = current_field.take() {
+                                fields.push(field);
+                            }
+                            current_field = Some(tok.text().to_string());
+                        }
+                    }
+                    SyntaxKind::COLON => {
+                        saw_colon = true;
+                    }
+                    SyntaxKind::COMMA => {
+                        if let Some(field) = current_field.take() {
+                            fields.push(field);
+                        }
+                        saw_colon = false;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        if let Some(field) = current_field {
+            fields.push(field);
+        }
+        fields
+    }
+
     pub(crate) fn collect_idents_before_eq(&self, node: &SyntaxNode) -> Vec<String> {
         self.collect_idents_until(node, |k| k == SyntaxKind::EQUAL)
     }

--- a/src/formatter/items.rs
+++ b/src/formatter/items.rs
@@ -133,8 +133,8 @@ impl Formatter<'_> {
             self.write("]");
         } else if has_lbrace_before_eq {
             self.write("{ ");
-            let idents = self.collect_idents_before_eq(node);
-            self.write(&idents.join(", "));
+            let fields = self.collect_destructure_fields(node);
+            self.write(&fields.join(", "));
             self.write(" }");
         } else if has_lparen_before_eq {
             self.write("(");

--- a/src/formatter/tests.rs
+++ b/src/formatter/tests.rs
@@ -681,3 +681,29 @@ fn format_member_keyword_names() {
     assert_fmt("Array.for(items)", "Array.for(items)");
     assert_fmt("Schema.type(x)", "Schema.type(x)");
 }
+
+// ── Object destructuring ────────────────────────────────────
+
+#[test]
+fn format_object_destructure_preserves_rename() {
+    assert_fmt(
+        "const { data: issues, isLoading: loading } = hook()",
+        "const { data: issues, isLoading: loading } = hook()",
+    );
+}
+
+#[test]
+fn format_object_destructure_without_rename() {
+    assert_fmt(
+        "const {  data ,  columns  } = hook()",
+        "const { data, columns } = hook()",
+    );
+}
+
+#[test]
+fn format_object_destructure_mixed() {
+    assert_fmt(
+        "const { data: items, isLoading } = hook()",
+        "const { data: items, isLoading } = hook()",
+    );
+}


### PR DESCRIPTION
closes #933

## Summary
The formatter converted `const { data: columns } = expr` into `const { data, columns } = expr`, silently changing semantics from a rename to destructuring two separate fields. This caused cascading errors (duplicate bindings, wrong field names).

Root cause: `collect_idents_before_eq` only collected IDENT tokens, ignoring colons. New `collect_destructure_fields` preserves `field: alias` pairs.

## Test plan
- [x] All 1239 lib tests pass (3 new formatter tests)
- [x] cargo clippy clean
- [x] floe fmt/check on example apps - all pass