### PR TITLE
fix: [#1021] Accept npm subtypes in function arguments

### DIFF
--- a/src/checker/type_compat.rs
+++ b/src/checker/type_compat.rs
@@ -150,10 +150,11 @@ impl Checker {
             return true;
         }
 
-        // Foreign types: nominal for Foreign-vs-Foreign, reject primitives,
-        // permissive with complex types for genuinely opaque npm types.
+        // Foreign types: reject primitives, permissive otherwise.
+        // Foreign-vs-Foreign is permissive because npm types often have subtype
+        // relationships (e.g. SQLiteColumn extends SQLWrapper) that Floe can't verify.
+        // TypeScript's own type checker validates the generated code.
         match (expected, actual) {
-            (Type::Foreign(a), Type::Foreign(b)) => return a == b,
             (Type::Foreign(_), _) if actual.is_primitive() => return false,
             (_, Type::Foreign(_)) if expected.is_primitive() => return false,
             (Type::Foreign(_), _) | (_, Type::Foreign(_)) => return true,


### PR DESCRIPTION
closes #1021

Make Foreign-vs-Foreign type comparison permissive instead of nominal. npm types often have subtype relationships (e.g. `SQLiteColumn extends SQLWrapper`) that Floe can't verify — TypeScript validates the generated code.

**One-line change** in `type_compat.rs`: removed the `(Foreign(a), Foreign(b)) => a == b` arm that rejected different Foreign type names.

## Test plan

- [x] `cargo test` — 1290 tests pass
- [x] Example apps check + build
- [x] Real Drizzle code (`snippet-repository.fl` with `eq(snippetsTable.code, code)`) — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)