### PR TITLE
fix: Remove unnecessary npm upgrade from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,9 +143,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Upgrade npm for trusted publishing support
-        run: npm install -g npm@latest
-
       - name: Build and publish Vite plugin
         working-directory: integrations/vite-plugin-floe
         run: |


### PR DESCRIPTION
## Summary
- Remove `npm install -g npm@latest` step from the `publish-npm` job in the release workflow
- Node 22 ships with npm 10.x which already supports `--provenance` (trusted publishing)
- The step was failing on GitHub Actions runners due to a broken `promise-retry` module in the pre-installed npm

## Test plan
- [ ] Merge and trigger a release to verify the npm publish step succeeds without the upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)