### PR TITLE
feat: [#1055] Load ambient types from tsconfig (lib, types, @types/*)

### DIFF
--- a/src/interop/ambient.rs
+++ b/src/interop/ambient.rs
@@ -1,10 +1,14 @@
 //! Ambient type loading from TypeScript lib definition files.
 //!
-//! Parses `lib.dom.d.ts` (and related lib files) to extract:
+//! Loads ambient types based on the project's `tsconfig.json`:
+//! - `compilerOptions.lib` → TS built-in lib files (lib.dom.d.ts, lib.es2020.d.ts, etc.)
+//! - `compilerOptions.types` → `@types/*` packages (e.g., @types/node)
+//! - Auto-includes all `@types/*` when `types` is not set (TS default)
+//!
+//! Extracts:
 //! - `declare var` / `declare function` → global variable/function types
 //! - `interface` definitions → for resolving member access on globals
-//!
-//! This replaces the hardcoded browser globals in checker.rs with real types.
+//! - `declare global { ... }` blocks → for @types/node style globals
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -22,26 +26,142 @@ use crate::checker::Type;
 #[derive(Default)]
 pub struct AmbientDeclarations {
     /// Global variables/functions (e.g., `window`, `document`, `navigator`, `fetch`).
-    /// These are registered directly in the checker's type environment.
     pub globals: Vec<(String, Type)>,
     /// Type definitions (interfaces) for resolving member access.
-    /// e.g., `Window`, `Navigator`, `Console`, `Location` — used when the
-    /// checker resolves `Foreign("Window")` to a concrete record type.
     pub types: HashMap<String, Type>,
 }
 
+impl AmbientDeclarations {
+    fn merge(&mut self, other: AmbientDeclarations, seen_globals: &mut HashSet<String>) {
+        for (name, ty) in other.globals {
+            if seen_globals.insert(name.clone()) {
+                self.globals.push((name, ty));
+            }
+        }
+        self.types.extend(other.types);
+    }
+}
+
+// ── TypeScript lib configuration ────────────────────────────────
+
+/// Parsed `compilerOptions.lib` and `compilerOptions.types` from tsconfig.json.
+struct TsAmbientConfig {
+    /// Lib file names to load (e.g., ["lib.es2020.d.ts", "lib.dom.d.ts"]).
+    lib_files: Vec<String>,
+    /// `@types/*` packages to load. `None` means auto-include all.
+    types: Option<Vec<String>>,
+}
+
+/// Parse ambient config from the project's tsconfig.json.
+fn parse_ambient_config(project_dir: &Path) -> TsAmbientConfig {
+    let tsconfig_path = match crate::resolve::find_tsconfig_from(project_dir) {
+        Some(p) => p,
+        None => {
+            return TsAmbientConfig {
+                lib_files: default_lib_files(),
+                types: None,
+            };
+        }
+    };
+
+    let content = match std::fs::read_to_string(&tsconfig_path) {
+        Ok(c) => c,
+        Err(_) => {
+            return TsAmbientConfig {
+                lib_files: default_lib_files(),
+                types: None,
+            };
+        }
+    };
+
+    let stripped = crate::resolve::strip_jsonc_comments(&content);
+    let json: serde_json::Value = match serde_json::from_str(&stripped) {
+        Ok(v) => v,
+        Err(_) => {
+            return TsAmbientConfig {
+                lib_files: default_lib_files(),
+                types: None,
+            };
+        }
+    };
+
+    // Parse compilerOptions.lib
+    let lib_files = json
+        .pointer("/compilerOptions/lib")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .map(lib_name_to_filename)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_else(default_lib_files);
+
+    // Parse compilerOptions.types — None means "auto-include all @types/*"
+    let types = json
+        .pointer("/compilerOptions/types")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        });
+
+    TsAmbientConfig { lib_files, types }
+}
+
+/// Default lib files when tsconfig doesn't specify `lib`.
+fn default_lib_files() -> Vec<String> {
+    vec!["lib.es5.d.ts".to_string(), "lib.dom.d.ts".to_string()]
+}
+
+/// Convert a tsconfig lib name to its filename.
+/// e.g., "ES2020" → "lib.es2020.d.ts", "DOM" → "lib.dom.d.ts"
+fn lib_name_to_filename(name: &str) -> String {
+    format!("lib.{}.d.ts", name.to_lowercase())
+}
+
+// ── Reference directive resolution ──────────────────────────────
+
+/// Extract `/// <reference lib="..." />` directives from file content.
+fn extract_reference_libs(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix("/// <reference lib=\"") {
+                rest.strip_suffix("\" />").map(lib_name_to_filename)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Extract `/// <reference path="..." />` directives from file content.
+fn extract_reference_paths(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix("/// <reference path=\"") {
+                rest.strip_suffix("\" />").map(String::from)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+// ── TS lib file loading ─────────────────────────────────────────
+
 /// Find the TypeScript lib directory from a project root.
-///
-/// Searches for `node_modules/typescript/lib/` in standard locations
-/// (npm/yarn hoisted, pnpm symlinks, and pnpm `.pnpm/` store).
 fn find_ts_lib_dir(project_dir: &Path) -> Option<PathBuf> {
-    // Standard location (npm, yarn, hoisted pnpm)
     let standard = project_dir.join("node_modules/typescript/lib");
     if standard.is_dir() {
         return Some(standard);
     }
 
-    // pnpm: check .pnpm store — find the latest typescript version
     let pnpm_dir = project_dir.join("node_modules/.pnpm");
     if pnpm_dir.is_dir()
         && let Ok(entries) = std::fs::read_dir(&pnpm_dir)
@@ -56,7 +176,6 @@ fn find_ts_lib_dir(project_dir: &Path) -> Option<PathBuf> {
             .map(|e| e.path().join("node_modules/typescript/lib"))
             .filter(|p| p.is_dir())
             .collect();
-        // Sort to get the latest version (lexicographic is fine for semver prefixed dirs)
         ts_dirs.sort();
         if let Some(dir) = ts_dirs.pop() {
             return Some(dir);
@@ -66,35 +185,182 @@ fn find_ts_lib_dir(project_dir: &Path) -> Option<PathBuf> {
     None
 }
 
-/// Load ambient type declarations from the project's TypeScript installation.
-///
-/// Parses `lib.dom.d.ts` (browser globals) and `lib.es5.d.ts` (core JS types
-/// like Date, RegExp, Map, Set, Promise, Error) and merges the results.
-///
-/// Returns `None` if TypeScript is not installed or lib files can't be parsed.
-pub fn load_ambient_types(project_dir: &Path) -> Option<AmbientDeclarations> {
-    let lib_dir = find_ts_lib_dir(project_dir)?;
+/// Load a TS lib file and recursively follow `/// <reference lib="..." />` directives.
+fn load_lib_file(
+    lib_dir: &Path,
+    filename: &str,
+    visited: &mut HashSet<String>,
+    merged: &mut AmbientDeclarations,
+    seen_globals: &mut HashSet<String>,
+) {
+    if !visited.insert(filename.to_string()) {
+        return;
+    }
 
-    // Load lib files in order — later files can override earlier ones
-    let lib_files = ["lib.es5.d.ts", "lib.dom.d.ts"];
-
-    let mut merged = AmbientDeclarations {
-        globals: Vec::new(),
-        types: HashMap::new(),
+    let path = lib_dir.join(filename);
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return;
     };
+
+    // Follow reference lib directives first (load dependencies before this file)
+    let ref_libs = extract_reference_libs(&content);
+    for ref_lib in &ref_libs {
+        load_lib_file(lib_dir, ref_lib, visited, merged, seen_globals);
+    }
+
+    let result = parse_ambient_lib(&content);
+    merged.merge(result, seen_globals);
+}
+
+// ── @types/* package loading ────────────────────────────────────
+
+/// Find all installed `@types/*` package names.
+fn discover_types_packages(project_dir: &Path) -> Vec<String> {
+    let types_dir = project_dir.join("node_modules/@types");
+    if !types_dir.is_dir() {
+        return Vec::new();
+    }
+
+    let Ok(entries) = std::fs::read_dir(&types_dir) else {
+        return Vec::new();
+    };
+
+    entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .filter_map(|e| {
+            let name = e.file_name().to_str()?.to_string();
+            // Skip scoped packages (e.g., @types/babel__core) for now
+            if name.starts_with('.') {
+                return None;
+            }
+            Some(name)
+        })
+        .collect()
+}
+
+/// Find the entry .d.ts for a types package.
+///
+/// Searches in `node_modules/@types/{name}` for standard @types packages,
+/// and also directly in `node_modules/{name}` for packages that ship their
+/// own types (e.g., `@cloudflare/workers-types`).
+fn find_types_entry(project_dir: &Path, package_name: &str) -> Option<PathBuf> {
+    // Try @types/{name} first (standard convention)
+    let at_types_dir = project_dir.join(format!("node_modules/@types/{package_name}"));
+    // Then try the package directly (for packages that ship their own types)
+    let direct_dir = project_dir.join(format!("node_modules/{package_name}"));
+
+    let types_dir = if at_types_dir.is_dir() {
+        at_types_dir
+    } else if direct_dir.is_dir() {
+        direct_dir
+    } else {
+        return None;
+    };
+
+    // Check index.d.ts (most common)
+    let index = types_dir.join("index.d.ts");
+    if index.exists() {
+        return Some(index);
+    }
+
+    // Check package.json types/typings field
+    let pkg_json = types_dir.join("package.json");
+    if let Ok(content) = std::fs::read_to_string(&pkg_json)
+        && let Ok(json) = serde_json::from_str::<serde_json::Value>(&content)
+        && let Some(types_field) = json
+            .get("types")
+            .or_else(|| json.get("typings"))
+            .and_then(|v| v.as_str())
+    {
+        let entry = types_dir.join(types_field);
+        if entry.exists() {
+            return Some(entry);
+        }
+    }
+
+    None
+}
+
+/// Load an @types package, following `/// <reference path="..." />` directives.
+fn load_types_package(
+    entry_path: &Path,
+    merged: &mut AmbientDeclarations,
+    seen_globals: &mut HashSet<String>,
+) {
+    let mut visited: HashSet<PathBuf> = HashSet::new();
+    load_types_file(entry_path, &mut visited, merged, seen_globals);
+}
+
+/// Load a single .d.ts file from an @types package, following path references.
+fn load_types_file(
+    file_path: &Path,
+    visited: &mut HashSet<PathBuf>,
+    merged: &mut AmbientDeclarations,
+    seen_globals: &mut HashSet<String>,
+) {
+    let canonical = file_path
+        .canonicalize()
+        .unwrap_or_else(|_| file_path.to_path_buf());
+    if !visited.insert(canonical) {
+        return;
+    }
+
+    let Ok(content) = std::fs::read_to_string(file_path) else {
+        return;
+    };
+
+    let parent = file_path.parent().unwrap_or(Path::new("."));
+
+    // Follow reference path directives
+    let ref_paths = extract_reference_paths(&content);
+    for ref_path in &ref_paths {
+        let resolved = parent.join(ref_path);
+        if resolved.exists() {
+            load_types_file(&resolved, visited, merged, seen_globals);
+        }
+    }
+
+    let result = parse_ambient_lib(&content);
+    merged.merge(result, seen_globals);
+}
+
+// ── Main entry point ────────────────────────────────────────────
+
+/// Load ambient type declarations based on the project's tsconfig.json.
+///
+/// Reads `compilerOptions.lib` and `compilerOptions.types` to determine
+/// which lib files and @types packages to load.
+pub fn load_ambient_types(project_dir: &Path) -> Option<AmbientDeclarations> {
+    let config = parse_ambient_config(project_dir);
+
+    let mut merged = AmbientDeclarations::default();
     let mut seen_globals: HashSet<String> = HashSet::new();
     let mut loaded_any = false;
 
-    for filename in &lib_files {
-        let path = lib_dir.join(filename);
-        if let Ok(content) = std::fs::read_to_string(&path) {
-            let result = parse_ambient_lib(&content);
-            for (name, ty) in result.globals {
-                if seen_globals.insert(name.clone()) {
-                    merged.globals.push((name, ty));
-                }
-            }
-            merged.types.extend(result.types);
+    // Load TS lib files based on compilerOptions.lib
+    if let Some(lib_dir) = find_ts_lib_dir(project_dir) {
+        let mut visited_libs: HashSet<String> = HashSet::new();
+        for filename in &config.lib_files {
+            load_lib_file(
+                &lib_dir,
+                filename,
+                &mut visited_libs,
+                &mut merged,
+                &mut seen_globals,
+            );
+        }
+        loaded_any = !visited_libs.is_empty();
+    }
+
+    // Load @types packages
+    let types_to_load = match config.types {
+        Some(explicit) => explicit,
+        None => discover_types_packages(project_dir),
+    };
+    for package_name in &types_to_load {
+        if let Some(entry) = find_types_entry(project_dir, package_name) {
+            load_types_package(&entry, &mut merged, &mut seen_globals);
             loaded_any = true;
         }
     }
@@ -102,7 +368,11 @@ pub fn load_ambient_types(project_dir: &Path) -> Option<AmbientDeclarations> {
     if loaded_any { Some(merged) } else { None }
 }
 
-/// Parse ambient declarations from a TypeScript lib file.
+// ── Parser ──────────────────────────────────────────────────────
+
+/// Parse ambient declarations from a single .d.ts file.
+///
+/// Handles top-level declarations and `declare global { ... }` blocks.
 fn parse_ambient_lib(content: &str) -> AmbientDeclarations {
     let allocator = Allocator::default();
     let source_type = SourceType::d_ts();
@@ -120,35 +390,55 @@ fn parse_ambient_lib(content: &str) -> AmbientDeclarations {
         types.insert(name.clone(), wrap_boundary_type(&ts_type));
     }
 
-    // Phase 2: Collect `declare var` and `declare function` globals
+    // Phase 2: Collect globals from top-level and `declare global` blocks
     let mut globals: Vec<(String, Type)> = Vec::new();
     let mut seen_globals: HashSet<String> = HashSet::new();
 
     for stmt in &ret.program.body {
-        match stmt {
-            Statement::VariableDeclaration(var_decl) if var_decl.declare => {
-                for declarator in &var_decl.declarations {
-                    if let Some(export) = convert_variable_declarator(declarator)
-                        && seen_globals.insert(export.name.clone())
-                    {
-                        globals.push((export.name, wrap_boundary_type(&export.ts_type)));
-                    }
-                }
-            }
-            Statement::FunctionDeclaration(func) if func.declare => {
-                if let Some(ref id) = func.id {
-                    let name = id.name.to_string();
-                    if seen_globals.insert(name.clone()) {
-                        let ts_type = convert_function(&func.params, &func.return_type);
-                        globals.push((name, wrap_boundary_type(&ts_type)));
-                    }
-                }
-            }
-            _ => {}
-        }
+        collect_globals_from_stmt(stmt, &mut globals, &mut seen_globals, false);
     }
 
     AmbientDeclarations { globals, types }
+}
+
+/// Extract `declare var` and `declare function` from a statement.
+/// Recurses into `declare global { ... }` blocks.
+///
+/// `inside_global` is true when we're inside a `declare global` block,
+/// where declarations don't carry the `declare` flag themselves.
+fn collect_globals_from_stmt(
+    stmt: &Statement<'_>,
+    globals: &mut Vec<(String, Type)>,
+    seen: &mut HashSet<String>,
+    inside_global: bool,
+) {
+    match stmt {
+        Statement::VariableDeclaration(var_decl) if var_decl.declare || inside_global => {
+            for declarator in &var_decl.declarations {
+                if let Some(export) = convert_variable_declarator(declarator)
+                    && seen.insert(export.name.clone())
+                {
+                    globals.push((export.name, wrap_boundary_type(&export.ts_type)));
+                }
+            }
+        }
+        Statement::FunctionDeclaration(func) if func.declare || inside_global => {
+            if let Some(ref id) = func.id {
+                let name = id.name.to_string();
+                if seen.insert(name.clone()) {
+                    let ts_type = convert_function(&func.params, &func.return_type);
+                    globals.push((name, wrap_boundary_type(&ts_type)));
+                }
+            }
+        }
+        // `declare global { ... }` — oxc parses this as TSGlobalDeclaration
+        Statement::TSGlobalDeclaration(global_decl) => {
+            for inner_stmt in &global_decl.body.body {
+                collect_globals_from_stmt(inner_stmt, globals, seen, true);
+            }
+        }
+        _ => {}
+    }
 }
 
 #[cfg(test)]
@@ -172,23 +462,19 @@ mod tests {
 
         let result = parse_ambient_lib(content);
 
-        // Should find 2 globals
         assert_eq!(result.globals.len(), 2);
         assert_eq!(result.globals[0].0, "window");
         assert_eq!(result.globals[1].0, "document");
 
-        // window should resolve to Foreign("Window")
         assert!(
             matches!(&result.globals[0].1, Type::Foreign(name) if name == "Window"),
             "expected Foreign(\"Window\"), got {:?}",
             result.globals[0].1
         );
 
-        // Window interface should be in types
         assert!(result.types.contains_key("Window"));
         assert!(result.types.contains_key("Location"));
 
-        // Window should be a Record with location and innerWidth fields
         if let Type::Record(fields) = &result.types["Window"] {
             assert!(fields.iter().any(|(name, _)| name == "location"));
             assert!(fields.iter().any(|(name, _)| name == "innerWidth"));
@@ -213,7 +499,6 @@ mod tests {
         assert_eq!(result.globals[0].0, "setTimeout");
         assert_eq!(result.globals[1].0, "clearTimeout");
 
-        // setTimeout should be a function
         assert!(
             matches!(&result.globals[0].1, Type::Function { .. }),
             "expected Function, got {:?}",
@@ -241,7 +526,6 @@ mod tests {
 
         let result = parse_ambient_lib(content);
 
-        // Navigator should have fields from all parents + own
         if let Type::Record(fields) = &result.types["Navigator"] {
             let field_names: Vec<&str> = fields.iter().map(|(n, _)| n.as_str()).collect();
             assert!(field_names.contains(&"userAgent"), "missing userAgent");
@@ -266,11 +550,81 @@ mod tests {
 
         let result = parse_ambient_lib(content);
 
-        // Should resolve to Foreign("Window"), not Unknown
         assert!(
             matches!(&result.globals[0].1, Type::Foreign(name) if name == "Window"),
             "expected Foreign(\"Window\"), got {:?}",
             result.globals[0].1
         );
+    }
+
+    #[test]
+    fn declare_global_extracts_globals() {
+        let content = r#"
+            declare global {
+                function fetch(input: string): Promise<Response>;
+                var process: NodeJS.Process;
+                interface Response {
+                    ok: boolean;
+                }
+            }
+        "#;
+
+        let result = parse_ambient_lib(content);
+
+        let global_names: Vec<&str> = result.globals.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(
+            global_names.contains(&"fetch"),
+            "missing fetch from declare global"
+        );
+        assert!(
+            global_names.contains(&"process"),
+            "missing process from declare global"
+        );
+
+        assert!(
+            result.types.contains_key("Response"),
+            "missing Response interface from declare global"
+        );
+    }
+
+    #[test]
+    fn lib_name_mapping() {
+        assert_eq!(lib_name_to_filename("ES2020"), "lib.es2020.d.ts");
+        assert_eq!(lib_name_to_filename("DOM"), "lib.dom.d.ts");
+        assert_eq!(lib_name_to_filename("ESNext"), "lib.esnext.d.ts");
+        assert_eq!(
+            lib_name_to_filename("ES2015.Collection"),
+            "lib.es2015.collection.d.ts"
+        );
+    }
+
+    #[test]
+    fn extract_reference_lib_directives() {
+        let content = r#"/// <reference no-default-lib="true"/>
+/// <reference lib="es2019" />
+/// <reference lib="es2020.bigint" />
+/// <reference lib="es2020.date" />
+
+interface Foo { x: number; }
+"#;
+
+        let refs = extract_reference_libs(content);
+        assert_eq!(refs.len(), 3);
+        assert_eq!(refs[0], "lib.es2019.d.ts");
+        assert_eq!(refs[1], "lib.es2020.bigint.d.ts");
+        assert_eq!(refs[2], "lib.es2020.date.d.ts");
+    }
+
+    #[test]
+    fn extract_reference_path_directives() {
+        let content = r#"/// <reference path="globals.d.ts" />
+/// <reference path="web-globals/fetch.d.ts" />
+/// <reference lib="es2020" />
+"#;
+
+        let refs = extract_reference_paths(content);
+        assert_eq!(refs.len(), 2);
+        assert_eq!(refs[0], "globals.d.ts");
+        assert_eq!(refs[1], "web-globals/fetch.d.ts");
     }
 }

--- a/src/interop/dts.rs
+++ b/src/interop/dts.rs
@@ -970,6 +970,12 @@ pub(super) fn collect_interface_info(
                 }
             }
         }
+        // `declare global { ... }` — oxc parses this as TSGlobalDeclaration
+        Statement::TSGlobalDeclaration(global_decl) => {
+            for inner_stmt in &global_decl.body.body {
+                collect_interface_info(inner_stmt, bodies, extends);
+            }
+        }
         _ => {}
     }
 }


### PR DESCRIPTION
closes #1055

Replace hardcoded `lib.dom.d.ts` + `lib.es5.d.ts` loading with tsconfig-driven ambient type resolution. Now supports any runtime (browser, Node, Bun, Deno, Cloudflare Workers, etc.) by reading the project's `tsconfig.json`.

## Changes

- Parse `compilerOptions.lib` to load the right TS lib files (e.g., `"ESNext"` follows the full reference chain down to ES5)
- Parse `compilerOptions.types` to load explicit type packages (e.g., `["@cloudflare/workers-types"]`)
- Auto-discover all `@types/*` packages when `types` is not specified (TS default behavior)
- Follow `/// <reference lib="..." />` directives transitively across lib files
- Follow `/// <reference path="..." />` directives for @types packages (needed for `@types/node`)
- Handle `declare global { ... }` blocks (`TSGlobalDeclaration` in oxc) to extract globals from `@types/node`-style packages
- Support non-`@types` packages in `types` field (e.g., `@cloudflare/workers-types`)
- Fall back to `lib.es5` + `lib.dom` when no tsconfig found

## What now works

```json
// tsconfig.json for a Cloudflare Workers project
{ "compilerOptions": { "lib": ["ESNext"], "types": ["@cloudflare/workers-types"] } }
```
- `Date`, `Promise`, `Map`, `Set` all work (from ESNext -> ES2025 -> ... -> ES5)
- No `window`/`document` (DOM not in lib list)
- Workers globals loaded from `@cloudflare/workers-types`

```json
// tsconfig.json for a Node project
{ "compilerOptions": { "lib": ["ES2020"], "types": ["node"] } }
```
- `process`, `Buffer`, `__dirname` available (from `@types/node` via `declare global`)

## Test plan

- [x] All 1325 existing tests pass
- [x] 8 ambient-specific unit tests including `declare_global_extracts_globals`, `lib_name_mapping`, reference directive extraction
- [x] Example apps (`todo-app`, `store`) pass `floe check`
- [x] Yeet API project (ESNext + Cloudflare Workers types) - `Date` resolves correctly
- [x] Graceful fallback when no tsconfig found (uses lib.es5 + lib.dom defaults)