### PR TITLE
fix: [#1046] Show normal type mismatch for untrusted Results

### DIFF
--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -2550,12 +2550,6 @@ impl Checker {
         expected: &Type,
         found: &Type,
     ) -> Option<(String, String)> {
-        // Found is Result<T, E> but T is what was expected — untrusted import not unwrapped
-        if self.is_untrusted_result_mismatch(expected, found) {
-            let msg = "found an untrusted import `Result` — use `?` to unwrap or `import trusted` if it cannot fail".to_string();
-            return Some((msg, "use `?` to unwrap or `import trusted`".to_string()));
-        }
-
         // Both are records — diff the fields and report only mismatches
         if let (Type::Record(exp_fields), Type::Record(fnd_fields)) = (expected, found) {
             let fnd_map: std::collections::HashMap<&str, &Type> =
@@ -2574,11 +2568,6 @@ impl Checker {
                         };
                         if compat {
                             None
-                        } else if self.is_untrusted_result_mismatch(exp_ty, fnd_ty) {
-                            Some(format!(
-                                "`{}`: untrusted import `Result` — use `?` to unwrap or `import trusted`",
-                                name
-                            ))
                         } else if let Some((msg, _)) = self.extra_mismatch_detail(exp_ty, fnd_ty) {
                             Some(format!("`{}`: {}", name, msg))
                         } else {

--- a/tests/snapshots/snapshot_errors__snapshot_error_untrusted_result_used_as_value.snap
+++ b/tests/snapshots/snapshot_errors__snapshot_error_untrusted_result_used_as_value.snap
@@ -2,12 +2,12 @@
 source: tests/snapshot_errors.rs
 expression: output
 ---
-[31m[E001] Error:[0m function `process`: expected return type `string`, found an untrusted import `Result` — use `?` to unwrap or `import trusted` if it cannot fail
+[31m[E001] Error:[0m function `process`: expected return type `string`, found `Result<unknown, Error>`
    [38;5;246m╭[0m[38;5;246m─[0m[38;5;246m[[0m test.fl:4:5 [38;5;246m][0m
    [38;5;246m│[0m
  [38;5;246m4 │[0m [38;5;249m [0m[38;5;249m [0m[38;5;249m [0m[38;5;249m [0m[31mr[0m[31me[0m[31ms[0m[31mu[0m[31ml[0m[31mt[0m
  [38;5;240m  │[0m     [31m─[0m[31m─[0m[31m─[0m[31m┬[0m[31m─[0m[31m─[0m[31m─[0m  
- [38;5;240m  │[0m        [31m╰[0m[31m─[0m[31m─[0m[31m─[0m[31m─[0m[31m─[0m use `?` to unwrap or `import trusted`
+ [38;5;240m  │[0m        [31m╰[0m[31m─[0m[31m─[0m[31m─[0m[31m─[0m[31m─[0m expected `string`
 [38;5;246m───╯[0m
 [33m[W001] Warning:[0m unused variable `process`
    [38;5;246m╭[0m[38;5;246m─[0m[38;5;246m[[0m test.fl:2:1 [38;5;246m][0m


### PR DESCRIPTION
closes #1046

Removes the special "untrusted import Result" hint from field mismatches. Just shows the types:

```
`code`: expected `string`, found `Result<string, Error>`
`expiresAt`: expected `Date`, found `Result<Date, Error>`
```

The types speak for themselves — user sees Result where a plain type is expected and knows to unwrap.

## Test plan

- [ ] `cargo nextest run -p floe` — all tests pass
- [ ] `floe check` on untrusted import code shows `expected X, found Result<X, Error>`