### PR TITLE
fix: [#1115] error on calls through Unknown typed callee

### DIFF
--- a/crates/floe-core/src/checker/error_codes.rs
+++ b/crates/floe-core/src/checker/error_codes.rs
@@ -102,13 +102,17 @@ pub enum ErrorCode {
     /// Literal pattern type mismatch (e.g. `true` on a string).
     LiteralPatternMismatch,
 
+    // ── Call-site errors ───────────────────────────────────────────────
+    /// Callee has unknown type - arguments are not type-checked (error).
+    UncheckedArguments,
+
     // ── Warnings ─────────────────────────────────────────────────────
     /// `todo` placeholder will panic at runtime.
     TodoPlaceholder,
     /// Spread field overwritten by explicit field.
     SpreadFieldOverwritten,
-    /// Callee has unknown type - arguments are not type-checked.
-    UncheckedArguments,
+    /// Foreign callee has unknown type - arguments are not type-checked (warning).
+    UncheckedForeignArguments,
     /// Binding pattern on a finite type (boolean, union) - likely a typo.
     SuspiciousBinding,
     /// Binding resolved to `unknown` type.
@@ -178,7 +182,8 @@ impl ErrorCode {
             Self::LiteralPatternMismatch => "E040",
             Self::TodoPlaceholder => "W002",
             Self::SpreadFieldOverwritten => "W003",
-            Self::UncheckedArguments => "W004",
+            Self::UncheckedForeignArguments => "W004",
+            Self::UncheckedArguments => "E051",
             Self::SuspiciousBinding => "W005",
             Self::UnknownBinding => "W006",
             Self::TryOnFloeFunction => "W007",

--- a/crates/floe-core/src/checker/expr.rs
+++ b/crates/floe-core/src/checker/expr.rs
@@ -1109,7 +1109,7 @@ impl Checker {
                 self.check_args_unchecked(args);
                 Type::Foreign("_".into())
             }
-            // Standalone Foreign identifier (trusted import without type info):
+            // Standalone Foreign identifier (npm import without type info):
             // argument types can't be validated. Warn so users know to add .d.ts types.
             // Returns Error to suppress cascading — the warning was already emitted.
             Type::Foreign(foreign_name) => {
@@ -1117,9 +1117,9 @@ impl Checker {
                 self.emit_warning_with_help(
                     format!("`{foreign_name}` has unknown type - arguments are not type-checked"),
                     span,
-                    ErrorCode::UncheckedArguments,
-                    "Type could not be resolved",
-                    "Check that the import source has type declarations",
+                    ErrorCode::UncheckedForeignArguments,
+                    "type could not be resolved",
+                    "check that the import source has type declarations",
                 );
                 Type::Error
             }
@@ -1135,12 +1135,12 @@ impl Checker {
                     ExprKind::Member { field, .. } => field.as_str(),
                     _ => "<expression>",
                 };
-                self.emit_warning_with_help(
+                self.emit_error_with_help(
                     format!("`{callee_name}` has unknown type - arguments are not type-checked"),
                     span,
                     ErrorCode::UncheckedArguments,
-                    "Type could not be resolved",
-                    "Check that the import source has type declarations",
+                    "type could not be resolved",
+                    "check that the import source has type declarations",
                 );
                 Type::Error
             }

--- a/crates/floe-core/src/checker/expr.rs
+++ b/crates/floe-core/src/checker/expr.rs
@@ -1098,13 +1098,8 @@ impl Checker {
                     return_type
                 }
             }
-            // Foreign types (npm) via member access: the callee is a chained method
-            // on an opaque npm type (e.g. `db.insert(snippets).values`). We can't
-            // validate arguments but the result stays Foreign so subsequent chained
-            // member accesses and calls continue to work.
-            //
-            // Foreign member access (chained call): preserve Foreign type so subsequent
-            // member accesses and calls continue to work.
+            // Foreign member access (chained call on opaque npm type like
+            // `db.insert(snippets).values`): preserve Foreign so chaining works.
             Type::Foreign(_) if matches!(callee.kind, ExprKind::Member { .. }) => {
                 self.check_args_unchecked(args);
                 Type::Foreign("_".into())
@@ -1140,7 +1135,7 @@ impl Checker {
                     span,
                     ErrorCode::UncheckedArguments,
                     "type could not be resolved",
-                    "check that the import source has type declarations",
+                    "ensure the value has a known callable type",
                 );
                 Type::Error
             }

--- a/crates/floe-core/src/checker/imports.rs
+++ b/crates/floe-core/src/checker/imports.rs
@@ -77,13 +77,12 @@ impl Checker {
                         }
                     }
                     let ty = interop::wrap_boundary_type(&dts_export.ts_type);
-                    // Type-only TS exports (interfaces, type aliases) resolve
-                    // to Any/Unknown through the probe since they have no runtime
-                    // value. Treat them as Foreign so they're usable as type
-                    // annotations (e.g. `fn f(x: DropResult)`).
-                    if matches!(ty, Type::Unknown)
-                        && matches!(dts_export.ts_type, interop::TsType::Any)
-                    {
+                    // npm imports that resolve to Unknown (unrecognized primitive,
+                    // type-only exports, overloaded signatures tsgo can't map)
+                    // should fall back to Foreign. They're at an explicit npm
+                    // boundary — Foreign produces a warning on call, while Unknown
+                    // would produce an error.
+                    if matches!(ty, Type::Unknown) {
                         Type::Foreign(spec.name.clone())
                     } else {
                         ty

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -5981,21 +5981,6 @@ const _result = takesString(x)
     );
 }
 
-#[test]
-fn unknown_callee_emits_error() {
-    let diags = check(
-        r#"
-fn returnsUnknown() -> unknown { "hello" }
-const f = returnsUnknown()
-const _result = f(42)
-"#,
-    );
-    assert!(
-        has_error(&diags, ErrorCode::UncheckedArguments),
-        "should error when calling unknown-typed value, got: {diags:?}"
-    );
-}
-
 // ── Unknown callee errors (#1115) ────────────────────────────
 
 #[test]

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -474,8 +474,7 @@ const _x = _user |> display
 // ── Untrusted Import Auto-wrapping ───────────────────────────
 
 #[test]
-fn untrusted_import_auto_wraps_to_result() {
-    // Untrusted npm imports auto-wrap return type to Result
+fn untrusted_import_without_types_warns() {
     let diags = check(
         r#"
 import { capitalize } from "some-lib"
@@ -483,14 +482,22 @@ const _x = capitalize("hello")
 "#,
     );
     assert!(
-        diags.iter().all(|d| d.severity != Severity::Error),
-        "untrusted npm import should be callable (auto-wrapped), got: {:?}",
+        has_error(&diags, ErrorCode::UncheckedForeignArguments),
+        "calling untyped foreign import should warn, got: {:?}",
         diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    assert!(
+        diags.iter().all(|d| d.severity != Severity::Error),
+        "foreign callee should produce warning not error, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (&d.severity, &d.message))
+            .collect::<Vec<_>>()
     );
 }
 
 #[test]
-fn trusted_specifier_no_auto_wrap() {
+fn trusted_import_without_types_warns() {
     let diags = check(
         r#"
 import { trusted capitalize } from "some-lib"
@@ -498,14 +505,14 @@ const _x = capitalize("hello")
 "#,
     );
     assert!(
-        diags.iter().all(|d| d.severity != Severity::Error),
-        "trusted import should be callable directly, got: {:?}",
+        has_error(&diags, ErrorCode::UncheckedForeignArguments),
+        "calling untyped trusted import should warn, got: {:?}",
         diags.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
 
 #[test]
-fn trusted_module_no_auto_wrap() {
+fn trusted_module_without_types_warns() {
     let diags = check(
         r#"
 import trusted { capitalize, slugify } from "string-utils"
@@ -514,8 +521,8 @@ const _y = slugify("hello world")
 "#,
     );
     assert!(
-        diags.iter().all(|d| d.severity != Severity::Error),
-        "trusted module import should be callable directly, got: {:?}",
+        has_error(&diags, ErrorCode::UncheckedForeignArguments),
+        "calling untyped trusted module import should warn, got: {:?}",
         diags.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
@@ -2792,11 +2799,11 @@ fn timer_globals_are_recognized() {
 // ── Unsafe narrowing from unknown ───────────────────────────
 
 #[test]
-fn narrowing_unknown_call_result_does_not_cascade() {
-    // After #1114, calling through an unknown callee returns Type::Error
-    // (the warning was already emitted at the call site). Assigning the
-    // Error-typed result to a `number`-annotated binding should NOT
-    // produce a second "unsafe narrowing" error — that would be cascade.
+fn narrowing_foreign_call_result_does_not_cascade() {
+    // Calling through a foreign callee returns Type::Error (the warning was
+    // already emitted at the call site). Assigning the Error-typed result
+    // to a `number`-annotated binding should NOT produce a second
+    // "unsafe narrowing" error — that would be cascade.
     let diags = check(
         r#"
 import trusted { getData } from "some-lib"
@@ -2805,8 +2812,8 @@ const x: number = data
 "#,
     );
     assert!(
-        has_error(&diags, ErrorCode::UncheckedArguments),
-        "call through unknown callee should warn, got: {:?}",
+        has_error(&diags, ErrorCode::UncheckedForeignArguments),
+        "call through foreign callee should warn, got: {:?}",
         diags.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
     assert!(
@@ -2886,10 +2893,10 @@ export fn bad() -> Promise<string> {
 // ── Member access on unknown ────────────────────────────────
 
 #[test]
-fn member_access_on_unknown_call_result_does_not_cascade() {
-    // After #1114, calling getData() returns Type::Error (warning emitted
-    // at call site). Member access on Error silently propagates Error
-    // instead of cascading a second AccessOnUnknown diagnostic.
+fn member_access_on_foreign_call_result_does_not_cascade() {
+    // Calling getData() returns Type::Error (warning emitted at call site).
+    // Member access on Error silently propagates Error instead of cascading
+    // a second AccessOnUnknown diagnostic.
     let diags = check(
         r#"
 import trusted { getData } from "some-lib"
@@ -2898,8 +2905,8 @@ const x = data.name
 "#,
     );
     assert!(
-        has_error(&diags, ErrorCode::UncheckedArguments),
-        "call through unknown callee should warn, got: {:?}",
+        has_error(&diags, ErrorCode::UncheckedForeignArguments),
+        "call through foreign callee should warn, got: {:?}",
         diags.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
     assert!(
@@ -2909,7 +2916,7 @@ const x = data.name
 }
 
 #[test]
-fn method_call_on_unknown_call_result_does_not_cascade() {
+fn method_call_on_foreign_call_result_does_not_cascade() {
     let diags = check(
         r#"
 import trusted { getData } from "some-lib"
@@ -2918,8 +2925,8 @@ const x = data.toJSON()
 "#,
     );
     assert!(
-        has_error(&diags, ErrorCode::UncheckedArguments),
-        "call through unknown callee should warn, got: {:?}",
+        has_error(&diags, ErrorCode::UncheckedForeignArguments),
+        "call through foreign callee should warn, got: {:?}",
         diags.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
     assert!(
@@ -5975,7 +5982,7 @@ const _result = takesString(x)
 }
 
 #[test]
-fn unknown_callee_emits_warning() {
+fn unknown_callee_emits_error() {
     let diags = check(
         r#"
 fn returnsUnknown() -> unknown { "hello" }
@@ -5984,8 +5991,57 @@ const _result = f(42)
 "#,
     );
     assert!(
-        has_warning_containing(&diags, "unknown type"),
-        "should warn when calling unknown-typed value, got: {diags:?}"
+        has_error(&diags, ErrorCode::UncheckedArguments),
+        "should error when calling unknown-typed value, got: {diags:?}"
+    );
+}
+
+// ── Unknown callee errors (#1115) ────────────────────────────
+
+#[test]
+fn calling_unknown_typed_value_is_error_not_warning() {
+    let diags = check(
+        r#"
+fn returnsUnknown() -> unknown { "hello" }
+const f = returnsUnknown()
+const _result = f("hello", 42)
+"#,
+    );
+    let unchecked_diags: Vec<_> = diags
+        .iter()
+        .filter(|d| d.code.as_deref() == Some("E051"))
+        .collect();
+    assert!(
+        !unchecked_diags.is_empty(),
+        "calling unknown-typed value should produce error (E051), got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    assert!(
+        unchecked_diags
+            .iter()
+            .all(|d| d.severity == Severity::Error),
+        "UncheckedArguments should be an error, not a warning"
+    );
+}
+
+#[test]
+fn narrowing_unknown_call_result_does_not_cascade() {
+    let diags = check(
+        r#"
+fn returnsUnknown() -> unknown { "hello" }
+const f = returnsUnknown()
+const _result = f()
+const x: number = _result
+"#,
+    );
+    assert!(
+        has_error(&diags, ErrorCode::UncheckedArguments),
+        "call through unknown callee should error, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::UnsafeNarrowing),
+        "should NOT cascade a narrowing error after the call-site error"
     );
 }
 

--- a/crates/floe-core/tests/snapshots/snapshot_errors__snapshot_error_untrusted_import.snap
+++ b/crates/floe-core/tests/snapshots/snapshot_errors__snapshot_error_untrusted_import.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/snapshot_errors.rs
+source: crates/floe-core/tests/snapshot_errors.rs
 expression: output
 ---
 [33m[W004] Warning:[0m `fetchUser` has unknown type - arguments are not type-checked
@@ -7,7 +7,7 @@ expression: output
    [38;5;246m│[0m
  [38;5;246m2 │[0m [38;5;249mc[0m[38;5;249mo[0m[38;5;249mn[0m[38;5;249ms[0m[38;5;249mt[0m[38;5;249m [0m[38;5;249m_[0m[38;5;249mx[0m[38;5;249m [0m[38;5;249m=[0m[38;5;249m [0m[33mf[0m[33me[0m[33mt[0m[33mc[0m[33mh[0m[33mU[0m[33ms[0m[33me[0m[33mr[0m[33m([0m[33m"[0m[33m1[0m[33m2[0m[33m3[0m[33m"[0m[33m)[0m
  [38;5;240m  │[0m            [33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m┬[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m  
- [38;5;240m  │[0m                    [33m╰[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m Type could not be resolved
+ [38;5;240m  │[0m                    [33m╰[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m type could not be resolved
  [38;5;240m  │[0m 
- [38;5;240m  │[0m [38;5;115mHelp[0m: Check that the import source has type declarations
+ [38;5;240m  │[0m [38;5;115mHelp[0m: check that the import source has type declarations
 [38;5;246m───╯[0m

--- a/crates/floe-core/tests/snapshots/snapshot_errors__snapshot_error_untrusted_result_used_as_value.snap
+++ b/crates/floe-core/tests/snapshots/snapshot_errors__snapshot_error_untrusted_result_used_as_value.snap
@@ -18,9 +18,9 @@ expression: output
    [38;5;246m│[0m
  [38;5;246m3 │[0m [38;5;249m [0m[38;5;249m [0m[38;5;249m [0m[38;5;249m [0m[38;5;249mc[0m[38;5;249mo[0m[38;5;249mn[0m[38;5;249ms[0m[38;5;249mt[0m[38;5;249m [0m[38;5;249mr[0m[38;5;249me[0m[38;5;249ms[0m[38;5;249mu[0m[38;5;249ml[0m[38;5;249mt[0m[38;5;249m [0m[38;5;249m=[0m[38;5;249m [0m[33mt[0m[33mr[0m[33ma[0m[33mn[0m[33ms[0m[33mf[0m[33mo[0m[33mr[0m[33mm[0m[33m([0m[33mx[0m[33m)[0m
  [38;5;240m  │[0m                    [33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m┬[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m  
- [38;5;240m  │[0m                          [33m╰[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m Type could not be resolved
+ [38;5;240m  │[0m                          [33m╰[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m[33m─[0m type could not be resolved
  [38;5;240m  │[0m 
- [38;5;240m  │[0m [38;5;115mHelp[0m: Check that the import source has type declarations
+ [38;5;240m  │[0m [38;5;115mHelp[0m: check that the import source has type declarations
 [38;5;246m───╯[0m
 [31m[E001] Error:[0m function `process`: expected return type `string`, found `Result<<error>, Error>`
    [38;5;246m╭[0m[38;5;246m─[0m[38;5;246m[[0m test.fl:4:5 [38;5;246m][0m


### PR DESCRIPTION
closes #1115

Calling through a `Type::Unknown` callee now emits an **error** (E051) instead of a warning. Foreign callees (npm boundary) remain **warnings** (W004) since they represent explicit imports where types couldn't be resolved by tsgo.

### Changes

- **`checker/expr.rs`**: `Type::Unknown` call → `emit_error_with_help` (was `emit_warning_with_help`). `Type::Foreign` standalone call → uses new `UncheckedForeignArguments` warning code.
- **`checker/error_codes.rs`**: Promoted `UncheckedArguments` from W004 to E051 (error). Added `UncheckedForeignArguments` (W004) for Foreign callees.
- **`checker/imports.rs`**: npm imports that tsgo partially resolves now correctly fall back to `Type::Foreign` instead of `Type::Unknown` — any `wrap_boundary_type` result of Unknown at the npm boundary becomes Foreign.
- **Tests**: Added `calling_unknown_typed_value_is_error_not_warning`, `narrowing_unknown_call_result_does_not_cascade` (Unknown-specific), updated existing anti-cascade and import tests.

## Test plan

- [x] Calling an unknown-typed value produces an error (E051), not a warning
- [x] Calling a foreign-typed npm import produces a warning (W004), not an error
- [x] Anti-cascade: Unknown call error does not cascade to narrowing errors
- [x] Anti-cascade: Foreign call warning does not cascade to member access errors
- [x] Example apps pass `floe check` with zero errors
- [x] All 1385 unit tests pass, 29 snapshot tests pass