### PR TITLE
feat: [#949] [#950] Add Promise.tryAwait and warn on try-on-Promise

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -400,10 +400,14 @@ items |> Array.dropWhile(.done)                   // drop while predicate holds
 
 // Promise helpers
 // Promise.await: Promise<T> -> T (compiles to await, infers async on enclosing fn)
+// Promise.tryAwait: Promise<T> -> Result<T, Error> (await + catch rejections)
 const users = Promise.all([fetchUser(1), fetchUser(2)]) |> Promise.await
 const fastest = Promise.race([fetchFromCDN(url), fetchFromOrigin(url)]) |> Promise.await
 const results = Promise.allSettled([fetchA(), fetchB()]) |> Promise.await  // Array<Result<T, Error>>
 Promise.delay(1000) |> Promise.await   // wait 1 second
+
+// Promise.tryAwait for npm interop — catches async rejections as Result
+const result = npmAsyncFn() |> Promise.tryAwait   // Result<T, Error>
 
 // parse<T> — compiler built-in for runtime type validation
 // No runtime library needed — the compiler inlines the checks

--- a/docs/site/src/content/docs/docs/reference/stdlib/promise.md
+++ b/docs/site/src/content/docs/docs/reference/stdlib/promise.md
@@ -11,6 +11,7 @@ Functions for working with `Promise<T>` values.
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `Promise.await` | `Promise<T> -> T` | Unwrap a Promise (compiles to `await`) |
+| `Promise.tryAwait` | `Promise<T> -> Result<T, Error>` | Await + catch rejections in one step |
 | `Promise.all` | `Array<Promise<T>> -> Promise<Array<T>>` | Wait for all, fail on first rejection |
 | `Promise.race` | `Array<Promise<T>> -> Promise<T>` | First to settle (resolve or reject) |
 | `Promise.any` | `Array<Promise<T>> -> Promise<T>` | First to resolve, fail if all reject |
@@ -32,6 +33,25 @@ fn fetchUser(id: string) -> Promise<User> {
 ```
 
 The return type must explicitly use `Promise<T>`, making async behavior visible to callers.
+
+## `Promise.tryAwait`
+
+`Promise.tryAwait` awaits a Promise and catches any rejection, returning a `Result<T, Error>`. Use it for npm/Tauri interop where async functions might reject:
+
+```floe
+// npm function that returns Promise<void> and might reject
+const result = jiraApi.transitionIssue(id, tid) |> Promise.tryAwait
+
+match result {
+    Ok(_) -> Console.log("Moved!"),
+    Err(e) -> Console.error("Failed:", e),
+}
+```
+
+| Pattern | Use case |
+|---|---|
+| `\|> Promise.await?` | Floe functions returning `Promise<Result<T, E>>` |
+| `\|> Promise.tryAwait` | npm/external calls returning `Promise<T>` that might reject |
 
 ## Examples
 

--- a/src/checker/error_codes.rs
+++ b/src/checker/error_codes.rs
@@ -109,6 +109,8 @@ pub enum ErrorCode {
     SuspiciousBinding,
     /// Binding resolved to `unknown` type.
     UnknownBinding,
+    /// `try` applied to a `Promise` — only catches sync errors.
+    TryOnPromise,
 }
 
 impl ErrorCode {
@@ -158,6 +160,7 @@ impl ErrorCode {
             Self::UncheckedArguments => "W004",
             Self::SuspiciousBinding => "W005",
             Self::UnknownBinding => "W006",
+            Self::TryOnPromise => "W007",
         }
     }
 }

--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -93,6 +93,15 @@ impl Checker {
             ExprKind::Try(inner) => {
                 let inner_ty =
                     self.with_context(|ctx| ctx.inside_try = true, |this| this.check_expr(inner));
+                if matches!(inner_ty, Type::Promise(_)) {
+                    self.emit_warning_with_help(
+                        "`try` on a `Promise` only catches synchronous errors",
+                        expr.span,
+                        ErrorCode::TryOnPromise,
+                        "async rejections will not be caught",
+                        "use `|> Promise.tryAwait` to catch both sync and async errors",
+                    );
+                }
                 Type::result_of(inner_ty, Type::Named(type_layout::TYPE_ERROR.to_string()))
             }
             ExprKind::Parse { type_arg, value } => {

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -2935,6 +2935,44 @@ fn test() -> Result<string, Error> {
     );
 }
 
+// ── Promise.tryAwait ────────────────────────────────────────
+
+#[test]
+fn try_on_promise_warns() {
+    // try on a Promise should warn — only catches sync errors
+    let diags = check(
+        r#"
+fn asyncOp() -> Promise<string> { "hello" }
+fn test() {
+    const _r = try asyncOp()
+}
+"#,
+    );
+    assert!(
+        has_error(&diags, ErrorCode::TryOnPromise),
+        "try on Promise should warn, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn try_on_non_promise_no_warning() {
+    // try on a non-Promise should NOT warn
+    let diags = check(
+        r#"
+import trusted { parseData } from "parser"
+fn test() {
+    const _r = try parseData("input")
+}
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::TryOnPromise),
+        "try on non-Promise should not warn, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
 #[test]
 fn try_without_unwrap_gives_result() {
     // try fetch() without ? should give Result<Promise<Response>, Error>

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -645,6 +645,15 @@ fn promise_await_pipe() {
     assert!(result.contains("await fetchData()"));
 }
 
+#[test]
+fn promise_try_await_pipe() {
+    let result = emit_with_types("const _x = fetchData() |> Promise.tryAwait");
+    assert!(
+        result.contains("async") && result.contains("await") && result.contains("ok:"),
+        "Promise.tryAwait should emit async IIFE with try/catch Result, got: {result}"
+    );
+}
+
 // ── Implicit Return ──────────────────────────────────────────
 
 #[test]

--- a/src/stdlib/promise.rs
+++ b/src/stdlib/promise.rs
@@ -7,6 +7,7 @@ pub fn register(fns: &mut Vec<StdlibFn>) {
 
     fns.extend([
         stdlib_fn!("Promise", "await", [promise_of(t.clone())], t.clone(), "await $0"),
+        stdlib_fn!("Promise", "tryAwait", [promise_of(t.clone())], result_of(t.clone(), Type::Named("Error".to_string())), "await (async () => { try { return { ok: true as const, value: await $0 }; } catch (_e) { return { ok: false as const, error: _e instanceof Error ? _e : new Error(String(_e)) }; } })()"),
         stdlib_fn!("Promise", "all", [array_of(promise_of(t.clone()))], promise_of(array_of(t.clone())), "Promise.all($0)"),
         stdlib_fn!("Promise", "race", [array_of(promise_of(t.clone()))], promise_of(t.clone()), "Promise.race($0)"),
         stdlib_fn!("Promise", "any", [array_of(promise_of(t.clone()))], promise_of(t.clone()), "Promise.any($0)"),


### PR DESCRIPTION
closes #949
closes #950

## Summary

- **`Promise.tryAwait`** stdlib function: `Promise<T> -> Result<T, Error>` — awaits a Promise and catches rejections in one step. For npm/Tauri interop where async functions might reject.
- **`TryOnPromise` warning (W007)**: when `try` is applied to a `Promise<T>` expression, warns that only sync errors are caught and suggests `Promise.tryAwait`.

### Before (bug: async rejections unhandled)
```floe
const result = try jiraApi.transitionIssue(id, tid)
// result: Result<Promise<()>, Error> — Promise rejection not caught!
```

### After
```floe
const result = jiraApi.transitionIssue(id, tid) |> Promise.tryAwait
// result: Result<(), Error> — both sync and async errors caught
```

| Pattern | Use case |
|---|---|
| `\|> Promise.await?` | Floe functions returning `Promise<Result<T, E>>` |
| `\|> Promise.tryAwait` | npm/external calls returning `Promise<T>` that might reject |

## Test plan

- [x] `try_on_promise_warns` — warns when try wraps Promise
- [x] `try_on_non_promise_no_warning` — no false positives
- [x] `promise_try_await_pipe` — codegen emits async IIFE try/catch
- [x] All 1300 tests pass, clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)