### PR TITLE
chore: [#1082] Document ambient type loading from tsconfig

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -55,4 +55,5 @@ After the checker runs, `annotate_types()` walks the AST and fills in `expr.ty` 
 | `stdlib.rs` | Standard library function registry - type signatures and codegen templates |
 | `resolve.rs` | Import resolution for .fl files |
 | `interop/` | npm/.d.ts import resolution via tsgo |
+| `interop/ambient.rs` | Ambient type loading from tsconfig (lib files, @types packages, `declare global` blocks) |
 | `desugar.rs` | AST transforms between checker and codegen |

--- a/docs/design.md
+++ b/docs/design.md
@@ -1602,6 +1602,38 @@ match findElement("app") {
 (() => { try { return { ok: true as const, value: parseYaml(input) }; } catch (_e) { return { ok: false as const, error: _e instanceof Error ? _e : new Error(String(_e)) }; } })()
 ```
 
+### Ambient Types (Browser/Runtime Globals)
+
+Floe loads ambient types (globals like `window`, `document`, `process`, `fetch`) from the project's `tsconfig.json` rather than hardcoding them.
+
+#### How it works
+
+1. **`compilerOptions.lib`** determines which TS lib files to load:
+   - `["ES2020", "DOM"]` → browser project (gets `window`, `document`, `navigator`, etc.)
+   - `["ESNext"]` → server project (gets `Date`, `Promise`, `Map`, etc. but no DOM)
+   - Lib files are loaded transitively via `/// <reference lib="..." />` directives
+
+2. **`compilerOptions.types`** determines which `@types/*` packages to load:
+   - `["node"]` → loads `@types/node` (gets `process`, `Buffer`, `__dirname`, etc.)
+   - `["@cloudflare/workers-types"]` → loads Cloudflare Workers globals
+   - When `types` is not set, all installed `@types/*` packages are auto-included (TS default)
+
+3. **`declare global { ... }` blocks** are parsed to extract globals from packages like `@types/node` that use this pattern
+
+4. **Fallback**: when no `tsconfig.json` is found, defaults to `lib.es5` + `lib.dom` (browser)
+
+#### Implementation
+
+The `interop/ambient.rs` module:
+- Parses `tsconfig.json` for `compilerOptions.lib` and `compilerOptions.types`
+- Locates TypeScript lib files in `node_modules/typescript/lib/`
+- Follows `/// <reference lib="..." />` and `/// <reference path="..." />` directives
+- Parses `declare var`, `declare function`, and `interface` definitions using `oxc_parser`
+- Converts TS types to Floe types via the existing `wrap_boundary_type()` pipeline
+- Registers globals in the checker's type environment, replacing hardcoded fallbacks
+
+Constructor globals (`declare var Window: { prototype: Window; new(): Window }`) are filtered out to prevent shadowing interface definitions used for member access resolution.
+
 ### Code Generator (`floe_codegen`)
 
 Emits clean, readable `.tsx`. Zero runtime imports.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -415,6 +415,25 @@ const fastest = Promise.race([fetchFromCDN(url), fetchFromOrigin(url)]) |> await
 const results = Promise.allSettled([fetchA(), fetchB()]) |> await  // Array<Result<T, Error>>
 Promise.delay(1000) |> await   // wait 1 second
 
+// ── Globals (browser/runtime) ──
+// Globals like window, document, navigator, fetch, process, Buffer are loaded
+// automatically from the project's tsconfig.json — no imports needed.
+//
+// compilerOptions.lib controls which TS lib files load:
+//   "lib": ["ES2020", "DOM"]  → browser globals (window, document, navigator)
+//   "lib": ["ESNext"]         → core JS only (Date, Promise, Map — no DOM)
+//
+// compilerOptions.types controls which @types/* packages load:
+//   "types": ["node"]                      → process, Buffer, __dirname
+//   "types": ["@cloudflare/workers-types"] → Cloudflare Workers globals
+//   (omitted)                              → auto-includes all @types/*
+//
+// Examples:
+const url = window.location.href        // string (from lib.dom.d.ts)
+navigator.clipboard.writeText("hello")  // Promise<void>
+const w = window.innerWidth             // number
+const p = process.env                   // from @types/node
+
 // npm imports are untrusted by default: wrapped in try/catch, return Result<T, Error>
 import { npmSyncFn } from "sync-lib"
 const result = npmSyncFn()            // Result<T, Error> — sync, no await needed

--- a/docs/site/src/content/docs/docs/guide/typescript-interop.md
+++ b/docs/site/src/content/docs/docs/guide/typescript-interop.md
@@ -170,6 +170,31 @@ export fn MyPage() -> JSX.Element {
 }
 ```
 
+## Globals (browser and runtime APIs)
+
+Browser globals like `window`, `document`, `navigator`, and `fetch` are available automatically -- no imports needed. Floe reads your `tsconfig.json` to determine which globals exist:
+
+```floe
+// Browser project (lib includes "DOM")
+const url = window.location.href
+navigator.clipboard.writeText("hello") |> await
+const width = window.innerWidth
+```
+
+For non-browser runtimes, configure `compilerOptions.lib` and `compilerOptions.types` in your `tsconfig.json`:
+
+```json
+// Node.js
+{ "compilerOptions": { "lib": ["ES2020"], "types": ["node"] } }
+```
+
+```floe
+// Now process, Buffer, etc. are available
+const env = process.env
+```
+
+See [Configuration](/docs/reference/configuration/#lib-and-types---controlling-globals) for details.
+
 ## Output
 
 Floe's compiled output is standard TypeScript. Your build tool (Vite, Next.js, etc.) processes it like any other `.ts` file. There is no Floe-specific runtime or framework to install.

--- a/docs/site/src/content/docs/docs/reference/configuration.md
+++ b/docs/site/src/content/docs/docs/reference/configuration.md
@@ -25,6 +25,29 @@ Key settings:
 - `strict: true` - matches Floe's strictness philosophy
 - `moduleResolution: "bundler"` - works with Vite and modern bundlers
 
+### `lib` and `types` - controlling globals
+
+Floe reads `compilerOptions.lib` and `compilerOptions.types` to determine which globals are available:
+
+```json
+// Browser project (default if lib is omitted)
+{ "compilerOptions": { "lib": ["ES2020", "DOM"] } }
+// → window, document, navigator, fetch, Date, Promise, etc.
+
+// Node.js backend
+{ "compilerOptions": { "lib": ["ES2020"], "types": ["node"] } }
+// → process, Buffer, __dirname (no window/document)
+
+// Cloudflare Workers
+{ "compilerOptions": { "lib": ["ESNext"], "types": ["@cloudflare/workers-types"] } }
+// → Workers globals, Date, Promise (no window/document)
+```
+
+- **`lib`** controls which TypeScript lib files are loaded (ES versions, DOM, WebWorker, etc.)
+- **`types`** controls which `@types/*` packages are loaded for global declarations
+- If `types` is omitted, all installed `@types/*` packages are auto-included (TypeScript default)
+- If `lib` is omitted, defaults to `ES5` + `DOM`
+
 ## Project Structure
 
 Recommended layout:


### PR DESCRIPTION
closes #1082

Document the ambient type loading feature added in #987 and #1055.

## Updated docs

- **`.claude/rules/architecture.md`** - added `interop/ambient.rs` to key modules table
- **`docs/design.md`** - added "Ambient Types" section in the compiler internals, covering how globals are loaded from tsconfig
- **`docs/llms.txt`** - added globals section with tsconfig `lib`/`types` examples
- **`docs/site/.../configuration.md`** - documented `compilerOptions.lib` and `compilerOptions.types` for controlling globals
- **`docs/site/.../typescript-interop.md`** - added "Globals" section showing browser/runtime API usage

## Test plan

- [x] Docs-only change, no code modifications