### PR TITLE
feat!: [#979] Remove auto-await from untrusted async imports

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1527,14 +1527,14 @@ Automatic conversions at import boundary:
 
 #### Default npm imports (untrusted)
 
-npm imports are untrusted by default — calls are auto-wrapped in `Result<T, Error>`:
+npm imports are untrusted by default — calls are wrapped in `Result<T, Error>`. Async functions (returning `Promise<T>`) are wrapped in `Promise<Result<T, Error>>` — the caller uses `|> await` to unwrap the Promise:
 
 ```floe
 import { parseYaml } from "yaml-lib"
 import { fetchUser } from "api-client"
 
-const data = parseYaml(input)     // Result<unknown, Error> — auto-wrapped
-const user = fetchUser(id)        // Result<User, Error> — auto-wrapped
+const data = parseYaml(input)          // Result<unknown, Error> — sync
+const user = fetchUser(id) |> await    // Promise<Result<User, Error>> → Result<User, Error>
 ```
 
 #### trusted imports
@@ -1549,7 +1549,7 @@ useState(0)                  // direct call, no wrapping
 // Per-function:
 import { trusted capitalize, fetchUser } from "some-ts-lib"
 capitalize("hello")          // string, direct call
-fetchUser(id)                // Result<User, Error> — auto-wrapped (untrusted)
+fetchUser(id) |> await       // Promise<Result<User, Error>> → Result<User, Error>
 ```
 
 #### Untrusted imports with Result and ?
@@ -1566,15 +1566,15 @@ import { parseYaml } from "yaml-lib"
 const data = parseYaml(input)
 // data: Result<unknown, Error>
 
-// Async untrusted: auto-awaits Promises and catches rejections
+// Async untrusted: returns Promise<Result<T, Error>>, use |> await to unwrap
 import { fetchUser } from "api-client"
-const user = fetchUser(id)
-// user: Result<User, Error> — auto-awaited + wrapped
+const user = fetchUser(id) |> await
+// user: Result<User, Error>
 
-// Compose with ? for concise error handling:
-fn loadProfile(id: string) -> Result<Profile, Error> {
-  const user = fetchUser(id)?
-  const posts = fetchPosts(user.id)?
+// Compose with |> await? for concise async error handling:
+fn loadProfile(id: string) -> Promise<Result<Profile, Error>> {
+  const user = fetchUser(id) |> await?
+  const posts = fetchPosts(user.id) |> await?
   Ok(Profile(user, posts))
 }
 ```

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -406,9 +406,11 @@ const fastest = Promise.race([fetchFromCDN(url), fetchFromOrigin(url)]) |> await
 const results = Promise.allSettled([fetchA(), fetchB()]) |> await  // Array<Result<T, Error>>
 Promise.delay(1000) |> await   // wait 1 second
 
-// npm imports are untrusted by default: auto-wrapped in try/catch, return Result<T, Error>
-import { npmAsyncFn } from "some-lib"
-const result = npmAsyncFn()       // Result<T, Error> — auto-wrapped, awaits + catches rejections
+// npm imports are untrusted by default: wrapped in try/catch, return Result<T, Error>
+import { npmSyncFn } from "sync-lib"
+const result = npmSyncFn()            // Result<T, Error> — sync, no await needed
+import { npmAsyncFn } from "async-lib"
+const result = npmAsyncFn() |> await  // Promise<Result<T, Error>> |> await → Result<T, Error>
 
 // parse<T> — compiler built-in for runtime type validation
 // No runtime library needed — the compiler inlines the checks

--- a/docs/site/src/content/docs/docs/reference/stdlib/promise.md
+++ b/docs/site/src/content/docs/docs/reference/stdlib/promise.md
@@ -57,15 +57,23 @@ fn fetchName(id: string) {
 // Inferred return type: Promise<string>
 ```
 
-## Untrusted async imports
+## Untrusted imports
 
-When an untrusted npm import returns a `Promise<T>`, the auto-wrapping handles both sync throws and async rejections. The call is auto-awaited and wrapped in `Result<T, Error>`:
+npm imports are untrusted by default. The compiler wraps calls in try/catch and returns `Result<T, Error>`:
+
+- **Sync functions**: wrapped in sync try/catch → `Result<T, Error>`
+- **Async functions** (returns `Promise<T>`): wrapped in async try/catch → `Promise<Result<T, Error>>` — use `|> await` to unwrap the Promise
 
 ```floe
-// npm async function that might reject (untrusted by default)
+// Sync npm function — Result<T, Error> directly
+import { parseYaml } from "yaml-lib"
+const result = parseYaml(text)
+// Result<Config, Error> — no await needed
+
+// Async npm function — Promise<Result<T, Error>>, needs |> await
 import { transitionIssue } from "jira-api"
-const result = transitionIssue(id, tid)
-// Result<(), Error> — auto-awaited, rejections caught
+const result = transitionIssue(id, tid) |> await
+// Result<(), Error>
 
 match result {
     Ok(_) -> Console.log("Moved!"),
@@ -75,8 +83,9 @@ match result {
 
 | Tool | For | Does |
 |---|---|---|
-| `Promise.await` | Floe async functions | Unwrap `Promise<Result<T, E>>`, use `?` for errors |
-| Untrusted imports (default) | npm functions | Auto-wrap calls in `Result<T, Error>` (auto-awaits if Promise) |
+| `|> await` | Floe async functions | Unwrap `Promise<T>` |
+| Untrusted imports (default) | npm sync functions | Wrap in `Result<T, Error>` |
+| Untrusted imports (default) | npm async functions | Wrap in `Promise<Result<T, Error>>` — use `|> await` |
 | `trusted` imports | npm functions known to be safe | Direct calls, no wrapping |
 
 ## Examples

--- a/docs/site/src/pages/index.astro
+++ b/docs/site/src/pages/index.astro
@@ -634,15 +634,15 @@ fn render(route: Route) -> JSX.Element {
           user.fl
         </div>
         <Code
-          code={`fn getUser(id: string) -> Result<User, ApiError> {
-  const response = fetch("/api/users/{id}")?
-  const user = response.json()?
+          code={`fn getUser(id: string) -> Promise<Result<User, ApiError>> {
+  const response = fetch("/api/users/{id}") |> await?
+  const user = response.json() |> await?
 
   Ok(user)
 }
 
 // The caller sees exactly what can go wrong
-match getUser("123") {
+match getUser("123") |> await {
   Ok(user) -> renderProfile(user),
   Err(NotFound) -> <p>User not found</p>,
   Err(Unauthorized) -> redirect("/login"),

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -34,33 +34,14 @@ pub fn annotate_types(program: &mut Program, types: &ExprTypeMap) {
 /// contain `Promise.await` calls or whose return type is `Promise<T>`.
 /// Also collects untrusted import names from the program for detection.
 pub fn mark_async_functions(program: &mut Program) {
-    // Collect untrusted import names (npm imports not marked `trusted`)
-    let mut throwing: HashSet<String> = HashSet::new();
-    for item in &program.items {
-        if let ItemKind::Import(decl) = &item.kind {
-            // Only track npm imports (source doesn't start with "./" or "../")
-            let is_npm = !decl.source.starts_with("./") && !decl.source.starts_with("../");
-            if is_npm {
-                for spec in &decl.specifiers {
-                    if !decl.trusted && !spec.trusted {
-                        let name = spec.alias.as_ref().unwrap_or(&spec.name);
-                        throwing.insert(name.clone());
-                    }
-                }
-            }
-        }
-    }
-
     for item in &mut program.items {
         match &mut item.kind {
             ItemKind::Function(decl) => {
-                decl.async_fn = body_has_promise_await(&decl.body)
-                    || body_has_throwing_call(&decl.body, &throwing);
+                decl.async_fn = body_has_promise_await(&decl.body);
             }
             ItemKind::ForBlock(block) => {
                 for func in &mut block.functions {
-                    func.async_fn = body_has_promise_await(&func.body)
-                        || body_has_throwing_call(&func.body, &throwing);
+                    func.async_fn = body_has_promise_await(&func.body);
                 }
             }
             _ => {}
@@ -71,60 +52,17 @@ pub fn mark_async_functions(program: &mut Program) {
     // nested `fn` declarations (e.g. handleDragEnd inside a component body).
     crate::walk::walk_program_mut(program, &mut |expr| match &mut expr.kind {
         ExprKind::Arrow { async_fn, body, .. } => {
-            *async_fn = body_has_promise_await(body) || body_has_throwing_call(body, &throwing);
+            *async_fn = body_has_promise_await(body);
         }
         ExprKind::Block(items) | ExprKind::Collect(items) => {
             for item in items {
                 if let ItemKind::Function(decl) = &mut item.kind {
-                    decl.async_fn = body_has_promise_await(&decl.body)
-                        || body_has_throwing_call(&decl.body, &throwing);
+                    decl.async_fn = body_has_promise_await(&decl.body);
                 }
             }
         }
         _ => {}
     });
-}
-
-/// Check if an expression body contains a call to a throwing import.
-fn body_has_throwing_call(expr: &Expr, throwing: &HashSet<String>) -> bool {
-    fn walk(expr: &Expr, throwing: &HashSet<String>) -> bool {
-        match &expr.kind {
-            ExprKind::Call { callee, args, .. } => {
-                let is_throwing = match &callee.kind {
-                    ExprKind::Identifier(name) => throwing.contains(name.as_str()),
-                    ExprKind::Member { object, .. } => {
-                        matches!(&object.kind, ExprKind::Identifier(n) if throwing.contains(n.as_str()))
-                    }
-                    _ => false,
-                };
-                is_throwing
-                    || walk(callee, throwing)
-                    || args.iter().any(|a| match a {
-                        Arg::Positional(e) | Arg::Named { value: e, .. } => walk(e, throwing),
-                    })
-            }
-            ExprKind::Pipe { left, right } => walk(left, throwing) || walk(right, throwing),
-            ExprKind::Binary { left, right, .. } => walk(left, throwing) || walk(right, throwing),
-            ExprKind::Block(items) | ExprKind::Collect(items) => {
-                items.iter().any(|item| match &item.kind {
-                    ItemKind::Expr(e) => walk(e, throwing),
-                    ItemKind::Const(c) => walk(&c.value, throwing),
-                    _ => false,
-                })
-            }
-            ExprKind::Match { subject, arms } => {
-                walk(subject, throwing) || arms.iter().any(|a| walk(&a.body, throwing))
-            }
-            ExprKind::Unwrap(inner)
-            | ExprKind::Unary { operand: inner, .. }
-            | ExprKind::Grouped(inner)
-            | ExprKind::Spread(inner)
-            | ExprKind::Value(inner) => walk(inner, throwing),
-            ExprKind::Arrow { .. } => false,
-            _ => false,
-        }
-    }
-    walk(expr, throwing)
 }
 
 /// Check if an expression body contains a `Promise.await` member access

--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -107,11 +107,20 @@ impl Codegen {
             }
 
             ExprKind::Call { callee, args, .. } => {
-                // Auto-wrap untrusted import calls in try/catch IIFE
+                // Wrap untrusted import calls in try/catch IIFE.
+                // Async calls (Promise<T>): async IIFE → Promise<Result<T, Error>>, caller uses |> await
+                // Sync calls: sync IIFE → Result<T, Error>
                 if self.is_untrusted_call(callee) {
-                    self.push(&format!(
-                        "await (async () => {{ try {{ return {{ {OK_FIELD}: true as const, {VALUE_FIELD}: await "
-                    ));
+                    let is_async = matches!(expr.ty, crate::checker::Type::Promise(_));
+                    if is_async {
+                        self.push(&format!(
+                            "(async () => {{ try {{ return {{ {OK_FIELD}: true as const, {VALUE_FIELD}: await "
+                        ));
+                    } else {
+                        self.push(&format!(
+                            "(() => {{ try {{ return {{ {OK_FIELD}: true as const, {VALUE_FIELD}: "
+                        ));
+                    }
                     self.emit_expr(callee);
                     self.push("(");
                     self.emit_args(args);


### PR DESCRIPTION
## Summary

- Untrusted async imports no longer auto-await. They return `Promise<Result<T, Error>>` — the caller writes `|> await` explicitly
- Sync untrusted imports unchanged: still return `Result<T, Error>` directly
- Removed `body_has_throwing_call` from async inference — untrusted calls no longer make the enclosing function async

## Breaking change

```floe
// Before:
const result = npmAsyncFn()           // Result<T, Error> — silently async

// After:
const result = npmAsyncFn() |> await  // Promise<Result<T, Error>> → Result<T, Error>
```

## Why

Floe's design principle: effects are explicit in types. `|> await` for Floe functions, `?` for Result, `Promise<T>` in return types. Auto-await was the one exception — now it's consistent.

## Test plan

- [x] `cargo test` — 1256 tests pass
- [x] `floe check` on example apps — no errors
- [x] Docs updated: promise.md, design.md, llms.txt, landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)