### PR TITLE
docs: [#937] Document Option.map for optional JSX rendering

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -251,6 +251,10 @@ match url {
   {match state { Submitting -> "Sending...", _ -> "Send" }}
 </Button>
 
+// Optional rendering — Option<JSX.Element> works as a JSX child
+// None compiles to undefined, which React ignores
+{user.nickname |> Option.map((nick) => <Badge>{nick}</Badge>)}
+
 ```
 
 Match uses `->` for arms (not `=>`), so it's visually distinct from closures.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -638,6 +638,11 @@ export fn App() -> JSX.Element {
     </div>
 }
 
+// Optional rendering — Option.map renders if present, nothing if absent
+// (None compiles to undefined, which React ignores)
+{user.nickname |> Option.map((nick) => <span className="badge">{nick}</span>)}
+// Replaces the TS pattern {x && <Comp />} without truthiness pitfalls
+
 // JSX spread attributes — forward all props
 export fn Card(props: CardProps) -> JSX.Element {
     <div {...props} className="card" />

--- a/docs/site/src/content/docs/docs/guide/from-typescript.md
+++ b/docs/site/src/content/docs/docs/guide/from-typescript.md
@@ -24,6 +24,7 @@ Floe is designed to be familiar to TypeScript developers.
 | `===` | `==` | `==` compiles to `===` |
 | `switch` | `match` | Exhaustive, no fall-through |
 | `try/catch` | `try` expression | `const result = try parseYaml(input)` |
+| `{x && <Comp />}` | `Option.map` | `{x \|> Option.map((v) => <Comp v={v} />)}` |
 | `T \| null` | `Option<T>` | `Some(value)` / `None` |
 | `throw` | `Result<T, E>` | `Ok(value)` / `Err(error)` |
 

--- a/docs/site/src/content/docs/docs/guide/jsx.md
+++ b/docs/site/src/content/docs/docs/guide/jsx.md
@@ -53,6 +53,19 @@ Use `match` expressions:
 </div>
 ```
 
+### Optional Rendering
+
+For the common "render if present, nothing if absent" pattern, use `Option.map`. Since `None` compiles to `undefined` and React ignores `undefined` children, `Option<JSX.Element>` works directly in JSX:
+
+```floe
+// Instead of matching with a None -> <></> arm:
+<div>
+  {user.nickname |> Option.map((nick) => <span className="badge">{nick}</span>)}
+</div>
+```
+
+This replaces the TypeScript `{x && <Component />}` pattern, without the [truthiness pitfalls](https://react.dev/learn/conditional-rendering#logical-and-operator-) (e.g. `{count && <Tag />}` rendering `0`).
+
 ## Lists
 
 Use pipes with `map`:

--- a/docs/site/src/content/docs/docs/reference/stdlib/option.md
+++ b/docs/site/src/content/docs/docs/reference/stdlib/option.md
@@ -70,6 +70,12 @@ const rows = data |> Option.unwrapOr([])
 // Collect all Options
 const allNames = [Some("Alice"), Some("Bob"), None]
   |> Option.all   // None (one is missing)
+
+// Optional JSX rendering — render if present, nothing if absent
+<div>
+  {user.nickname |> Option.map((nick) => <Badge>{nick}</Badge>)}
+</div>
+// None renders nothing (undefined is ignored by React)
 ```
 
 ## Guard Pattern


### PR DESCRIPTION
closes #937

## Summary

- **`docs/guide/jsx.md`** — added "Optional Rendering" section showing `Option.map` pattern, with note about truthiness pitfalls it avoids
- **`docs/reference/stdlib/option.md`** — added JSX example to the examples section
- **`docs/guide/from-typescript.md`** — added `{x && <Comp />}` → `Option.map` row to the migration table
- **`docs/llms.txt`** — added optional rendering example in JSX section
- **`docs/design.md`** — added optional rendering note in match/JSX section

No compiler changes needed — `Option<JSX.Element>` already works as a JSX child since `None` compiles to `undefined` and React ignores it. This was just undocumented.

## Test plan

- [x] Verified `floe check` and `floe build` both pass with `Option.map` in JSX children
- [x] Verified generated TypeScript output is correct (`item !== undefined ? f(item) : undefined`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)