### PR TITLE
feat: [#955] Trusted propagation through member access

### DIFF
--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -95,14 +95,12 @@ impl Checker {
                     self.with_context(|ctx| ctx.inside_try = true, |this| this.check_expr(inner));
 
                 // Warn when try wraps a Floe function call (Floe functions never throw)
-                if let Some(callee_name) = Self::extract_callee_name(inner)
-                    && !self.npm_imports.contains(callee_name)
-                    && !self.stdlib.is_module(callee_name)
+                if let Some(root_name) = Self::extract_call_root_name(inner)
+                    && !self.npm_imports.contains(root_name)
+                    && !self.stdlib.is_module(root_name)
                 {
                     self.emit_warning_with_help(
-                        format!(
-                            "`try` is unnecessary — Floe function `{callee_name}` never throws"
-                        ),
+                        format!("`try` is unnecessary — Floe function `{root_name}` never throws"),
                         expr.span,
                         ErrorCode::TryOnFloeFunction,
                         "Floe functions use `Result` for errors, not exceptions",
@@ -281,14 +279,19 @@ impl Checker {
         }
     }
 
-    /// Extract the callee function name from a call expression (possibly inside pipes).
-    fn extract_callee_name(expr: &Expr) -> Option<&str> {
+    /// Extract the root identifier name from a call expression's callee.
+    /// For `foo(x)` returns "foo", for `obj.method(x)` returns "obj".
+    fn extract_call_root_name(expr: &Expr) -> Option<&str> {
         match &expr.kind {
             ExprKind::Call { callee, .. } => match &callee.kind {
                 ExprKind::Identifier(name) => Some(name),
+                ExprKind::Member { object, .. } => match &object.kind {
+                    ExprKind::Identifier(name) => Some(name),
+                    _ => None,
+                },
                 _ => None,
             },
-            ExprKind::Pipe { right, .. } => Self::extract_callee_name(right),
+            ExprKind::Pipe { right, .. } => Self::extract_call_root_name(right),
             _ => None,
         }
     }
@@ -704,17 +707,31 @@ impl Checker {
         }
 
         // Check for untrusted import call without try
-        if let ExprKind::Identifier(name) = &callee.kind
-            && !self.ctx.inside_try
-            && self.untrusted_imports.contains(name)
-        {
-            self.emit_error_with_help(
-                format!("calling untrusted import `{name}` requires `try`"),
-                span,
-                ErrorCode::UntrustedImport,
-                "untrusted import",
-                format!("use `try {name}(...)` or mark the import as `trusted`"),
-            );
+        if !self.ctx.inside_try {
+            if let ExprKind::Identifier(name) = &callee.kind
+                && self.untrusted_imports.contains(name)
+            {
+                self.emit_error_with_help(
+                    format!("calling untrusted import `{name}` requires `try`"),
+                    span,
+                    ErrorCode::UntrustedImport,
+                    "untrusted import",
+                    format!("use `try {name}(...)` or mark the import as `trusted`"),
+                );
+            }
+            // Trusted propagation: obj.method() where obj is an untrusted import
+            if let ExprKind::Member { object, field } = &callee.kind
+                && let ExprKind::Identifier(obj_name) = &object.kind
+                && self.untrusted_imports.contains(obj_name.as_str())
+            {
+                self.emit_error_with_help(
+                    format!("calling `{obj_name}.{field}` requires `try` — `{obj_name}` is an untrusted import"),
+                    span,
+                    ErrorCode::UntrustedImport,
+                    "untrusted import",
+                    format!("use `try {obj_name}.{field}(...)` or mark the import as `trusted`"),
+                );
+            }
         }
 
         // Save pipe context before checking callee (which would consume it)

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -534,6 +534,74 @@ const _y = fetchUser("id")
     assert!(has_error_containing(&diags, "fetchUser"));
 }
 
+// ── Trusted propagation through member access ──────────────
+
+#[test]
+fn untrusted_member_call_requires_try() {
+    let diags = check(
+        r#"
+import { jiraCommands } from "jira-lib"
+const _r = jiraCommands.getTransitions("id")
+"#,
+    );
+    assert!(
+        has_error(&diags, ErrorCode::UntrustedImport),
+        "member call on untrusted import should require try, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn untrusted_member_call_ok_with_try() {
+    let diags = check(
+        r#"
+import { jiraCommands } from "jira-lib"
+fn test() -> Result<string, Error> {
+    const _r = try jiraCommands.getTransitions("id")
+    Ok("done")
+}
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::UntrustedImport),
+        "try on untrusted member call should be allowed, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn trusted_member_call_no_error() {
+    let diags = check(
+        r#"
+import trusted { jiraCommands } from "jira-lib"
+const _r = jiraCommands.getTransitions("id")
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::UntrustedImport),
+        "member call on trusted import should not error, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn try_on_trusted_member_call_no_floe_warning() {
+    let diags = check(
+        r#"
+import trusted { jiraCommands } from "jira-lib"
+fn test() -> Result<string, Error> {
+    const _r = try jiraCommands.getTransitions("id")
+    Ok("done")
+}
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::TryOnFloeFunction),
+        "try on trusted member call should not warn about Floe function, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
 // ── Constructor field validation ────────────────────────────
 
 #[test]


### PR DESCRIPTION
closes #955

## Summary

Untrusted/trusted status now propagates through member access. If `obj` is from an npm import, `obj.method()` inherits the same trust level.

- `import { jiraCommands } from "jira-lib"` + `jiraCommands.getTransitions()` → **E014 error** (untrusted, needs `try`)
- `import trusted { jiraCommands } from "jira-lib"` + `jiraCommands.getTransitions()` → **no error** (trusted)
- `try jiraCommands.getTransitions()` on trusted import → **no W007 warning** (correctly identified as npm, not Floe)

### Changes
- Extend untrusted import check to handle `Member { object, field }` callee patterns
- Update `extract_call_root_name` to resolve through member access to find the root import name
- TryOnFloeFunction warning correctly skips npm member calls

## Test plan
- [x] `untrusted_member_call_requires_try` — obj.method() on untrusted import errors
- [x] `untrusted_member_call_ok_with_try` — try obj.method() allowed
- [x] `trusted_member_call_no_error` — trusted import member call passes
- [x] `try_on_trusted_member_call_no_floe_warning` — no false W007 warning
- [x] All 1256 tests pass, clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)