### PR TITLE
feat: [#958] Smart try - auto-await Promises, remove Promise.tryAwait

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -400,14 +400,13 @@ items |> Array.dropWhile(.done)                   // drop while predicate holds
 
 // Promise helpers
 // Promise.await: Promise<T> -> T (compiles to await, infers async on enclosing fn)
-// Promise.tryAwait: Promise<T> -> Result<T, Error> (await + catch rejections)
 const users = Promise.all([fetchUser(1), fetchUser(2)]) |> Promise.await
 const fastest = Promise.race([fetchFromCDN(url), fetchFromOrigin(url)]) |> Promise.await
 const results = Promise.allSettled([fetchA(), fetchB()]) |> Promise.await  // Array<Result<T, Error>>
 Promise.delay(1000) |> Promise.await   // wait 1 second
 
-// Promise.tryAwait for npm interop — catches async rejections as Result
-const result = npmAsyncFn() |> Promise.tryAwait   // Result<T, Error>
+// Smart try: auto-awaits Promises for npm interop
+const result = try npmAsyncFn()   // Result<T, Error> — awaits + catches rejections
 
 // parse<T> — compiler built-in for runtime type validation
 // No runtime library needed — the compiler inlines the checks

--- a/docs/site/src/content/docs/docs/reference/stdlib/promise.md
+++ b/docs/site/src/content/docs/docs/reference/stdlib/promise.md
@@ -11,7 +11,6 @@ Functions for working with `Promise<T>` values.
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `Promise.await` | `Promise<T> -> T` | Unwrap a Promise (compiles to `await`) |
-| `Promise.tryAwait` | `Promise<T> -> Result<T, Error>` | Await + catch rejections in one step |
 | `Promise.all` | `Array<Promise<T>> -> Promise<Array<T>>` | Wait for all, fail on first rejection |
 | `Promise.race` | `Array<Promise<T>> -> Promise<T>` | First to settle (resolve or reject) |
 | `Promise.any` | `Array<Promise<T>> -> Promise<T>` | First to resolve, fail if all reject |
@@ -34,13 +33,14 @@ fn fetchUser(id: string) -> Promise<User> {
 
 The return type must explicitly use `Promise<T>`, making async behavior visible to callers.
 
-## `Promise.tryAwait`
+## Smart `try` with Promises
 
-`Promise.tryAwait` awaits a Promise and catches any rejection, returning a `Result<T, Error>`. Use it for npm/Tauri interop where async functions might reject:
+When `try` is applied to a `Promise<T>` expression, it auto-awaits the Promise and catches both sync throws and async rejections:
 
 ```floe
-// npm function that returns Promise<void> and might reject
-const result = jiraApi.transitionIssue(id, tid) |> Promise.tryAwait
+// npm async function that might reject
+const result = try jiraApi.transitionIssue(id, tid)
+// Result<(), Error> — auto-awaited, rejections caught
 
 match result {
     Ok(_) -> Console.log("Moved!"),
@@ -48,10 +48,10 @@ match result {
 }
 ```
 
-| Pattern | Use case |
-|---|---|
-| `\|> Promise.await?` | Floe functions returning `Promise<Result<T, E>>` |
-| `\|> Promise.tryAwait` | npm/external calls returning `Promise<T>` that might reject |
+| Tool | For | Does |
+|---|---|---|
+| `Promise.await` | Floe async functions | Unwrap `Promise<Result<T, E>>`, use `?` for errors |
+| `try` | npm/trusted functions | Catch errors (auto-awaits if Promise), returns `Result<T, Error>` |
 
 ## Examples
 

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -55,7 +55,7 @@ pub fn mark_async_functions(program: &mut Program) {
 }
 
 /// Check if an expression body contains a `Promise.await` member access
-/// at any depth (including inside pipes, calls, blocks, etc.)
+/// or a `try` on a Promise-typed expression (smart try auto-awaits).
 fn body_has_promise_await(expr: &Expr) -> bool {
     fn walk(expr: &Expr) -> bool {
         match &expr.kind {
@@ -65,6 +65,8 @@ fn body_has_promise_await(expr: &Expr) -> bool {
             {
                 true
             }
+            // Smart try: `try promiseExpr` auto-awaits, making the function async
+            ExprKind::Try(inner) if matches!(inner.ty, Type::Promise(_)) => true,
             ExprKind::Call { callee, args, .. } => {
                 walk(callee)
                     || args.iter().any(|a| match a {

--- a/src/checker/error_codes.rs
+++ b/src/checker/error_codes.rs
@@ -109,8 +109,6 @@ pub enum ErrorCode {
     SuspiciousBinding,
     /// Binding resolved to `unknown` type.
     UnknownBinding,
-    /// `try` applied to a `Promise` — only catches sync errors.
-    TryOnPromise,
 }
 
 impl ErrorCode {
@@ -160,7 +158,6 @@ impl ErrorCode {
             Self::UncheckedArguments => "W004",
             Self::SuspiciousBinding => "W005",
             Self::UnknownBinding => "W006",
-            Self::TryOnPromise => "W007",
         }
     }
 }

--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -93,16 +93,16 @@ impl Checker {
             ExprKind::Try(inner) => {
                 let inner_ty =
                     self.with_context(|ctx| ctx.inside_try = true, |this| this.check_expr(inner));
-                if matches!(inner_ty, Type::Promise(_)) {
-                    self.emit_warning_with_help(
-                        "`try` on a `Promise` only catches synchronous errors — use `|> Promise.tryAwait` instead",
-                        expr.span,
-                        ErrorCode::TryOnPromise,
-                        "async rejections will not be caught",
-                        "use `|> Promise.tryAwait` to catch both sync and async errors",
-                    );
-                }
-                Type::result_of(inner_ty, Type::Named(type_layout::TYPE_ERROR.to_string()))
+                // Smart try: if the expression is Promise<T>, unwrap to T
+                // (try auto-awaits Promises and catches both sync throws and async rejections)
+                let effective_ty = match &inner_ty {
+                    Type::Promise(inner) => *inner.clone(),
+                    _ => inner_ty,
+                };
+                Type::result_of(
+                    effective_ty,
+                    Type::Named(type_layout::TYPE_ERROR.to_string()),
+                )
             }
             ExprKind::Parse { type_arg, value } => {
                 let t = self.resolve_type(type_arg);

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -2935,40 +2935,22 @@ fn test() -> Result<string, Error> {
     );
 }
 
-// ── Promise.tryAwait ────────────────────────────────────────
+// ── Smart try: auto-awaits Promises ─────────────────────────
 
 #[test]
-fn try_on_promise_warns() {
-    // try on a Promise should warn — only catches sync errors
+fn try_on_promise_unwraps_to_result_of_inner() {
+    // try on Promise<string> should give Result<string, Error>, not Result<Promise<string>, Error>
     let diags = check(
         r#"
 fn asyncOp() -> Promise<string> { "hello" }
-fn test() {
-    const _r = try asyncOp()
+export fn test() -> Result<string, Error> {
+    try asyncOp()
 }
 "#,
     );
     assert!(
-        has_error(&diags, ErrorCode::TryOnPromise),
-        "try on Promise should warn, got: {:?}",
-        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
-    );
-}
-
-#[test]
-fn try_on_non_promise_no_warning() {
-    // try on a non-Promise should NOT warn
-    let diags = check(
-        r#"
-import trusted { parseData } from "parser"
-fn test() {
-    const _r = try parseData("input")
-}
-"#,
-    );
-    assert!(
-        !has_error(&diags, ErrorCode::TryOnPromise),
-        "try on non-Promise should not warn, got: {:?}",
+        !has_error_containing(&diags, "expected return type"),
+        "try on Promise<string> should produce Result<string, Error>, got: {:?}",
         diags.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -11,6 +11,7 @@ mod types;
 
 use std::collections::{HashMap, HashSet};
 
+use crate::checker::Type;
 use crate::parser::ast::*;
 use crate::resolve::ResolvedImports;
 use crate::stdlib::StdlibRegistry;

--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -280,17 +280,21 @@ impl Codegen {
 
             // Try: `try expr` → IIFE with try/catch wrapping in Result
             // Non-Error throws are coerced to Error for consistent typing
+            // Smart try: if expr is Promise<T>, auto-await inside the IIFE
             ExprKind::Try(inner) => {
                 let has_await = expr_contains_await(inner);
-                if has_await {
-                    self.push(&format!("await (async () => {{ try {{ return {{ {OK_FIELD}: true as const, {VALUE_FIELD}: "));
+                let is_promise = matches!(inner.ty, Type::Promise(_));
+                if has_await || is_promise {
+                    self.push(&format!("await (async () => {{ try {{ return {{ {OK_FIELD}: true as const, {VALUE_FIELD}: await "));
+                    self.emit_expr(inner);
+                    self.push(&format!(" }}; }} catch (_e) {{ return {{ {OK_FIELD}: false as const, {ERROR_FIELD}: _e instanceof Error ? _e : new Error(String(_e)) }}; }} }})()"));
                 } else {
                     self.push(&format!(
                         "(() => {{ try {{ return {{ {OK_FIELD}: true as const, {VALUE_FIELD}: "
                     ));
+                    self.emit_expr(inner);
+                    self.push(&format!(" }}; }} catch (_e) {{ return {{ {OK_FIELD}: false as const, {ERROR_FIELD}: _e instanceof Error ? _e : new Error(String(_e)) }}; }} }})()"));
                 }
-                self.emit_expr(inner);
-                self.push(&format!(" }}; }} catch (_e) {{ return {{ {OK_FIELD}: false as const, {ERROR_FIELD}: _e instanceof Error ? _e : new Error(String(_e)) }}; }} }})()"));
             }
 
             // parse<T>(value) → validation IIFE

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -646,11 +646,12 @@ fn promise_await_pipe() {
 }
 
 #[test]
-fn promise_try_await_pipe() {
-    let result = emit_with_types("const _x = fetchData() |> Promise.tryAwait");
+fn smart_try_on_promise_emits_async_iife() {
+    let result =
+        emit_with_types("fn asyncOp() -> Promise<string> { \"hi\" }\nconst _x = try asyncOp()");
     assert!(
         result.contains("async") && result.contains("await") && result.contains("ok:"),
-        "Promise.tryAwait should emit async IIFE with try/catch Result, got: {result}"
+        "try on Promise should emit async IIFE with await, got: {result}"
     );
 }
 

--- a/src/stdlib/promise.rs
+++ b/src/stdlib/promise.rs
@@ -7,7 +7,6 @@ pub fn register(fns: &mut Vec<StdlibFn>) {
 
     fns.extend([
         stdlib_fn!("Promise", "await", [promise_of(t.clone())], t.clone(), "await $0"),
-        stdlib_fn!("Promise", "tryAwait", [promise_of(t.clone())], result_of(t.clone(), Type::Named("Error".to_string())), "await (async () => { try { return { ok: true as const, value: await $0 }; } catch (_e) { return { ok: false as const, error: _e instanceof Error ? _e : new Error(String(_e)) }; } })()"),
         stdlib_fn!("Promise", "all", [array_of(promise_of(t.clone()))], promise_of(array_of(t.clone())), "Promise.all($0)"),
         stdlib_fn!("Promise", "race", [array_of(promise_of(t.clone()))], promise_of(t.clone()), "Promise.race($0)"),
         stdlib_fn!("Promise", "any", [array_of(promise_of(t.clone()))], promise_of(t.clone()), "Promise.any($0)"),


### PR DESCRIPTION
closes #958

## Summary

`try` now auto-awaits Promise expressions. One keyword for the npm boundary.

### Before (two tools, confusing)
```floe
const data = try parseYaml(input)                           // sync
const data = jiraApi.getTransitions(id) |> Promise.tryAwait  // async
```

### After (one tool)
```floe
const data = try parseYaml(input)             // sync - catches throw
const data = try jiraApi.getTransitions(id)   // async - auto-awaits + catches rejection
```

Both return `Result<T, Error>`. Compiler sees the type and does the right thing.

**Changes:**
- Checker: `try` on `Promise<T>` returns `Result<T, Error>` (unwraps Promise)
- Codegen: emits async IIFE with `await` when `try` wraps a Promise-typed expression
- `mark_async_functions`: detects `try`-on-Promise for async inference
- Removed `Promise.tryAwait` (redundant)
- Removed `TryOnPromise` warning W007 (no longer needed)

## Test plan
- [x] `try_on_promise_unwraps_to_result_of_inner` - type is `Result<T, Error>` not `Result<Promise<T>, Error>`
- [x] `smart_try_on_promise_emits_async_iife` - codegen emits async IIFE with await
- [x] All 1297 tests pass, clippy clean
- [x] Example apps pass check

🤖 Generated with [Claude Code](https://claude.com/claude-code)