### PR TITLE
fix: Use npx npm@latest for provenance publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
         working-directory: integrations/vite-plugin-floe
         run: |
           pnpm build
-          npm publish --access public --provenance
+          npx npm@latest publish --access public --provenance
 
   publish-extension:
     name: Publish VS Code Extension


### PR DESCRIPTION
## Summary
- Replace `npm publish` with `npx npm@latest publish` in the release workflow
- Stock npm 10.x on Node 22 runners has a provenance bug (404 on PUT)
- The previous workaround (`npm install -g npm@latest`) broke when the runner image (20260329.72) shipped a corrupted npm that can't self-upgrade
- `npx npm@latest` bypasses both issues by downloading and running the latest npm directly

## Context
- v0.3.0 published fine because the older runner image (20260323.65) could still self-upgrade npm
- v0.4.0 failed at the upgrade step (missing `promise-retry`)
- v0.4.1 failed at publish after we removed the upgrade step (stock npm provenance bug)

## Test plan
- [ ] Merge, then re-run the failed release workflow to verify npm publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)