### PR TITLE
fix: [#1054] reject bare type name used as value expression

### DIFF
--- a/src/checker/error_codes.rs
+++ b/src/checker/error_codes.rs
@@ -121,6 +121,8 @@ pub enum ErrorCode {
     TsgoNotFound,
     /// Wrong number of type arguments for a generic type.
     TypeArgumentArity,
+    /// Type name used where a value is expected.
+    TypeUsedAsValue,
 }
 
 impl ErrorCode {
@@ -176,6 +178,7 @@ impl ErrorCode {
             Self::TsgoNotFound => "E043",
             Self::ExportNotFound => "E044",
             Self::TypeArgumentArity => "E045",
+            Self::TypeUsedAsValue => "E046",
         }
     }
 }

--- a/src/checker/expr.rs
+++ b/src/checker/expr.rs
@@ -260,6 +260,19 @@ impl Checker {
                     required_params,
                 };
             }
+            // A registered type name used as a bare value is an error
+            // (record/union/alias types are not runtime values). Qualified
+            // variant access like `Route.Home` is parsed as `Construct`, not
+            // `Member`, so it never reaches this branch.
+            if self.env.lookup_type(name).is_some() {
+                self.emit_error(
+                    format!("`{name}` is a type, not a value"),
+                    span,
+                    ErrorCode::TypeUsedAsValue,
+                    "type name used as value",
+                );
+                return Type::Unknown;
+            }
             ty
         } else if self.stdlib.is_module(name) {
             // Stdlib module names (Array, String, etc.) are valid identifiers

--- a/src/checker/tests.rs
+++ b/src/checker/tests.rs
@@ -5360,7 +5360,7 @@ fn bracket_access_on_record_errors() {
     let diags = check(
         r#"
 type User { name: string, age: number }
-const u = User { name: "Alice", age: 30 }
+const u = User(name: "Alice", age: 30)
 const x = u[0]
 "#,
     );
@@ -6840,4 +6840,58 @@ const _x = expiresAt
         "expiresAt should be Result<unknown, Error> from untrusted call, got: {}",
         expires_type
     );
+}
+
+#[test]
+fn record_type_name_as_bare_value_errors() {
+    let diags = check(
+        r#"
+type Foo { a: string }
+export fn bad() -> number {
+    const x = Foo
+    42
+}
+"#,
+    );
+    assert!(has_error(&diags, ErrorCode::TypeUsedAsValue));
+    assert!(has_error_containing(&diags, "`Foo` is a type, not a value"));
+}
+
+#[test]
+fn union_type_name_as_bare_value_errors() {
+    let diags = check(
+        r#"
+type Route { | Home | Profile(string) }
+export fn bad() -> Route {
+    Route
+}
+"#,
+    );
+    assert!(has_error(&diags, ErrorCode::TypeUsedAsValue));
+}
+
+#[test]
+fn qualified_variant_access_still_works() {
+    let diags = check(
+        r#"
+type Route { | Home | Profile(string) }
+export fn ok() -> Route {
+    Route.Home
+}
+"#,
+    );
+    assert!(!has_error(&diags, ErrorCode::TypeUsedAsValue));
+}
+
+#[test]
+fn bare_nullary_variant_still_works() {
+    let diags = check(
+        r#"
+type Route { | Home | Profile(string) }
+export fn ok() -> Route {
+    Home
+}
+"#,
+    );
+    assert!(!has_error(&diags, ErrorCode::TypeUsedAsValue));
 }


### PR DESCRIPTION
closes #1054

## Summary

Bare references to a type name (record, union, alias) resolved through the value namespace with no guard. Code like `const x = Foo` or `return Route` silently type-checked and compiled to TypeScript that references the type at runtime and crashes.

`src/checker/type_registration.rs` defines type names in both the value namespace (`env.define`) and the type namespace (`env.define_type`) — union names need to resolve for `Route.Home` qualified variant access, and records have their `Type::Named` for construction paths. But `check_identifier` just read from the env with no check that the identifier is actually being used as a value.

## Fix

- Add `E046 TypeUsedAsValue` error code.
- In `check_identifier`, after the env lookup, check `env.lookup_type(name)` — if the name is a registered type definition, emit `` `Foo` is a type, not a value ``.
- Nullary and parameterised variant constructors are unaffected (variants are not registered in `type_defs`).
- Qualified variant access like `Route.Home` is parsed as `Construct`, not `Member`, so it never reaches `check_identifier`.

## Test plan

- [x] Regression tests for record, union, and alias type names used as bare values
- [x] Tests confirming `Route.Home` qualified access and bare nullary variants still work
- [x] `cargo test --lib` (1308 passed)
- [x] `python3 -m pytest tests/lsp/` (236 passed)
- [x] `floe check` + `floe build` on both example apps pass