### PR TITLE
feat: [#938] LSP hover on pipe operator shows the piped value type

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -49,6 +49,30 @@ fn find_expr_type_at_offset(program: &Program, offset: usize) -> Option<(usize, 
     best
 }
 
+/// Find the type of the left-hand side of a pipe expression at the given offset.
+/// Used for hover on `|>` to show what value is being piped.
+fn find_pipe_input_type_at_offset(program: &Program, offset: usize) -> Option<Type> {
+    use crate::parser::ast::{Expr, ExprKind};
+
+    let mut best: Option<(usize, Type)> = None;
+
+    let mut check = |expr: &Expr| {
+        if let ExprKind::Pipe { left, .. } = &expr.kind
+            && offset >= expr.span.start
+            && offset <= expr.span.end
+            && !matches!(left.ty, Type::Unknown)
+        {
+            let width = expr.span.end - expr.span.start;
+            if best.as_ref().is_none_or(|(w, _)| width < *w) {
+                best = Some((width, left.ty.clone()));
+            }
+        }
+    };
+
+    crate::walk::walk_program(program, &mut check);
+    best.map(|(_, ty)| ty)
+}
+
 // ── Helpers ─────────────────────────────────────────────────────
 
 fn offset_to_range(source: &str, start: usize, end: usize) -> Range {

--- a/src/lsp/hover.rs
+++ b/src/lsp/hover.rs
@@ -21,6 +21,25 @@ impl FloeLsp {
         let word = word_at_offset(&doc.content, offset);
 
         if word.is_empty() {
+            // Check for pipe operator `|>` at cursor
+            let bytes = doc.content.as_bytes();
+            let is_pipe = (offset > 0
+                && offset < bytes.len()
+                && bytes[offset - 1] == b'|'
+                && bytes[offset] == b'>')
+                || (offset + 1 < bytes.len() && bytes[offset] == b'|' && bytes[offset + 1] == b'>');
+            if is_pipe
+                && let Some(ref typed_program) = doc.typed_program
+                && let Some(pipe_ty) = super::find_pipe_input_type_at_offset(typed_program, offset)
+            {
+                return Ok(Some(Hover {
+                    contents: HoverContents::Markup(MarkupContent {
+                        kind: MarkupKind::Markdown,
+                        value: format!("```floe\n|> {pipe_ty}\n```\nPipe input type"),
+                    }),
+                    range: None,
+                }));
+            }
             return Ok(None);
         }
 
@@ -201,9 +220,7 @@ impl FloeLsp {
             "match" => {
                 "```floe\nmatch expr { pattern -> body, ... }\n```\nExhaustive pattern matching expression."
             }
-            "|>" => {
-                "```floe\nexpr |> function\n```\nPipe operator: passes left side as first argument to right side."
-            }
+            // Note: |> is handled earlier (before empty word check) since it's not a word char
             "todo" => "```floe\ntodo\n```\nPlaceholder for unfinished code. Throws at runtime.",
             "unreachable" => {
                 "```floe\nunreachable\n```\nAsserts a code path is impossible. Throws at runtime."

--- a/tests/lsp/fixtures.py
+++ b/tests/lsp/fixtures.py
@@ -864,3 +864,8 @@ fn _test(x: boolean) -> string {
     }
 }
 """
+
+PIPE_HOVER = """\
+const items = [1, 2, 3]
+const _result = items |> map((x) => x + 1) |> Array.length
+"""

--- a/tests/lsp/test_hover.py
+++ b/tests/lsp/test_hover.py
@@ -363,6 +363,20 @@ class TestHoverRecordSpread:
         assert h is not None, f"Expected hover for render prop param provided, got None"
         assert "?T" not in h, f"Render prop param should not show type var, got: {h}"
 
+    def test_pipe_hover_shows_input_type(self, lsp):
+        open_doc(lsp, URI, F.PIPE_HOVER)
+        # First |> at col 22: items (Array<number>) is being piped
+        h = hover_text(lsp.hover(URI, 1, 22))
+        assert h is not None, f"Expected hover for pipe operator, got None"
+        assert "Array" in h, f"Pipe hover should show Array type, got: {h}"
+
+    def test_pipe_hover_second_pipe_shows_mapped_type(self, lsp):
+        open_doc(lsp, URI, F.PIPE_HOVER)
+        # Second |> at col 43: map result (Array<number>) is being piped
+        h = hover_text(lsp.hover(URI, 1, 43))
+        assert h is not None, f"Expected hover for second pipe, got None"
+        assert "Array" in h, f"Second pipe should show Array type, got: {h}"
+
     def test_match_pattern_literal_shows_boolean(self, lsp):
         open_doc(lsp, URI, F.MATCH_PATTERN_LITERAL)
         # Hover on 'true' in match pattern (line 2, col 8)


### PR DESCRIPTION
closes #938

## Summary
Hovering over `|>` now shows the type of the value being piped into the next step:

```floe
items |> filter(.active) |> map(.name) |> Array.join(", ")
//    ^                  ^             ^
//    Array<Item>        Array<string> string
```

Detects the pipe operator token before the empty-word early return, finds the narrowest Pipe expression at the cursor, and displays `left.ty`.

## Test plan
- [x] All 1239 lib tests pass
- [x] All 235 LSP tests pass (2 new pipe hover tests)
- [x] cargo clippy clean