### PR TITLE
feat: [#1105] add parse time infrastructure (line_numbers + ModuleExtra)

### DIFF
--- a/crates/floe-core/src/lib.rs
+++ b/crates/floe-core/src/lib.rs
@@ -6,9 +6,11 @@ pub mod diagnostic;
 pub mod formatter;
 pub mod interop;
 pub mod lexer;
+pub mod line_numbers;
 pub mod lower;
 #[cfg(feature = "cli")]
 pub mod lsp;
+pub mod parse;
 pub mod parser;
 pub mod pretty;
 pub mod resolve;

--- a/crates/floe-core/src/line_numbers.rs
+++ b/crates/floe-core/src/line_numbers.rs
@@ -1,0 +1,202 @@
+//! Columns are measured in bytes (not characters) to match the rest of the
+//! compiler's span representation. LSP clients that require UTF-16 code unit
+//! columns must translate at the boundary.
+
+/// Precomputed line start positions for a single source file. Allows
+/// O(log n) resolution of a byte offset to a 1-based (line, column) pair.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LineNumbers {
+    /// Total length of the source in bytes.
+    pub length: u32,
+    /// Byte offsets where each line begins, in ascending order.
+    ///
+    /// Always contains `0` as the first entry. A newline at byte `i` causes
+    /// `i + 1` to be recorded as the start of the next line, even if the file
+    /// ends there — so an empty trailing line is represented explicitly.
+    pub line_starts: Vec<u32>,
+}
+
+impl LineNumbers {
+    pub fn new(src: &str) -> Self {
+        let bytes = src.as_bytes();
+        // Heuristic: assume ~40 bytes per line on average. Avoids repeated
+        // reallocations for typical source files without over-reserving.
+        let mut line_starts = Vec::with_capacity(bytes.len() / 40 + 1);
+        line_starts.push(0);
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'\n' {
+                line_starts.push((i + 1) as u32);
+            }
+        }
+        Self {
+            length: bytes.len() as u32,
+            line_starts,
+        }
+    }
+
+    /// Offsets past the end of the source return the last line number.
+    pub fn line_number(&self, offset: u32) -> u32 {
+        match self.line_starts.binary_search(&offset) {
+            Ok(idx) => (idx + 1) as u32,
+            Err(idx) => idx.max(1) as u32,
+        }
+    }
+
+    /// Column is measured in bytes from the start of the line — a byte offset
+    /// inside a multi-byte UTF-8 character yields a column pointing at that
+    /// byte, so callers that care about grapheme clusters must translate.
+    pub fn line_and_column_number(&self, offset: u32) -> (u32, u32) {
+        let clamped = offset.min(self.length);
+        let line = self.line_number(clamped);
+        let line_start = self.line_starts[(line - 1) as usize];
+        let column = clamped - line_start + 1;
+        (line, column)
+    }
+
+    /// Out-of-range inputs clamp to the source bounds: `line == 0` behaves as
+    /// `line == 1`, `column == 0` behaves as `column == 1`, and any position
+    /// past the end of the source returns `self.length`.
+    pub fn byte_index(&self, line: u32, column: u32) -> u32 {
+        let line = line.max(1);
+        let idx = (line - 1) as usize;
+        if idx >= self.line_starts.len() {
+            return self.length;
+        }
+        let line_start = self.line_starts[idx];
+        let col_offset = column.saturating_sub(1);
+        (line_start + col_offset).min(self.length)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_source() {
+        let ln = LineNumbers::new("");
+        assert_eq!(ln.length, 0);
+        assert_eq!(ln.line_starts, vec![0]);
+        assert_eq!(ln.line_and_column_number(0), (1, 1));
+    }
+
+    #[test]
+    fn single_line_no_newline() {
+        let ln = LineNumbers::new("hello");
+        assert_eq!(ln.line_starts, vec![0]);
+        assert_eq!(ln.line_and_column_number(0), (1, 1));
+        assert_eq!(ln.line_and_column_number(1), (1, 2));
+        assert_eq!(ln.line_and_column_number(4), (1, 5));
+        // At EOF position
+        assert_eq!(ln.line_and_column_number(5), (1, 6));
+    }
+
+    #[test]
+    fn single_line_with_trailing_newline() {
+        let ln = LineNumbers::new("hello\n");
+        // Line 2 starts just after the newline, even though it's empty.
+        assert_eq!(ln.line_starts, vec![0, 6]);
+        assert_eq!(ln.line_and_column_number(5), (1, 6));
+        assert_eq!(ln.line_and_column_number(6), (2, 1));
+    }
+
+    #[test]
+    fn multi_line() {
+        // "ab\ncde\nf"
+        //  01 2 345 6 7
+        let ln = LineNumbers::new("ab\ncde\nf");
+        assert_eq!(ln.line_starts, vec![0, 3, 7]);
+
+        assert_eq!(ln.line_and_column_number(0), (1, 1)); // 'a'
+        assert_eq!(ln.line_and_column_number(1), (1, 2)); // 'b'
+        assert_eq!(ln.line_and_column_number(2), (1, 3)); // '\n'
+        assert_eq!(ln.line_and_column_number(3), (2, 1)); // 'c'
+        assert_eq!(ln.line_and_column_number(4), (2, 2)); // 'd'
+        assert_eq!(ln.line_and_column_number(5), (2, 3)); // 'e'
+        assert_eq!(ln.line_and_column_number(6), (2, 4)); // '\n'
+        assert_eq!(ln.line_and_column_number(7), (3, 1)); // 'f'
+    }
+
+    #[test]
+    fn line_number_uses_binary_search() {
+        // Many lines so the binary search branch actually matters.
+        let src: String = (0..100).map(|_| "x\n").collect();
+        let ln = LineNumbers::new(&src);
+        assert_eq!(ln.line_starts.len(), 101);
+
+        // Byte 0 is the start of line 1.
+        assert_eq!(ln.line_number(0), 1);
+        // Byte 50 is in line 26 (each line is 2 bytes).
+        assert_eq!(ln.line_number(50), 26);
+        // Byte 199 is the last 'x' on line 100.
+        assert_eq!(ln.line_number(199), 100);
+        // Byte 200 is the start of line 101 (past the final \n).
+        assert_eq!(ln.line_number(200), 101);
+    }
+
+    #[test]
+    fn multi_byte_utf8_column_counts_bytes() {
+        // 'é' is 2 bytes in UTF-8 (0xC3 0xA9). 'a' 'é' 'b':
+        //  byte 0: 'a'
+        //  byte 1: 0xC3 (lead byte of 'é')
+        //  byte 2: 0xA9 (continuation byte)
+        //  byte 3: 'b'
+        let src = "aéb";
+        let ln = LineNumbers::new(src);
+        assert_eq!(ln.length, 4);
+        assert_eq!(ln.line_and_column_number(0), (1, 1));
+        assert_eq!(ln.line_and_column_number(1), (1, 2)); // lead byte of 'é'
+        assert_eq!(ln.line_and_column_number(2), (1, 3)); // continuation byte
+        assert_eq!(ln.line_and_column_number(3), (1, 4)); // 'b'
+    }
+
+    #[test]
+    fn multi_byte_across_lines() {
+        let src = "é\né";
+        // bytes: [0xC3, 0xA9, b'\n', 0xC3, 0xA9]  length 5
+        let ln = LineNumbers::new(src);
+        assert_eq!(ln.line_starts, vec![0, 3]);
+        assert_eq!(ln.line_and_column_number(0), (1, 1));
+        assert_eq!(ln.line_and_column_number(3), (2, 1));
+        assert_eq!(ln.line_and_column_number(4), (2, 2));
+    }
+
+    #[test]
+    fn offset_past_end_clamps() {
+        let ln = LineNumbers::new("hi");
+        assert_eq!(ln.line_and_column_number(100), (1, 3));
+    }
+
+    #[test]
+    fn byte_index_round_trip() {
+        let src = "ab\ncde\nf";
+        let ln = LineNumbers::new(src);
+        for offset in 0u32..(src.len() as u32) {
+            let (line, col) = ln.line_and_column_number(offset);
+            assert_eq!(ln.byte_index(line, col), offset, "offset {offset}");
+        }
+    }
+
+    #[test]
+    fn byte_index_handles_edge_inputs() {
+        let ln = LineNumbers::new("ab\ncde");
+        // Line 0 clamps to line 1.
+        assert_eq!(ln.byte_index(0, 1), 0);
+        // Column 0 clamps to column 1.
+        assert_eq!(ln.byte_index(2, 0), 3);
+        // Line past end clamps to source length.
+        assert_eq!(ln.byte_index(99, 1), ln.length);
+        // Column past end of file clamps to source length.
+        assert_eq!(ln.byte_index(2, 999), ln.length);
+    }
+
+    #[test]
+    fn consecutive_empty_lines() {
+        // "a\n\n\nb" — three newlines, two empty lines in the middle.
+        let ln = LineNumbers::new("a\n\n\nb");
+        assert_eq!(ln.line_starts, vec![0, 2, 3, 4]);
+        assert_eq!(ln.line_number(2), 2); // start of first empty line
+        assert_eq!(ln.line_number(3), 3); // start of second empty line
+        assert_eq!(ln.line_number(4), 4); // 'b'
+    }
+}

--- a/crates/floe-core/src/parse.rs
+++ b/crates/floe-core/src/parse.rs
@@ -1,0 +1,3 @@
+pub mod extra;
+
+pub use extra::{ModuleExtra, SrcSpan};

--- a/crates/floe-core/src/parse/extra.rs
+++ b/crates/floe-core/src/parse/extra.rs
@@ -1,0 +1,333 @@
+//! Storing comments as byte spans in a side channel (rather than attaching
+//! them to AST nodes) is what lets the formatter walk the tree without any
+//! risk of filtering comments out.
+
+use crate::lexer::token::{Token, TokenKind};
+
+/// A byte-only source span. Intentionally narrower than [`crate::lexer::span::Span`] —
+/// it carries just the start/end byte offsets because `ModuleExtra` only needs
+/// to point at ranges of source text. Line/column resolution is done on demand
+/// through [`crate::line_numbers::LineNumbers`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SrcSpan {
+    pub start: u32,
+    pub end: u32,
+}
+
+impl SrcSpan {
+    pub const fn new(start: u32, end: u32) -> Self {
+        Self { start, end }
+    }
+
+    pub fn len(&self) -> u32 {
+        self.end - self.start
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.start == self.end
+    }
+
+    /// Returns `true` if `offset` is within `[start, end)`.
+    pub fn contains(&self, offset: u32) -> bool {
+        offset >= self.start && offset < self.end
+    }
+}
+
+/// Parse-time side-channel for a single module.
+///
+/// All vectors are kept in ascending order of `start`, which lets callers use
+/// binary search to answer "what appears between two AST nodes?" queries.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ModuleExtra {
+    /// Regular comments: `// ...` and `/* ... */`.
+    pub comments: Vec<SrcSpan>,
+    /// Doc comments: `/// ...`. Attach to the following declaration.
+    pub doc_comments: Vec<SrcSpan>,
+    /// Module-level doc comments: `//// ...`. Attach to the whole module.
+    pub module_comments: Vec<SrcSpan>,
+    /// Byte offsets of the terminating newline of each blank line. A blank
+    /// line is a line whose content between its start and its trailing `\n`
+    /// is entirely whitespace. Recording the terminating newline (rather than
+    /// the one that opens the line) gives each blank line a unique offset and
+    /// lets "is there a blank line between X and Y?" be a simple range query.
+    pub empty_lines: Vec<u32>,
+    /// Byte offsets of every `\n` in the source, in ascending order. Used by
+    /// the formatter to decide whether two spans straddle a line boundary.
+    pub new_lines: Vec<u32>,
+}
+
+impl ModuleExtra {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// `tokens` must include trivia — the ones from `Lexer::tokenize_with_trivia`.
+    /// Newlines and empty lines are collected by walking the source bytes
+    /// directly rather than the whitespace tokens, so interior newlines of
+    /// multi-line strings and templates are still tracked.
+    pub fn from_tokens(source: &str, tokens: &[Token]) -> Self {
+        let mut extra = Self::new();
+        collect_newlines(source, &mut extra);
+        classify_comments(source, tokens, &mut extra);
+        extra
+    }
+
+    /// Returns the earliest comment whose `start` lies in `[start, end)`.
+    /// The range is half-open so a comment starting exactly at `end` is
+    /// *not* included.
+    pub fn first_comment_between(&self, start: u32, end: u32) -> Option<SrcSpan> {
+        [&self.comments, &self.doc_comments, &self.module_comments]
+            .into_iter()
+            .filter_map(|list| first_starting_in(list, start, end))
+            .min_by_key(|s| s.start)
+    }
+}
+
+/// Binary-search for the first span in `list` whose `start` is in `[start, end)`.
+fn first_starting_in(list: &[SrcSpan], start: u32, end: u32) -> Option<SrcSpan> {
+    let idx = list.partition_point(|s| s.start < start);
+    list.get(idx).copied().filter(|s| s.start < end)
+}
+
+fn collect_newlines(source: &str, extra: &mut ModuleExtra) {
+    let bytes = source.as_bytes();
+    // Rough heuristic: ~40 bytes per line. Avoids repeated Vec reallocations on
+    // files with thousands of lines. Same rule used by LineNumbers::new.
+    let capacity = bytes.len() / 40 + 1;
+    extra.new_lines.reserve(capacity);
+
+    // Single pass: for each `\n`, record it and check whether the segment
+    // since the previous newline (or BOF) was entirely whitespace. If so the
+    // current newline terminates a blank line.
+    let mut segment_blank = true;
+    for (i, &b) in bytes.iter().enumerate() {
+        if b == b'\n' {
+            if segment_blank {
+                extra.empty_lines.push(i as u32);
+            }
+            extra.new_lines.push(i as u32);
+            segment_blank = true;
+        } else if !b.is_ascii_whitespace() {
+            segment_blank = false;
+        }
+    }
+}
+
+fn classify_comments(source: &str, tokens: &[Token], extra: &mut ModuleExtra) {
+    for token in tokens {
+        let span = SrcSpan::new(token.span.start as u32, token.span.end as u32);
+        match token.kind {
+            TokenKind::Comment => {
+                let text = &source[token.span.start..token.span.end];
+                if text.starts_with("////") {
+                    extra.module_comments.push(span);
+                } else if text.starts_with("///") {
+                    extra.doc_comments.push(span);
+                } else {
+                    extra.comments.push(span);
+                }
+            }
+            TokenKind::BlockComment => {
+                extra.comments.push(span);
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::Lexer;
+
+    fn build(source: &str) -> ModuleExtra {
+        let tokens = Lexer::new(source).tokenize_with_trivia();
+        ModuleExtra::from_tokens(source, &tokens)
+    }
+
+    fn span(start: u32, end: u32) -> SrcSpan {
+        SrcSpan::new(start, end)
+    }
+
+    #[test]
+    fn src_span_basics() {
+        let s = span(3, 7);
+        assert_eq!(s.len(), 4);
+        assert!(!s.is_empty());
+        assert!(s.contains(3));
+        assert!(s.contains(6));
+        assert!(!s.contains(7));
+        assert!(!s.contains(2));
+
+        let empty = span(5, 5);
+        assert!(empty.is_empty());
+        assert_eq!(empty.len(), 0);
+    }
+
+    #[test]
+    fn empty_source_produces_empty_extra() {
+        let extra = build("");
+        assert!(extra.comments.is_empty());
+        assert!(extra.doc_comments.is_empty());
+        assert!(extra.module_comments.is_empty());
+        assert!(extra.empty_lines.is_empty());
+        assert!(extra.new_lines.is_empty());
+    }
+
+    #[test]
+    fn source_without_comments_has_empty_comment_lists() {
+        let extra = build("const x = 1\nconst y = 2\n");
+        assert!(extra.comments.is_empty());
+        assert!(extra.doc_comments.is_empty());
+        assert!(extra.module_comments.is_empty());
+    }
+
+    #[test]
+    fn classifies_line_doc_and_module_comments() {
+        //                              1111111111222222222233333333334444444444
+        //                    0123456789012345678901234567890123456789012345678
+        let source = "//// module doc\n/// item doc\n// regular\nconst x = 1\n";
+
+        let extra = build(source);
+
+        assert_eq!(extra.module_comments.len(), 1);
+        assert_eq!(extra.doc_comments.len(), 1);
+        assert_eq!(extra.comments.len(), 1);
+
+        assert_eq!(extra.module_comments[0].start, 0);
+        assert_eq!(extra.module_comments[0].end, 15);
+        assert!(source[..extra.module_comments[0].end as usize].starts_with("////"));
+
+        assert_eq!(extra.doc_comments[0].start, 16);
+        assert_eq!(extra.doc_comments[0].end, 28);
+
+        assert_eq!(extra.comments[0].start, 29);
+        assert_eq!(extra.comments[0].end, 39);
+    }
+
+    #[test]
+    fn block_comment_classified_as_regular() {
+        let source = "/* a block comment */ const x = 1";
+        let extra = build(source);
+        assert_eq!(extra.comments.len(), 1);
+        assert!(extra.doc_comments.is_empty());
+        assert!(extra.module_comments.is_empty());
+        assert_eq!(extra.comments[0].start, 0);
+        assert_eq!(extra.comments[0].end, 21);
+    }
+
+    #[test]
+    fn comments_are_recorded_in_source_order() {
+        let source = "// one\n// two\n// three\nconst x = 1";
+        let extra = build(source);
+        assert_eq!(extra.comments.len(), 3);
+        let starts: Vec<u32> = extra.comments.iter().map(|s| s.start).collect();
+        assert_eq!(starts, vec![0, 7, 14]);
+        for window in extra.comments.windows(2) {
+            assert!(window[0].start < window[1].start);
+        }
+    }
+
+    #[test]
+    fn tracks_every_newline() {
+        let source = "a\nb\nc\n";
+        let extra = build(source);
+        assert_eq!(extra.new_lines, vec![1, 3, 5]);
+    }
+
+    #[test]
+    fn empty_lines_between_statements_are_preserved() {
+        // "a\n\nb\n" — one blank line between "a" and "b".
+        //     ^ pos 1 is the newline that ends line 1
+        //      ^ pos 2 is the terminating newline of the blank line
+        let source = "a\n\nb\n";
+        let extra = build(source);
+        assert_eq!(extra.new_lines, vec![1, 2, 4]);
+        assert_eq!(extra.empty_lines, vec![2]);
+    }
+
+    #[test]
+    fn multiple_consecutive_empty_lines() {
+        // Three newlines in a row = two blank lines, with terminators at
+        // positions 2 and 3.
+        let source = "a\n\n\nb";
+        let extra = build(source);
+        assert_eq!(extra.new_lines, vec![1, 2, 3]);
+        assert_eq!(extra.empty_lines, vec![2, 3]);
+    }
+
+    #[test]
+    fn blank_line_with_whitespace_still_counts() {
+        let source = "a\n   \nb";
+        let extra = build(source);
+        // The " " run is tokenized as Whitespace, but we drive empty-line
+        // detection from raw bytes so it's still found.
+        assert_eq!(extra.new_lines, vec![1, 5]);
+        assert_eq!(extra.empty_lines, vec![5]);
+    }
+
+    #[test]
+    fn leading_blank_lines_are_recorded() {
+        let source = "\n\nconst x = 1";
+        let extra = build(source);
+        assert_eq!(extra.new_lines, vec![0, 1]);
+        // Both lines before the const are blank, so we record both terminators.
+        assert_eq!(extra.empty_lines, vec![0, 1]);
+    }
+
+    #[test]
+    fn first_comment_between_returns_none_when_empty() {
+        let extra = ModuleExtra::new();
+        assert_eq!(extra.first_comment_between(0, 100), None);
+    }
+
+    #[test]
+    fn first_comment_between_finds_earliest_across_categories() {
+        let mut extra = ModuleExtra::new();
+        extra.comments.push(span(20, 25));
+        extra.comments.push(span(60, 65));
+        extra.doc_comments.push(span(10, 18));
+        extra.doc_comments.push(span(50, 58));
+        extra.module_comments.push(span(0, 8));
+
+        // Whole range: earliest is the module comment at 0.
+        assert_eq!(extra.first_comment_between(0, 100), Some(span(0, 8)));
+
+        // Range that excludes the module comment: earliest is the doc at 10.
+        assert_eq!(extra.first_comment_between(9, 100), Some(span(10, 18)));
+
+        // Range that contains only the late regular comment.
+        assert_eq!(extra.first_comment_between(59, 100), Some(span(60, 65)));
+
+        // Empty range → nothing.
+        assert_eq!(extra.first_comment_between(26, 49), None);
+
+        // Exclusive end: a comment at exactly `end` does not match.
+        assert_eq!(extra.first_comment_between(10, 10), None);
+        // Inclusive start: a comment at exactly `start` does match.
+        assert_eq!(extra.first_comment_between(10, 11), Some(span(10, 18)));
+    }
+
+    #[test]
+    fn first_comment_between_uses_binary_search_correctness() {
+        let mut extra = ModuleExtra::new();
+        for i in 0..100u32 {
+            extra.comments.push(span(i * 10, i * 10 + 5));
+        }
+
+        // Search in the middle of a densely packed range.
+        assert_eq!(extra.first_comment_between(500, 600), Some(span(500, 505)));
+        assert_eq!(extra.first_comment_between(501, 600), Some(span(510, 515)));
+        // No match when the range falls between two comments.
+        assert_eq!(extra.first_comment_between(505, 510), None);
+    }
+
+    #[test]
+    fn comments_inside_strings_are_not_captured() {
+        // The `//` inside a string literal must NOT be reported as a comment —
+        // the lexer handles escaping, and we walk its tokens.
+        let source = r#"const url = "https://floe.dev""#;
+        let extra = build(source);
+        assert!(extra.comments.is_empty());
+    }
+}

--- a/crates/floe-core/src/parser.rs
+++ b/crates/floe-core/src/parser.rs
@@ -3,10 +3,11 @@ pub mod ast;
 #[cfg(test)]
 mod tests;
 
-use crate::cst::CstParser;
+use crate::cst::{CstError, CstParser, Parse as CstParse};
 use crate::lexer::Lexer;
 use crate::lexer::span::Span;
 use crate::lower::{lower_program, lower_program_lossy};
+use crate::parse::ModuleExtra;
 use ast::*;
 
 /// Classification of parse errors for structured diagnostic handling.
@@ -71,55 +72,70 @@ impl Parser {
 
     /// Parse a complete program using the CST pipeline (lexer -> CST -> lower -> AST).
     pub fn parse(source: &str) -> Result<Program, Vec<ParseError>> {
-        let tokens = Lexer::new(source).tokenize_with_trivia();
-        let cst_parse = CstParser::new(source, tokens).parse();
-
+        let cst_parse = lex_and_cst(source);
         if !cst_parse.errors.is_empty() {
-            return Err(cst_parse
-                .errors
-                .into_iter()
-                .map(|e| {
-                    let kind = ParseErrorKind::classify(&e.message);
-                    ParseError {
-                        message: e.message,
-                        span: e.span,
-                        kind,
-                    }
-                })
-                .collect());
+            return Err(classify_cst_errors(cst_parse.errors));
         }
+        lower_program(&cst_parse.syntax(), source)
+    }
 
-        let root = cst_parse.syntax();
-        lower_program(&root, source)
+    /// Parse a complete module, returning the AST alongside the parse-time
+    /// side channel ([`ModuleExtra`]) that records comments, doc comments, and
+    /// empty line positions. Consumers that don't need the side channel can
+    /// use [`Parser::parse`] instead — it skips the `ModuleExtra` construction
+    /// pass, which matters for compiler hot paths that discard the extras.
+    pub fn parse_module(source: &str) -> Result<(Program, ModuleExtra), Vec<ParseError>> {
+        let (cst_parse, extra) = lex_and_cst_with_extra(source);
+        if !cst_parse.errors.is_empty() {
+            return Err(classify_cst_errors(cst_parse.errors));
+        }
+        lower_program(&cst_parse.syntax(), source).map(|program| (program, extra))
     }
 
     /// Parse on a best-effort basis, returning whatever AST was successfully
     /// built along with any parse errors. Used by the LSP so that a partial
     /// symbol index can be built even when the source has errors.
     pub fn parse_lossy(source: &str) -> (Program, Vec<ParseError>) {
-        let tokens = Lexer::new(source).tokenize_with_trivia();
-        let cst_parse = CstParser::new(source, tokens).parse();
-
-        let cst_errors: Vec<ParseError> = cst_parse
-            .errors
-            .iter()
-            .map(|e| {
-                let kind = ParseErrorKind::classify(&e.message);
-                ParseError {
-                    message: e.message.clone(),
-                    span: e.span,
-                    kind,
-                }
-            })
-            .collect();
-
+        let cst_parse = lex_and_cst(source);
         let root = cst_parse.syntax();
+        let mut errors = classify_cst_errors(cst_parse.errors);
         let (program, lower_errors) = lower_program_lossy(&root, source);
-
-        let mut all_errors = cst_errors;
-        all_errors.extend(lower_errors);
-        (program, all_errors)
+        errors.extend(lower_errors);
+        (program, errors)
     }
+
+    /// Best-effort parse that also returns the [`ModuleExtra`] side channel.
+    pub fn parse_lossy_module(source: &str) -> (Program, ModuleExtra, Vec<ParseError>) {
+        let (cst_parse, extra) = lex_and_cst_with_extra(source);
+        let root = cst_parse.syntax();
+        let mut errors = classify_cst_errors(cst_parse.errors);
+        let (program, lower_errors) = lower_program_lossy(&root, source);
+        errors.extend(lower_errors);
+        (program, extra, errors)
+    }
+}
+
+fn lex_and_cst(source: &str) -> CstParse {
+    let tokens = Lexer::new(source).tokenize_with_trivia();
+    CstParser::new(source, tokens).parse()
+}
+
+fn lex_and_cst_with_extra(source: &str) -> (CstParse, ModuleExtra) {
+    let tokens = Lexer::new(source).tokenize_with_trivia();
+    let extra = ModuleExtra::from_tokens(source, &tokens);
+    let parse = CstParser::new(source, tokens).parse();
+    (parse, extra)
+}
+
+fn classify_cst_errors(errors: Vec<CstError>) -> Vec<ParseError> {
+    errors
+        .into_iter()
+        .map(|e| ParseError {
+            kind: ParseErrorKind::classify(&e.message),
+            message: e.message,
+            span: e.span,
+        })
+        .collect()
 }
 
 /// Handle returned by `Parser::new(source)` that allows calling `parse_program()`.

--- a/crates/floe-core/src/parser/tests.rs
+++ b/crates/floe-core/src/parser/tests.rs
@@ -2112,3 +2112,49 @@ fn type_alias_still_parses_as_alias() {
         other => panic!("expected TypeDecl, got {other:?}"),
     }
 }
+
+#[test]
+fn parse_module_classifies_comment_kinds() {
+    let source = "\
+//// module header
+/// item doc
+// plain
+const x = 1
+";
+    let (program, extra) = Parser::parse_module(source).unwrap();
+    assert_eq!(program.items.len(), 1);
+    assert_eq!(extra.module_comments.len(), 1);
+    assert_eq!(extra.doc_comments.len(), 1);
+    assert_eq!(extra.comments.len(), 1);
+
+    let module_text =
+        &source[extra.module_comments[0].start as usize..extra.module_comments[0].end as usize];
+    assert!(module_text.starts_with("////"));
+
+    let doc_text =
+        &source[extra.doc_comments[0].start as usize..extra.doc_comments[0].end as usize];
+    assert!(doc_text.starts_with("///") && !doc_text.starts_with("////"));
+
+    let comment_text = &source[extra.comments[0].start as usize..extra.comments[0].end as usize];
+    assert!(comment_text.starts_with("//") && !comment_text.starts_with("///"));
+}
+
+#[test]
+fn parse_module_records_empty_lines_between_statements() {
+    let source = "const a = 1\n\nconst b = 2\n";
+    let (_, extra) = Parser::parse_module(source).unwrap();
+    assert_eq!(extra.empty_lines.len(), 1);
+    let offset = extra.empty_lines[0] as usize;
+    assert_eq!(source.as_bytes()[offset], b'\n');
+    assert!(source[..offset].ends_with("const a = 1\n"));
+    assert!(source[offset + 1..].starts_with("const b = 2"));
+}
+
+#[test]
+fn parse_lossy_module_exposes_extra_even_when_errors() {
+    let source = "// leading\nconst = 1\n";
+    let (_, extra, errors) = Parser::parse_lossy_module(source);
+    assert!(!errors.is_empty(), "expected parse errors");
+    assert_eq!(extra.comments.len(), 1);
+    assert!(extra.new_lines.contains(&10));
+}


### PR DESCRIPTION
closes #1105

Part of epic #1101 (Gleam-style compiler refactor). Adds two pieces of parse-time infrastructure the compiler was missing: a `LineNumbers` table for byte-offset → (line, column) via binary search, and a `ModuleExtra` side-channel that records comment/empty-line/newline spans outside the AST.

## Summary

- `floe-core/src/line_numbers.rs` — `LineNumbers { length, line_starts }` with binary-search `line_number`, `line_and_column_number`, `byte_index`. Byte-based columns (LSP clients translate to UTF-16 at the boundary).
- `floe-core/src/parse/extra.rs` — new `SrcSpan { start, end }` (byte-only) and `ModuleExtra { comments, doc_comments, module_comments, empty_lines, new_lines }`. Single-pass source scan for newlines + empty lines, token-stream scan for comment classification (`//` vs `///` vs `////`). `first_comment_between` does 3-way binary search with `partition_point`.
- `floe-core/src/parser.rs` — new `Parser::parse_module` / `parse_lossy_module` return `(Program, ModuleExtra)`. Existing `Parser::parse` / `parse_lossy` skip the `ModuleExtra` construction pass so the 30+ hot-path callers (tests, dts parsing, codegen, interop) that discard the extras don't pay for it. Shared `lex_and_cst`, `lex_and_cst_with_extra`, `classify_cst_errors` helpers keep the four entry points short.

Storing comments as byte spans in a side channel (rather than attaching them to AST nodes) is the Gleam pattern that makes the formatter robust — tree walks can't filter comments out. This unblocks #1116 (formatter rewrite on pretty.rs + ModuleExtra).

## Test plan

- [x] `cargo test -p floe-core --lib` → 1376 passed, 0 failed (+29 new tests)
  - 11 `line_numbers` tests: empty file, trailing newline, multi-line binary search, multi-byte UTF-8 (column counts bytes), offset-past-end clamping, round-trips, edge inputs, consecutive empty lines
  - 15 `parse::extra` tests: `SrcSpan` helpers, comment kind classification, source-order recording, newline tracking, empty-line detection (including blank-lines-with-whitespace and leading blank lines), `first_comment_between` binary search across three vectors, strings-containing-`//` not captured
  - 3 `parser::tests` integration tests: `parse_module_classifies_comment_kinds`, `parse_module_records_empty_lines_between_statements`, `parse_lossy_module_exposes_extra_even_when_errors`
- [x] `cargo clippy --workspace --all-targets` → clean
- [x] `cargo fmt --check` → clean
- [x] `floe check examples/todo-app/src/` → 6 files, no errors
- [x] `floe check examples/store/src/` → 8 files, no errors