### PR TITLE
feat: [#1003/#1005] Create @floeorg/register Node loader hook

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -19,6 +19,11 @@
         },
         {
           "type": "json",
+          "path": "integrations/register/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "editors/vscode/package.json",
           "jsonpath": "$.version"
         }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,12 @@ jobs:
           pnpm build
           npx npm@latest publish --access public --provenance
 
+      - name: Build and publish register package
+        working-directory: integrations/register
+        run: |
+          pnpm build
+          npx npm@latest publish --access public --provenance
+
       - name: Build and publish Vite plugin
         working-directory: integrations/vite-plugin-floe
         run: |

--- a/integrations/register/package.json
+++ b/integrations/register/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@floeorg/register",
+  "version": "0.1.0",
+  "description": "Node.js loader hook for Floe - resolve .fl imports at runtime",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc"
+  },
+  "keywords": [
+    "floe",
+    "loader",
+    "register"
+  ],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/floeorg/floe",
+    "directory": "integrations/register"
+  },
+  "homepage": "https://github.com/floeorg/floe",
+  "engines": {
+    "node": ">=22.14.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "typescript": "^6.0.2"
+  }
+}

--- a/integrations/register/src/index.ts
+++ b/integrations/register/src/index.ts
@@ -1,0 +1,81 @@
+import { registerHooks } from "node:module";
+import { statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+/**
+ * Find the project root by walking up to find node_modules or package.json.
+ * Matches the Floe compiler's `find_project_dir` logic.
+ */
+function findProjectRoot(start: string): string {
+  let dir = start;
+  let packageJsonDir: string | null = null;
+  while (true) {
+    try {
+      statSync(join(dir, "node_modules"));
+      return dir;
+    } catch {}
+    if (packageJsonDir === null) {
+      try {
+        statSync(join(dir, "package.json"));
+        packageJsonDir = dir;
+      } catch {}
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return packageJsonDir ?? start;
+    dir = parent;
+  }
+}
+
+/**
+ * Find the compiled .ts/.tsx output in .floe/ for a given .fl file.
+ * Returns the absolute path if found, null otherwise.
+ */
+function findCompiledPath(
+  flFile: string,
+  projectRoot: string,
+): string | null {
+  const rel = relative(projectRoot, flFile);
+  const floeDir = join(projectRoot, ".floe");
+
+  for (const ext of ["tsx", "ts"]) {
+    const outPath = join(floeDir, rel).replace(/\.fl$/, `.${ext}`);
+    try {
+      statSync(outPath);
+      return outPath;
+    } catch {}
+  }
+  return null;
+}
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (!specifier.endsWith(".fl")) {
+      return nextResolve(specifier, context);
+    }
+
+    // Only handle relative imports — bare specifiers go through normal resolution
+    if (!specifier.startsWith(".")) {
+      return nextResolve(specifier, context);
+    }
+
+    const parentPath = context.parentURL
+      ? fileURLToPath(context.parentURL)
+      : join(process.cwd(), "__entry__");
+    const flFile = resolve(dirname(parentPath), specifier);
+    const projectRoot = findProjectRoot(dirname(flFile));
+    const compiled = findCompiledPath(flFile, projectRoot);
+
+    if (compiled) {
+      return {
+        url: pathToFileURL(compiled).href,
+        shortCircuit: true,
+      };
+    }
+
+    throw new Error(
+      `Floe: compiled output not found for "${specifier}". ` +
+        `Run \`floe build\` or \`floe watch\` first.`,
+    );
+  },
+});

--- a/integrations/register/tsconfig.json
+++ b/integrations/register/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "types": ["node"],
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
closes #1005

Node.js loader hook that resolves `.fl` imports at runtime by redirecting them to compiled `.ts`/`.tsx` output in `.floe/`.

```bash
node --import @floeorg/register src/app.ts
```

Works with node (v22.14+), tsx, and any Node-based runtime. Requires `floe build` or `floe watch` to have populated `.floe/` first.

**Tested with:**
- `node --import` - direct Node with built-in TypeScript support
- `npx tsx --import` - tsx runner

## Test plan

- [x] `node --import @floeorg/register src/main.ts` resolves `.fl` imports via `.floe/`
- [x] `npx tsx --import @floeorg/register src/main.ts` works with tsx
- [x] Clear error when `.floe/` is missing: "Run `floe build` or `floe watch` first"
- [ ] `cd integrations/register && npm install && npm run build` compiles clean