### PR TITLE
feat: [#990] Vite plugin reads from .floe/ output

### DIFF
--- a/integrations/vite-plugin-floe/src/index.ts
+++ b/integrations/vite-plugin-floe/src/index.ts
@@ -62,7 +62,6 @@ export default function floe(options: FloeOptions = {}): import("vite").Plugin {
           return transformTsx(cached, cleanId);
         }
 
-        // Fallback: compile on-demand via CLI
         const compiled = compileFloe(compiler, code, id);
         return transformTsx(compiled.code, cleanId);
       } catch (error) {


### PR DESCRIPTION
closes #990

The Vite plugin now tries to read pre-compiled output from `.floe/` (kept fresh by `floe watch`) before falling back to shelling out to `floe build --emit-stdout`. Uses mtime comparison to ensure freshness.

This unifies the compilation path so both Vite and other tools (wrangler, node, bun) use the same `.floe/` output directory. `floe watch` becomes the universal dev-time primitive.

## Test plan

- [ ] Run `floe watch src/` + `vite dev` together — verify `.fl` files compile via the `.floe/` cache (no per-file process spawn)
- [ ] Run `vite dev` without `floe watch` — verify fallback to `floe build --emit-stdout` still works
- [ ] Edit a `.fl` file while both are running — verify HMR picks up the change
- [ ] Run `vite build` with stale `.floe/` — verify fallback kicks in when mtime is older