### PR TITLE
fix: [#935] Checker accepts non-Option/Result/Array values in stdlib calls without error

### DIFF
--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -615,7 +615,8 @@ impl Checker {
             let mut type_var_bindings: HashMap<usize, Type> = HashMap::new();
             let mut arg_count = 0;
 
-            // Pass 1: check non-arrow args and unify with stdlib param types
+            // Pass 1: check non-arrow args and collect type var bindings
+            let mut non_arrow_args: Vec<(usize, Type, Span)> = Vec::new();
             for (i, arg) in args.iter().enumerate() {
                 let (Arg::Positional(e) | Arg::Named { value: e, .. }) = arg;
                 if !matches!(e.kind, ExprKind::Arrow { .. }) {
@@ -627,7 +628,28 @@ impl Checker {
                             &mut type_var_bindings,
                         );
                     }
+                    non_arrow_args.push((i, actual_ty, e.span));
                     arg_count += 1;
+                }
+            }
+
+            // Validate non-arrow args against fully-resolved param types
+            for &(i, ref actual_ty, arg_span) in &non_arrow_args {
+                if let Some(param_ty) = stdlib_params.get(i) {
+                    let resolved_param = Self::substitute_type_vars(param_ty, &type_var_bindings);
+                    if !self.types_compatible(&resolved_param, actual_ty) {
+                        self.emit_error(
+                            format!(
+                                "argument {} to `{display}`: expected `{}`, found `{}`",
+                                i + 1,
+                                resolved_param,
+                                actual_ty
+                            ),
+                            arg_span,
+                            ErrorCode::TypeMismatch,
+                            format!("expected `{}`", resolved_param),
+                        );
+                    }
                 }
             }
 

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -4767,6 +4767,196 @@ fn stdlib_call_correct_arity_ok() {
     );
 }
 
+// ── Stdlib argument type validation ────────────────────
+
+#[test]
+fn stdlib_option_map_rejects_non_option_direct_call() {
+    let diags = check(r#"const _x = Option.map("hello", (s) => s)"#);
+    assert!(
+        has_error(&diags, ErrorCode::TypeMismatch),
+        "Option.map with string first arg should error, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn stdlib_option_map_rejects_non_option_pipe() {
+    let diags = check(r#"const _x = "hello" |> Option.map((s) => s)"#);
+    assert!(
+        has_error(&diags, ErrorCode::TypeMismatch),
+        "piping string into Option.map should error, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn stdlib_option_unwrap_or_rejects_non_option_pipe() {
+    let diags = check(r#"const _x = "hello" |> Option.unwrapOr("")"#);
+    assert!(
+        has_error(&diags, ErrorCode::TypeMismatch),
+        "piping string into Option.unwrapOr should error, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn stdlib_option_is_some_rejects_non_option() {
+    let diags = check("const _x = Option.isSome(42)");
+    assert!(
+        has_error(&diags, ErrorCode::TypeMismatch),
+        "Option.isSome with number should error, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn stdlib_result_map_rejects_non_result() {
+    let diags = check(r#"const _x = Result.map("hello", (s) => s)"#);
+    assert!(
+        has_error(&diags, ErrorCode::TypeMismatch),
+        "Result.map with string first arg should error, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn stdlib_result_is_ok_rejects_non_result() {
+    let diags = check("const _x = Result.isOk(42)");
+    assert!(
+        has_error(&diags, ErrorCode::TypeMismatch),
+        "Result.isOk with number should error, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn stdlib_array_sort_rejects_non_array() {
+    let diags = check("const _x = Array.sort(42)");
+    assert!(
+        has_error(&diags, ErrorCode::TypeMismatch),
+        "Array.sort with number should error, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn stdlib_array_map_rejects_non_array_pipe() {
+    let diags = check("const _x = 42 |> Array.map((n) => n)");
+    assert!(
+        has_error(&diags, ErrorCode::TypeMismatch),
+        "piping number into Array.map should error, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn stdlib_option_map_accepts_valid_option() {
+    let diags = check("const _x = Option.map(Some(1), (n) => n * 2)");
+    assert!(
+        !has_error(&diags, ErrorCode::TypeMismatch),
+        "Option.map with Some value should not error, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn stdlib_option_map_accepts_valid_option_pipe() {
+    let diags = check("const _x = Some(1) |> Option.map((n) => n * 2)");
+    assert!(
+        !has_error(&diags, ErrorCode::TypeMismatch),
+        "piping Some into Option.map should not error, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn stdlib_array_map_accepts_valid_array() {
+    let diags = check("const _x = Array.map([1, 2, 3], (n) => n * 2)");
+    assert!(
+        !has_error(&diags, ErrorCode::TypeMismatch),
+        "Array.map with array should not error, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn stdlib_implicit_some_wrapping_still_works_for_concrete_option_params() {
+    // Functions that take Option<concrete_type> should still accept bare values
+    let diags = check(
+        r#"
+        fn foo(x: Option<number>) -> Option<number> { x }
+        const _x = foo(42)
+    "#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::TypeMismatch),
+        "implicit Some wrapping for concrete Option params should still work, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn stdlib_string_split_rejects_wrong_type() {
+    let diags = check("const _x = String.split(42, \",\")");
+    assert!(
+        has_error(&diags, ErrorCode::TypeMismatch),
+        "String.split with number should error, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
 // ── For-block method resolution with multiple overloads ──
 
 #[test]

--- a/src/checker/type_compat.rs
+++ b/src/checker/type_compat.rs
@@ -235,10 +235,16 @@ impl Checker {
                     _ => true,
                 }
             }
-            // A concrete value T is assignable to Option<T> (implicit Some wrapping)
+            // A concrete value T is assignable to Option<T> (implicit Some wrapping),
+            // but not when the inner type is an unresolved type variable — that would
+            // make any value match Option<Var(0)> in stdlib signatures.
             (expected, actual) if expected.is_option() => {
                 if let Some(inner) = expected.option_inner() {
-                    self.types_compatible(inner, actual)
+                    if matches!(inner, Type::Var(_)) {
+                        false
+                    } else {
+                        self.types_compatible(inner, actual)
+                    }
                 } else {
                     true
                 }


### PR DESCRIPTION
closes #935

## Summary

- The checker was not validating argument types for stdlib function calls in either direct-call or pipe syntax
- `Option.map("hello", ...)`, `Result.isOk(42)`, `Array.sort(42)` all silently accepted wrong types
- Root cause: the direct-call path only checked arity (never called `types_compatible`), and the implicit Some wrapping rule in `types_compatible` matched any value against `Option<Var(0)>` because unresolved type variables always returned true

## Changes

- **`src/checker/expr.rs`**: After collecting all type var bindings in Pass 1, validate each non-arrow argument against its fully-resolved parameter type
- **`src/checker/type_compat.rs`**: Block implicit Some wrapping when the Option's inner type is an unresolved type variable (`Var(_)`)
- **`src/checker/tests.rs`**: 13 new tests covering Option, Result, Array, and String stdlib validation (both rejection and acceptance)

## Test plan

- [x] All 13 new stdlib type validation tests pass
- [x] Implicit Some wrapping still works for concrete `Option<T>` params
- [x] `cargo clippy -- -D warnings` clean
- [x] `RUSTFLAGS="-D warnings" cargo test` — all tests pass
- [x] `floe fmt/check/build` on both example apps — no errors
- [x] 233 LSP integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)