### PR TITLE
fix: [#1028] Foreign method chain calls are untrusted

### DIFF
--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -13,7 +13,7 @@ fn extract_chain_segments(expr: &Expr) -> Option<Vec<String>> {
             segs.push(field.clone());
             Some(segs)
         }
-        ExprKind::Call { callee, .. } => extract_chain_segments(callee),
+        ExprKind::Call { callee, .. } | ExprKind::Unwrap(callee) => extract_chain_segments(callee),
         _ => None,
     }
 }
@@ -107,9 +107,12 @@ impl Checker {
                 type_args,
                 args,
             } => {
+                // Check untrusted BEFORE check_call, since check_call's nested
+                // expression evaluation would clobber any shared state
+                let is_untrusted =
+                    self.is_untrusted_call(callee) || self.is_callee_on_untrusted_foreign(callee);
                 let ret = self.check_call(callee, type_args, args, expr.span);
-                // Auto-wrap untrusted import calls in Result
-                if self.is_untrusted_call(callee) {
+                if is_untrusted {
                     match &ret {
                         Type::Promise(inner) => Type::Promise(Box::new(Type::result_of(
                             *inner.clone(),
@@ -294,18 +297,75 @@ impl Checker {
         }
     }
 
-    /// Check if a call expression targets an untrusted import (direct or member access).
+    /// Check if a call expression targets an untrusted import.
+    /// Walks chain roots through Call/Unwrap: db.insert(...)?.values(...) → checks db.
     fn is_untrusted_call(&self, callee: &Expr) -> bool {
-        match &callee.kind {
-            ExprKind::Identifier(name) => self.untrusted_imports.contains(name.as_str()),
-            ExprKind::Member { object, .. } => {
-                if let ExprKind::Identifier(obj_name) = &object.kind {
-                    self.untrusted_imports.contains(obj_name.as_str())
-                } else {
-                    false
-                }
+        fn find_root(expr: &Expr) -> Option<&str> {
+            match &expr.kind {
+                ExprKind::Identifier(name) => Some(name.as_str()),
+                ExprKind::Member { object, .. } => find_root(object),
+                ExprKind::Call { callee, .. } => find_root(callee),
+                ExprKind::Unwrap(inner) => find_root(inner),
+                _ => None,
             }
-            _ => false,
+        }
+        find_root(callee).is_some_and(|root| self.untrusted_imports.contains(root))
+    }
+
+    /// Check if a callee is a method on an untrusted Foreign type (e.g. self.client: Database).
+    /// Check if a callee chain passes through an untrusted npm type at any level.
+    fn is_callee_on_untrusted_foreign(&self, callee: &Expr) -> bool {
+        fn walk(checker: &Checker, expr: &Expr) -> bool {
+            match &expr.kind {
+                ExprKind::Identifier(name) => checker
+                    .env
+                    .lookup(name)
+                    .is_some_and(|ty| checker.is_type_untrusted(ty)),
+                ExprKind::Member { object, field } => {
+                    // Check object type and its member type
+                    if let Some(obj_ty) = checker.peek_object_type(object) {
+                        if checker.is_type_untrusted(&obj_ty) {
+                            return true;
+                        }
+                        let member_ty = checker.resolve_member_type_silent(&obj_ty, field);
+                        if checker.is_type_untrusted(&member_ty) {
+                            return true;
+                        }
+                    }
+                    walk(checker, object)
+                }
+                ExprKind::Call { callee, .. } | ExprKind::Unwrap(callee) => walk(checker, callee),
+                _ => false,
+            }
+        }
+        walk(self, callee)
+    }
+
+    fn is_type_untrusted(&self, ty: &Type) -> bool {
+        let name = match ty {
+            Type::Foreign(n) | Type::Named(n) => n,
+            _ => return false,
+        };
+        let base = name.split(['<', '.']).next().unwrap_or(name);
+        self.untrusted_imports.contains(base)
+    }
+
+    /// Peek at an object expression's type from the env without running check_expr.
+    /// Handles Identifier, Member (self.field), and chains through Call/Unwrap.
+    fn peek_object_type(&self, expr: &Expr) -> Option<Type> {
+        match &expr.kind {
+            ExprKind::Identifier(name) => self.env.lookup(name).cloned(),
+            // Resolve member access recursively: self.field, or deeper chains
+            ExprKind::Member { object, field } => {
+                let obj_ty = self.peek_object_type(object)?;
+                Some(self.resolve_member_type_silent(&obj_ty, field))
+            }
+            // expr()?.field or expr().field — recurse to find if the chain
+            // originates from a Foreign type
+            ExprKind::Call { callee, .. } | ExprKind::Unwrap(callee) => {
+                self.peek_object_type(callee)
+            }
+            _ => None,
         }
     }
 

--- a/src/checker/items.rs
+++ b/src/checker/items.rs
@@ -612,7 +612,12 @@ impl Checker {
 
             // Check the function body
             let prev_return_type = self.ctx.current_return_type.take();
-            self.ctx.current_return_type = Some(return_type.clone());
+            // For Promise<T> return types, unwrap so ? sees the inner type
+            let effective_return = match &return_type {
+                Type::Promise(inner) => *inner.clone(),
+                _ => return_type.clone(),
+            };
+            self.ctx.current_return_type = Some(effective_return);
 
             self.env.push_scope();
 

--- a/src/interop/tsgo/probe_gen.rs
+++ b/src/interop/tsgo/probe_gen.rs
@@ -1275,7 +1275,7 @@ fn extract_import_chain_path(
             ExprKind::Identifier(name) if imported_names.contains_key(name) => {
                 Some(vec![name.clone(), field.clone()])
             }
-            ExprKind::Call { callee, .. } => {
+            ExprKind::Call { callee, .. } | ExprKind::Unwrap(callee) => {
                 let mut path = extract_import_chain_path(callee, imported_names)?;
                 path.push(field.clone());
                 Some(path)
@@ -1322,8 +1322,8 @@ fn extract_typed_param_chain_path(
                         None
                     }
                 }
-                // Chained call: expr().method(...)
-                ExprKind::Call { callee, .. } => {
+                // Chained call or unwrap: expr().method(...) or expr()?.method(...)
+                ExprKind::Call { callee, .. } | ExprKind::Unwrap(callee) => {
                     let (type_name, mut path) = extract_inner(callee, param_type_map)?;
                     path.push(field.clone());
                     Some((type_name, path))
@@ -1376,6 +1376,9 @@ fn collect_chain_step_args(
                 }
                 walk(callee, imported_names, type_path, args_map, zero_args);
             }
+            ExprKind::Unwrap(inner) => {
+                walk(inner, imported_names, type_path, args_map, zero_args);
+            }
             _ => {}
         }
     }
@@ -1399,10 +1402,12 @@ fn count_chain_depth(expr: &Expr) -> usize {
             {
                 1
             }
-            ExprKind::Call { callee, .. } => 1 + count_chain_depth(callee),
+            ExprKind::Call { callee, .. } | ExprKind::Unwrap(callee) => {
+                1 + count_chain_depth(callee)
+            }
             _ => 0,
         },
-        ExprKind::Call { callee, .. } => count_chain_depth(callee),
+        ExprKind::Call { callee, .. } | ExprKind::Unwrap(callee) => count_chain_depth(callee),
         _ => 0,
     }
 }


### PR DESCRIPTION
closes #1028

Method calls on untrusted npm types are now auto-wrapped in Result. When `Database` is imported without `trusted`, all chain calls on it require `?`:

```floe
self.client.insert(snippetsTable)?
    .values({ code: snippet.code, content: snippet.content })?
    .returning()? |> await
```

### How it works

`is_callee_on_untrusted_foreign` walks the callee chain AST BEFORE `check_call` runs, checking if any object in the chain resolves to a type that's in `untrusted_imports`. No shared mutable state — pure AST + env lookup.

### Also fixes
- For-block `current_return_type` unwraps Promise so `?` works in async for-block methods
- Chain extractors see through `Unwrap` nodes for `?`-annotated chains

## Test plan
- [x] `cargo test` — 1301 tests pass
- [x] `snippet-repository.fl` with `?` on chain steps — only `eq()?` errors (correct: `eq` is trusted)
- [x] Example apps (use `import trusted`) — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)