### PR TITLE
fix: [#906] Dot shorthand with captured variables resolves outer references as unknown

### DIFF
--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -5835,6 +5835,41 @@ const _r = find(users, .name == "a")
     assert!(diags.is_empty(), "expected no errors, got: {diags:?}");
 }
 
+#[test]
+fn dot_shorthand_predicate_with_captured_variable() {
+    let diags = check(
+        r#"
+type Column { id: string }
+type Issue { status_name: string }
+const columns: Array<Column> = [Column(id: "todo")]
+const issue = Issue(status_name: "todo")
+const _r = columns |> Array.find(.id == issue.status_name)
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "captured variable in dot shorthand predicate should not resolve as unknown, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn dot_shorthand_predicate_with_function_call_rhs() {
+    let diags = check(
+        r#"
+type User { name: string, active: boolean }
+fn getName() -> string { "alice" }
+const users: Array<User> = [User(name: "alice", active: true)]
+const _r = users |> Array.find(.name == getName())
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "function call on rhs of dot shorthand should work, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
 // ── Bug #804: Suggest try await instead of await try ────────
 
 #[test]

--- a/src/cst/exprs.rs
+++ b/src/cst/exprs.rs
@@ -570,7 +570,7 @@ impl<'src> CstParser<'src> {
         {
             self.bump(); // operator
             self.eat_trivia();
-            self.parse_primary_expr();
+            self.parse_postfix_expr();
         }
 
         self.builder.finish_node();


### PR DESCRIPTION
closes #906

## Summary

- `.id == issue.status_name` in dot shorthand predicates failed because the parser used `parse_primary_expr()` for the RHS, which only parsed `issue` and dropped the `.status_name` member access
- Changed to `parse_postfix_expr()` so member access (`obj.field`) and function calls (`fn()`) work correctly on the RHS of dot shorthand predicates

## Root cause

In `src/cst/exprs.rs`, `parse_dot_shorthand()` called `parse_primary_expr()` for the expression after the binary operator. Primary expressions only handle literals, identifiers, and simple constructs — not postfix operations like `.field` or `()`. So `issue.status_name` was parsed as just `issue`, and the `.status_name` was silently dropped.

## Test plan

- [x] New test: dot shorthand with captured variable member access
- [x] New test: dot shorthand with function call RHS
- [x] Existing dot shorthand tests still pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `RUSTFLAGS="-D warnings" cargo test` — all tests pass
- [x] `floe fmt/check/build` on both example apps — no errors
- [x] 235 LSP integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)