### PR TITLE
perf: [#1108] migrate Type to Arc<Type>

### DIFF
--- a/crates/floe-core/src/checker.rs
+++ b/crates/floe-core/src/checker.rs
@@ -278,7 +278,7 @@ impl Checker {
                 "json".to_string(),
                 Type::Function {
                     params: vec![],
-                    return_type: Box::new(Type::Unknown),
+                    return_type: Arc::new(Type::Unknown),
                     required_params: 0,
                 },
             ),
@@ -286,7 +286,7 @@ impl Checker {
                 "text".to_string(),
                 Type::Function {
                     params: vec![],
-                    return_type: Box::new(Type::String),
+                    return_type: Arc::new(Type::String),
                     required_params: 0,
                 },
             ),
@@ -317,7 +317,7 @@ impl Checker {
                 "preventDefault".to_string(),
                 Type::Function {
                     params: vec![],
-                    return_type: Box::new(Type::Unit),
+                    return_type: Arc::new(Type::Unit),
                     required_params: 0,
                 },
             ),
@@ -325,7 +325,7 @@ impl Checker {
                 "stopPropagation".to_string(),
                 Type::Function {
                     params: vec![],
-                    return_type: Box::new(Type::Unit),
+                    return_type: Arc::new(Type::Unit),
                     required_params: 0,
                 },
             ),
@@ -354,7 +354,7 @@ impl Checker {
                 "fetch",
                 Type::Function {
                     params: vec![Type::String],
-                    return_type: Box::new(Type::Promise(Box::new(Type::Named(
+                    return_type: Arc::new(Type::Promise(Arc::new(Type::Named(
                         "Response".to_string(),
                     )))),
                     required_params: 1,
@@ -368,12 +368,12 @@ impl Checker {
                     params: vec![
                         Type::Function {
                             params: vec![],
-                            return_type: Box::new(Type::Unit),
+                            return_type: Arc::new(Type::Unit),
                             required_params: 0,
                         },
                         Type::Number,
                     ],
-                    return_type: Box::new(Type::Number),
+                    return_type: Arc::new(Type::Number),
                     required_params: 2,
                 },
             ),
@@ -383,12 +383,12 @@ impl Checker {
                     params: vec![
                         Type::Function {
                             params: vec![],
-                            return_type: Box::new(Type::Unit),
+                            return_type: Arc::new(Type::Unit),
                             required_params: 0,
                         },
                         Type::Number,
                     ],
-                    return_type: Box::new(Type::Number),
+                    return_type: Arc::new(Type::Number),
                     required_params: 2,
                 },
             ),
@@ -396,7 +396,7 @@ impl Checker {
                 "clearTimeout",
                 Type::Function {
                     params: vec![Type::Number],
-                    return_type: Box::new(Type::Unit),
+                    return_type: Arc::new(Type::Unit),
                     required_params: 1,
                 },
             ),
@@ -404,7 +404,7 @@ impl Checker {
                 "clearInterval",
                 Type::Function {
                     params: vec![Type::Number],
-                    return_type: Box::new(Type::Unit),
+                    return_type: Arc::new(Type::Unit),
                     required_params: 1,
                 },
             ),
@@ -630,7 +630,7 @@ impl Checker {
                 let required_params = func.params.iter().filter(|p| p.default.is_none()).count();
                 let fn_type = Type::Function {
                     params: param_types,
-                    return_type: Box::new(return_type),
+                    return_type: Arc::new(return_type),
                     required_params,
                 };
                 self.env.define(&func.name, fn_type);
@@ -865,7 +865,7 @@ impl Checker {
                 option_type.clone(),
                 Type::Function {
                     params: vec![option_type],
-                    return_type: Box::new(Type::Unit),
+                    return_type: Arc::new(Type::Unit),
                     required_params: 1,
                 },
             ]));

--- a/crates/floe-core/src/checker/expr.rs
+++ b/crates/floe-core/src/checker/expr.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::*;
 use crate::type_layout;
 
@@ -142,8 +144,8 @@ impl Checker {
                 let ret = self.check_call(callee, type_args, args, expr.span);
                 if is_untrusted {
                     match &ret {
-                        Type::Promise(inner) => Type::Promise(Box::new(Type::result_of(
-                            *inner.clone(),
+                        Type::Promise(inner) => Type::Promise(Arc::new(Type::result_of(
+                            inner.as_ref().clone(),
                             Type::Named(type_layout::TYPE_ERROR.to_string()),
                         ))),
                         _ => Type::result_of(ret, Type::Named(type_layout::TYPE_ERROR.to_string())),
@@ -192,10 +194,10 @@ impl Checker {
             // Ok/Err/Some/None are handled by check_construct as variant constructors
             ExprKind::Value(inner) => {
                 let inner_ty = self.check_expr(inner);
-                Type::Settable(Box::new(inner_ty))
+                Type::Settable(Arc::new(inner_ty))
             }
-            ExprKind::Clear => Type::Settable(Box::new(Type::Unknown)),
-            ExprKind::Unchanged => Type::Settable(Box::new(Type::Unknown)),
+            ExprKind::Clear => Type::Settable(Arc::new(Type::Unknown)),
+            ExprKind::Unchanged => Type::Settable(Arc::new(Type::Unknown)),
             ExprKind::Todo => {
                 self.emit_warning_with_help(
                     "`todo` is a placeholder that will panic at runtime",
@@ -299,7 +301,7 @@ impl Checker {
                 let required_params = field_types.len();
                 return Type::Function {
                     params: field_types.clone(),
-                    return_type: Box::new(ty),
+                    return_type: Arc::new(ty),
                     required_params,
                 };
             }
@@ -623,7 +625,7 @@ impl Checker {
         let required_params = param_types.len();
         Type::Function {
             params: param_types,
-            return_type: Box::new(return_type),
+            return_type: Arc::new(return_type),
             required_params,
         }
     }
@@ -702,7 +704,7 @@ impl Checker {
         self.env.pop_scope();
 
         let e = err_type.unwrap_or(Type::Unknown);
-        Type::result_of(last_type, Type::Array(Box::new(e)))
+        Type::result_of(last_type, Type::Array(Arc::new(e)))
     }
 
     fn check_array(&mut self, elements: &[Expr]) -> Type {
@@ -722,9 +724,9 @@ impl Checker {
             }
         }
         if mixed {
-            Type::Array(Box::new(Type::Unknown))
+            Type::Array(Arc::new(Type::Unknown))
         } else {
-            Type::Array(Box::new(elem_type.unwrap_or(Type::Unknown)))
+            Type::Array(Arc::new(elem_type.unwrap_or(Type::Unknown)))
         }
     }
 
@@ -994,12 +996,12 @@ impl Checker {
                         Self::infer_generic_params(&generic_params, &params, &arg_types)
                     };
                     if substitutions.is_empty() {
-                        *return_type
+                        return_type.as_ref().clone()
                     } else {
                         Self::substitute_generics(&return_type, &substitutions)
                     }
                 } else {
-                    *return_type
+                    return_type.as_ref().clone()
                 };
 
                 if has_placeholder && piped_ty_was_none {
@@ -1044,7 +1046,7 @@ impl Checker {
                     let required_params = placeholder_param_types.len();
                     Type::Function {
                         params: placeholder_param_types,
-                        return_type: Box::new(return_type),
+                        return_type: Arc::new(return_type),
                         required_params,
                     }
                 } else {
@@ -1074,7 +1076,7 @@ impl Checker {
                             };
                             let resolved = Type::Function {
                                 params: fn_params.clone(),
-                                return_type: Box::new(resolved_ret),
+                                return_type: Arc::new(resolved_ret),
                                 required_params: fn_params.len(),
                             };
                             self.expr_types
@@ -1272,7 +1274,7 @@ impl Checker {
             let required_params = field_types.len();
             return Type::Function {
                 params: field_types.clone(),
-                return_type: Box::new(ty),
+                return_type: Arc::new(ty),
                 required_params,
             };
         }
@@ -1677,7 +1679,7 @@ impl Checker {
         {
             self.unused.used_names.insert(func_name.to_string());
             return match fn_type {
-                Type::Function { return_type, .. } => *return_type.clone(),
+                Type::Function { return_type, .. } => return_type.as_ref().clone(),
                 _ => Type::Unknown,
             };
         }
@@ -1784,7 +1786,7 @@ impl Checker {
                             label,
                         );
                     }
-                    return *return_type;
+                    return return_type.as_ref().clone();
                 }
                 // Unknown/Error types: don't error (not enough info or error already emitted)
                 Type::Unknown | Type::Error | Type::Var(_) => {}
@@ -1857,7 +1859,7 @@ impl Checker {
         // infer it from the lambda's actual return type.
         if infer_from_lambda {
             match &stdlib_fn.return_type {
-                Type::Array(_) => Type::Array(Box::new(lambda_return.unwrap())),
+                Type::Array(_) => Type::Array(Arc::new(lambda_return.unwrap())),
                 ret if ret.is_option() => Type::option_of(lambda_return.unwrap()),
                 _ => Self::substitute_type_vars(&stdlib_fn.return_type, &var_bindings),
             }
@@ -1896,7 +1898,7 @@ impl Checker {
                         if i == 0
                             && let Type::Function { return_type, .. } = &ty
                         {
-                            lambda_return = Some(*return_type.clone());
+                            lambda_return = Some(return_type.as_ref().clone());
                         }
                     }
                 }
@@ -1966,24 +1968,24 @@ impl Checker {
         match ty {
             Type::Var(n) => bindings.get(n).cloned().unwrap_or_else(|| ty.clone()),
             Type::Array(inner) => {
-                Type::Array(Box::new(Self::substitute_type_vars(inner, bindings)))
+                Type::Array(Arc::new(Self::substitute_type_vars(inner, bindings)))
             }
             Type::Promise(inner) => {
-                Type::Promise(Box::new(Self::substitute_type_vars(inner, bindings)))
+                Type::Promise(Arc::new(Self::substitute_type_vars(inner, bindings)))
             }
             Type::Settable(inner) => {
-                Type::Settable(Box::new(Self::substitute_type_vars(inner, bindings)))
+                Type::Settable(Arc::new(Self::substitute_type_vars(inner, bindings)))
             }
             Type::Set { element } => Type::Set {
-                element: Box::new(Self::substitute_type_vars(element, bindings)),
+                element: Arc::new(Self::substitute_type_vars(element, bindings)),
             },
             Type::Map { key, value } => Type::Map {
-                key: Box::new(Self::substitute_type_vars(key, bindings)),
-                value: Box::new(Self::substitute_type_vars(value, bindings)),
+                key: Arc::new(Self::substitute_type_vars(key, bindings)),
+                value: Arc::new(Self::substitute_type_vars(value, bindings)),
             },
             Type::RecordMap { key, value } => Type::RecordMap {
-                key: Box::new(Self::substitute_type_vars(key, bindings)),
-                value: Box::new(Self::substitute_type_vars(value, bindings)),
+                key: Arc::new(Self::substitute_type_vars(key, bindings)),
+                value: Arc::new(Self::substitute_type_vars(value, bindings)),
             },
             Type::Tuple(types) => Type::Tuple(
                 types
@@ -2014,7 +2016,7 @@ impl Checker {
                     .iter()
                     .map(|t| Self::substitute_type_vars(t, bindings))
                     .collect(),
-                return_type: Box::new(Self::substitute_type_vars(return_type, bindings)),
+                return_type: Arc::new(Self::substitute_type_vars(return_type, bindings)),
                 required_params: *required_params,
             },
             other => other.clone(),
@@ -2200,17 +2202,17 @@ impl Checker {
     fn substitute_generics(ty: &Type, subs: &HashMap<String, Type>) -> Type {
         match ty {
             Type::Named(n) if subs.contains_key(n) => subs[n].clone(),
-            Type::Array(inner) => Type::Array(Box::new(Self::substitute_generics(inner, subs))),
+            Type::Array(inner) => Type::Array(Arc::new(Self::substitute_generics(inner, subs))),
             Type::Map { key, value } => Type::Map {
-                key: Box::new(Self::substitute_generics(key, subs)),
-                value: Box::new(Self::substitute_generics(value, subs)),
+                key: Arc::new(Self::substitute_generics(key, subs)),
+                value: Arc::new(Self::substitute_generics(value, subs)),
             },
             Type::RecordMap { key, value } => Type::RecordMap {
-                key: Box::new(Self::substitute_generics(key, subs)),
-                value: Box::new(Self::substitute_generics(value, subs)),
+                key: Arc::new(Self::substitute_generics(key, subs)),
+                value: Arc::new(Self::substitute_generics(value, subs)),
             },
             Type::Set { element } => Type::Set {
-                element: Box::new(Self::substitute_generics(element, subs)),
+                element: Arc::new(Self::substitute_generics(element, subs)),
             },
             _ if ty.is_option() => {
                 if let Some(inner) = ty.option_inner() {
@@ -2234,7 +2236,7 @@ impl Checker {
                     .iter()
                     .map(|t| Self::substitute_generics(t, subs))
                     .collect(),
-                return_type: Box::new(Self::substitute_generics(return_type, subs)),
+                return_type: Arc::new(Self::substitute_generics(return_type, subs)),
                 required_params: *required_params,
             },
             Type::Union { name, variants } => Type::Union {
@@ -2889,7 +2891,7 @@ pub(crate) fn simple_resolve_type_expr(type_expr: &crate::parser::ast::TypeExpr)
                     .first()
                     .map(simple_resolve_type_expr)
                     .unwrap_or(Type::Unknown);
-                Type::Array(Box::new(inner))
+                Type::Array(Arc::new(inner))
             }
             type_layout::TYPE_OPTION => {
                 let inner = type_args
@@ -2903,7 +2905,7 @@ pub(crate) fn simple_resolve_type_expr(type_expr: &crate::parser::ast::TypeExpr)
                     .first()
                     .map(simple_resolve_type_expr)
                     .unwrap_or(Type::Unknown);
-                Type::Settable(Box::new(inner))
+                Type::Settable(Arc::new(inner))
             }
             type_layout::TYPE_RESULT => {
                 let ok = type_args
@@ -2918,7 +2920,7 @@ pub(crate) fn simple_resolve_type_expr(type_expr: &crate::parser::ast::TypeExpr)
             }
             _ => Type::Named(name.to_string()),
         },
-        TypeExprKind::Array(inner) => Type::Array(Box::new(simple_resolve_type_expr(inner))),
+        TypeExprKind::Array(inner) => Type::Array(Arc::new(simple_resolve_type_expr(inner))),
         TypeExprKind::Record(fields) => {
             let field_types: Vec<_> = fields
                 .iter()
@@ -2935,7 +2937,7 @@ pub(crate) fn simple_resolve_type_expr(type_expr: &crate::parser::ast::TypeExpr)
             let required_params = param_types.len();
             Type::Function {
                 params: param_types,
-                return_type: Box::new(ret),
+                return_type: Arc::new(ret),
                 required_params,
             }
         }

--- a/crates/floe-core/src/checker/imports.rs
+++ b/crates/floe-core/src/checker/imports.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::*;
 
 impl Checker {
@@ -271,7 +273,7 @@ impl Checker {
             let required_params = param_types.len();
             let fn_type = Type::Function {
                 params: param_types,
-                return_type: Box::new(return_type),
+                return_type: Arc::new(return_type),
                 required_params,
             };
             self.env.define(&func.name, fn_type.clone());

--- a/crates/floe-core/src/checker/items.rs
+++ b/crates/floe-core/src/checker/items.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::*;
 
 /// Returns the span of the last item in a block body, falling back to the body's own span.
@@ -73,7 +75,7 @@ impl Checker {
             if Self::expr_has_promise_await(&decl.value)
                 && let Type::Promise(inner) = ty
             {
-                *inner
+                inner.as_ref().clone()
             } else {
                 ty
             }
@@ -90,8 +92,8 @@ impl Checker {
         // resolved to a concrete unwrapped type, re-wrap so the Result isn't lost.
         if value_type.is_result() && !final_type.is_result() {
             final_type = match final_type {
-                Type::Promise(inner) => Type::Promise(Box::new(Type::result_of(
-                    *inner,
+                Type::Promise(inner) => Type::Promise(Arc::new(Type::result_of(
+                    inner.as_ref().clone(),
                     Type::Named(type_layout::TYPE_ERROR.to_string()),
                 ))),
                 other => Type::result_of(other, Type::Named(type_layout::TYPE_ERROR.to_string())),
@@ -440,7 +442,7 @@ impl Checker {
                 );
                 return_type
             } else {
-                Type::Promise(Box::new(return_type))
+                Type::Promise(Arc::new(return_type))
             }
         } else {
             return_type
@@ -462,7 +464,7 @@ impl Checker {
         let required_params = decl.params.iter().filter(|p| p.default.is_none()).count();
         let fn_type = Type::Function {
             params: param_types.clone(),
-            return_type: Box::new(return_type.clone()),
+            return_type: Arc::new(return_type.clone()),
             required_params,
         };
         self.check_no_redefinition(&decl.name, span);
@@ -491,7 +493,7 @@ impl Checker {
         let prev_expected = self.ctx.expected_type.take();
         // For Promise<T> return types, unwrap so ? sees the inner type
         let effective_return = match &return_type {
-            Type::Promise(inner) => *inner.clone(),
+            Type::Promise(inner) => inner.as_ref().clone(),
             _ => return_type.clone(),
         };
         self.ctx.current_return_type = Some(effective_return.clone());
@@ -539,13 +541,13 @@ impl Checker {
             // If the body uses await, or the function is declared `async`,
             // wrap the inferred return type in Promise<T>
             let inferred_return = if uses_await || decl.async_fn {
-                Type::Promise(Box::new(body_type.clone()))
+                Type::Promise(Arc::new(body_type.clone()))
             } else {
                 body_type.clone()
             };
             let fn_type = Type::Function {
                 params: param_types.clone(),
-                return_type: Box::new(inferred_return),
+                return_type: Arc::new(inferred_return),
                 required_params,
             };
             // Update in the name_types map for hover display
@@ -562,7 +564,7 @@ impl Checker {
         if decl.return_type.is_some() {
             let resolved = if decl.async_fn {
                 match &return_type {
-                    Type::Promise(inner) => *inner.clone(),
+                    Type::Promise(inner) => inner.as_ref().clone(),
                     _ => return_type.clone(),
                 }
             } else {
@@ -684,7 +686,7 @@ impl Checker {
             let required_params = param_types.len();
             let fn_type = Type::Function {
                 params: param_types.clone(),
-                return_type: Box::new(return_type.clone()),
+                return_type: Arc::new(return_type.clone()),
                 required_params,
             };
             // Allow for-block functions with the same name on different types
@@ -731,7 +733,7 @@ impl Checker {
             let prev_expected = self.ctx.expected_type.take();
             // For Promise<T> return types, unwrap so ? sees the inner type
             let effective_return = match &return_type {
-                Type::Promise(inner) => *inner.clone(),
+                Type::Promise(inner) => inner.as_ref().clone(),
                 _ => return_type.clone(),
             };
             self.ctx.current_return_type = Some(effective_return.clone());

--- a/crates/floe-core/src/checker/match_check.rs
+++ b/crates/floe-core/src/checker/match_check.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::*;
 
 // ── Match Exhaustiveness (delegated to exhaustiveness module) ────
@@ -220,7 +222,7 @@ impl Checker {
                     let rest_ty = if let Type::Array(_) = subject_ty {
                         subject_ty.clone()
                     } else {
-                        Type::Array(Box::new(Type::Unknown))
+                        Type::Array(Arc::new(Type::Unknown))
                     };
                     self.env.define(name, rest_ty.clone());
                     self.name_types.insert(name.clone(), rest_ty.to_string());

--- a/crates/floe-core/src/checker/prelude.rs
+++ b/crates/floe-core/src/checker/prelude.rs
@@ -70,17 +70,17 @@ pub fn undefined() -> Type {
 
 #[inline]
 pub fn array_of(inner: Type) -> Type {
-    Type::Array(Box::new(inner))
+    Type::Array(Arc::new(inner))
 }
 
 #[inline]
 pub fn promise_of(inner: Type) -> Type {
-    Type::Promise(Box::new(inner))
+    Type::Promise(Arc::new(inner))
 }
 
 #[inline]
 pub fn settable_of(inner: Type) -> Type {
-    Type::Settable(Box::new(inner))
+    Type::Settable(Arc::new(inner))
 }
 
 #[inline]

--- a/crates/floe-core/src/checker/traits.rs
+++ b/crates/floe-core/src/checker/traits.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::*;
 
 impl Checker {
@@ -243,7 +245,7 @@ impl Checker {
 
                     return Some(Type::Function {
                         params: param_types,
-                        return_type: Box::new(return_type),
+                        return_type: Arc::new(return_type),
                         required_params: method.params.len() + 1, // +1 for self
                     });
                 }

--- a/crates/floe-core/src/checker/type_compat.rs
+++ b/crates/floe-core/src/checker/type_compat.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::*;
 
 impl Checker {
@@ -76,10 +78,10 @@ impl Checker {
                 Type::option_of(Self::merge_types(&a_inner, &b_inner))
             }
             (Type::Promise(a_inner), Type::Promise(b_inner)) => {
-                Type::Promise(Box::new(Self::merge_types(a_inner, b_inner)))
+                Type::Promise(Arc::new(Self::merge_types(a_inner, b_inner)))
             }
             (Type::Array(a_inner), Type::Array(b_inner)) => {
-                Type::Array(Box::new(Self::merge_types(a_inner, b_inner)))
+                Type::Array(Arc::new(Self::merge_types(a_inner, b_inner)))
             }
             (Type::Tuple(a_elems), Type::Tuple(b_elems)) if a_elems.len() == b_elems.len() => {
                 Type::Tuple(

--- a/crates/floe-core/src/checker/type_registration.rs
+++ b/crates/floe-core/src/checker/type_registration.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::*;
 
 impl Checker {
@@ -491,7 +493,7 @@ impl Checker {
                     let self_type = Type::Named(type_name.clone());
                     let fn_type = Type::Function {
                         params: vec![self_type],
-                        return_type: Box::new(Type::String),
+                        return_type: Arc::new(Type::String),
                         required_params: 1,
                     };
                     self.env.define(&fn_name, fn_type);

--- a/crates/floe-core/src/checker/type_resolve.rs
+++ b/crates/floe-core/src/checker/type_resolve.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::*;
 
 impl Checker {
@@ -30,11 +32,11 @@ impl Checker {
                 let required_params = param_types.len();
                 Type::Function {
                     params: param_types,
-                    return_type: Box::new(ret),
+                    return_type: Arc::new(ret),
                     required_params,
                 }
             }
-            TypeExprKind::Array(inner) => Type::Array(Box::new(self.resolve_type(inner))),
+            TypeExprKind::Array(inner) => Type::Array(Arc::new(self.resolve_type(inner))),
             TypeExprKind::Tuple(types) => {
                 Type::Tuple(types.iter().map(|t| self.resolve_type(t)).collect())
             }
@@ -148,7 +150,7 @@ impl Checker {
                     .first()
                     .map(|t| self.resolve_type(t))
                     .unwrap_or(Type::Unknown);
-                Type::Settable(Box::new(inner))
+                Type::Settable(Arc::new(inner))
             }
             type_layout::TYPE_ARRAY => {
                 self.check_type_arg_arity(name, 1, type_args.len(), span);
@@ -156,7 +158,7 @@ impl Checker {
                     .first()
                     .map(|t| self.resolve_type(t))
                     .unwrap_or(Type::Unknown);
-                Type::Array(Box::new(inner))
+                Type::Array(Arc::new(inner))
             }
             type_layout::TYPE_PROMISE => {
                 self.check_type_arg_arity(name, 1, type_args.len(), span);
@@ -164,7 +166,7 @@ impl Checker {
                     .first()
                     .map(|t| self.resolve_type(t))
                     .unwrap_or(Type::Unknown);
-                Type::Promise(Box::new(inner))
+                Type::Promise(Arc::new(inner))
             }
             _ => {
                 // Trait names are not types — always error when used in a type position.

--- a/crates/floe-core/src/checker/types.rs
+++ b/crates/floe-core/src/checker/types.rs
@@ -3,11 +3,17 @@
 //! stack, display formatting, prelude constructors) were split into
 //! `environment.rs`, `printer.rs`, and `prelude.rs` as part of #1107.
 
+use std::sync::Arc;
+
 use super::printer::{TypeDisplay, TypeDisplayStyle};
 
 // ── Types ────────────────────────────────────────────────────────
 
 /// Internal type representation used by the checker.
+///
+/// Sub-types are stored behind `Arc<Type>` for cheap cloning — type trees
+/// are cloned frequently during inference. Arc refcount bumps replace the
+/// deep copies that `Box<Type>` required.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Type {
     /// Primitive types: number, string, boolean
@@ -22,41 +28,41 @@ pub enum Type {
     /// but TypeScript validated it at the source
     Foreign(String),
     /// Promise<T> — async return type, unwrapped by `Promise.await`
-    Promise(Box<Type>),
+    Promise(Arc<Type>),
     /// Opaque type: only the defining module can construct/destructure
     Opaque {
         name: String,
-        base: Box<Type>,
+        base: Arc<Type>,
     },
     // Result<T, E> is now represented as Type::Union { name: "Result", variants: [("Ok", [T]), ("Err", [E])] }
     // Use Type::result_of(ok, err) to construct, ty.is_result() / ty.result_ok() / ty.result_err() to inspect.
     // Option<T> is now represented as Type::Union { name: "Option", variants: [("Some", [T]), ("None", [])] }
     // Use Type::option_of(inner) to construct, ty.is_option() / ty.option_inner() to inspect.
     /// Settable<T> = Set(T) | Clear | Unchanged
-    Settable(Box<Type>),
+    Settable(Arc<Type>),
     /// Function type. `required_params` is how many leading params the caller
     /// must provide; trailing params beyond that index have defaults and can be omitted.
     Function {
         params: Vec<Type>,
         required_params: usize,
-        return_type: Box<Type>,
+        return_type: Arc<Type>,
     },
     /// Array type
-    Array(Box<Type>),
+    Array(Arc<Type>),
     /// Map type: Map<K, V> (JS Map at runtime)
     Map {
-        key: Box<Type>,
-        value: Box<Type>,
+        key: Arc<Type>,
+        value: Arc<Type>,
     },
     /// TS Record<K, V> — plain object at runtime, supports Map operations
     /// via bracket access codegen instead of JS Map API
     RecordMap {
-        key: Box<Type>,
-        value: Box<Type>,
+        key: Arc<Type>,
+        value: Arc<Type>,
     },
     /// Set type: Set<T>
     Set {
-        element: Box<Type>,
+        element: Arc<Type>,
     },
     /// Tuple type
     Tuple(Vec<Type>),

--- a/crates/floe-core/src/interop/tests.rs
+++ b/crates/floe-core/src/interop/tests.rs
@@ -1,4 +1,5 @@
 //! Tests for the interop module.
+use std::sync::Arc;
 
 use super::*;
 
@@ -205,7 +206,7 @@ fn wrap_function_wraps_params_and_return() {
         wrapped,
         Type::Function {
             params: vec![Type::option_of(Type::String)],
-            return_type: Box::new(Type::Unknown),
+            return_type: Arc::new(Type::Unknown),
             required_params: 1,
         }
     );
@@ -232,7 +233,7 @@ fn wrap_function_optional_params_become_option() {
         wrapped,
         Type::Function {
             params: vec![Type::String, Type::option_of(Type::Number)],
-            return_type: Box::new(Type::Unit),
+            return_type: Arc::new(Type::Unit),
             required_params: 1,
         }
     );
@@ -248,7 +249,7 @@ fn wrap_array_wraps_inner() {
     let wrapped = wrap_boundary_type(&ts);
     assert_eq!(
         wrapped,
-        Type::Array(Box::new(Type::option_of(Type::String)))
+        Type::Array(Arc::new(Type::option_of(Type::String)))
     );
 }
 
@@ -289,7 +290,7 @@ fn wrap_optional_nullable_becomes_settable() {
         wrapped,
         Type::Record(vec![(
             "email".to_string(),
-            Type::Settable(Box::new(Type::String))
+            Type::Settable(Arc::new(Type::String))
         ),])
     );
 }
@@ -390,7 +391,7 @@ fn parse_function_nullable_return_wraps_to_option() {
         wrapped,
         Type::Function {
             params: vec![Type::String],
-            return_type: Box::new(Type::option_of(Type::Foreign("Element".to_string()))),
+            return_type: Arc::new(Type::option_of(Type::Foreign("Element".to_string()))),
             required_params: 1,
         }
     );
@@ -404,7 +405,7 @@ fn parse_function_any_param_wraps_to_unknown() {
         wrapped,
         Type::Function {
             params: vec![Type::Unknown],
-            return_type: Box::new(Type::Unit),
+            return_type: Arc::new(Type::Unit),
             required_params: 1,
         }
     );

--- a/crates/floe-core/src/interop/wrapper.rs
+++ b/crates/floe-core/src/interop/wrapper.rs
@@ -1,4 +1,5 @@
 //! Boundary type wrapping: converts TypeScript types to Floe types at the import boundary.
+use std::sync::Arc;
 
 use super::*;
 use crate::type_layout;
@@ -38,24 +39,24 @@ pub fn wrap_boundary_type(ts_type: &TsType) -> Type {
         TsType::Generic { name, args } => {
             match name.as_str() {
                 "Array" | "ReadonlyArray" if args.len() == 1 => {
-                    Type::Array(Box::new(wrap_boundary_type(&args[0])))
+                    Type::Array(Arc::new(wrap_boundary_type(&args[0])))
                 }
                 "Promise" if args.len() == 1 => {
-                    Type::Promise(Box::new(wrap_boundary_type(&args[0])))
+                    Type::Promise(Arc::new(wrap_boundary_type(&args[0])))
                 }
                 // FloeOption<T> → Option<T> (our probe wrapper for Option)
                 "FloeOption" if args.len() == 1 => Type::option_of(wrap_boundary_type(&args[0])),
                 // TS Record<K, V> → Floe RecordMap<K, V> (plain-object map)
                 "Record" if args.len() == 2 => Type::RecordMap {
-                    key: Box::new(wrap_boundary_type(&args[0])),
-                    value: Box::new(wrap_boundary_type(&args[1])),
+                    key: Arc::new(wrap_boundary_type(&args[0])),
+                    value: Arc::new(wrap_boundary_type(&args[1])),
                 },
                 // React's Dispatch<SetStateAction<T>> is a function: (T) -> ()
                 "Dispatch" if args.len() == 1 => {
                     let inner = unwrap_set_state_action(&args[0]);
                     Type::Function {
                         params: vec![wrap_boundary_type(inner)],
-                        return_type: Box::new(Type::Unit),
+                        return_type: Arc::new(Type::Unit),
                         required_params: 1,
                     }
                 }
@@ -87,12 +88,12 @@ pub fn wrap_boundary_type(ts_type: &TsType) -> Type {
             let wrapped_return = wrap_boundary_type(return_type);
             Type::Function {
                 params: wrapped_params,
-                return_type: Box::new(wrapped_return),
+                return_type: Arc::new(wrapped_return),
                 required_params,
             }
         }
 
-        TsType::Array(inner) => Type::Array(Box::new(wrap_boundary_type(inner))),
+        TsType::Array(inner) => Type::Array(Arc::new(wrap_boundary_type(inner))),
 
         TsType::Object(fields) => {
             let wrapped: Vec<(String, Type)> = fields
@@ -102,7 +103,7 @@ pub fn wrap_boundary_type(ts_type: &TsType) -> Type {
                         // x?: T | null → Settable<T>
                         // Wrap the non-null inner type directly, skipping the Option wrapper
                         let inner = wrap_non_null_inner(&f.ty);
-                        Type::Settable(Box::new(inner))
+                        Type::Settable(Arc::new(inner))
                     } else if f.optional {
                         // x?: T → Option<T>
                         Type::option_of(wrap_boundary_type(&f.ty))

--- a/crates/floe-core/src/stdlib/mod.rs
+++ b/crates/floe-core/src/stdlib/mod.rs
@@ -21,6 +21,8 @@ mod result;
 mod set;
 mod string;
 
+use std::sync::Arc;
+
 use crate::checker::Type;
 
 /// A standard library function definition.
@@ -99,7 +101,7 @@ fn tv(n: usize) -> Type {
     Type::Var(n)
 }
 fn array_of(t: Type) -> Type {
-    Type::Array(Box::new(t))
+    Type::Array(Arc::new(t))
 }
 fn option_of(t: Type) -> Type {
     Type::option_of(t)
@@ -109,29 +111,29 @@ fn result_of(ok: Type, err: Type) -> Type {
 }
 fn map_of(k: Type, v: Type) -> Type {
     Type::Map {
-        key: Box::new(k),
-        value: Box::new(v),
+        key: Arc::new(k),
+        value: Arc::new(v),
     }
 }
 fn record_of(k: Type, v: Type) -> Type {
     Type::RecordMap {
-        key: Box::new(k),
-        value: Box::new(v),
+        key: Arc::new(k),
+        value: Arc::new(v),
     }
 }
 fn set_of(t: Type) -> Type {
     Type::Set {
-        element: Box::new(t),
+        element: Arc::new(t),
     }
 }
 fn promise_of(t: Type) -> Type {
-    Type::Promise(Box::new(t))
+    Type::Promise(Arc::new(t))
 }
 fn fun(params: Vec<Type>, ret: Type) -> Type {
     let required_params = params.len();
     Type::Function {
         params,
-        return_type: Box::new(ret),
+        return_type: Arc::new(ret),
         required_params,
     }
 }


### PR DESCRIPTION
## Summary

- Replaces `Box<Type>` with `Arc<Type>` in all 8 Type enum variants that hold sub-types: `Promise`, `Opaque`, `Settable`, `Function` (return_type), `Array`, `Map`, `RecordMap`, `Set`
- Updates all construction sites from `Box::new(...)` to `Arc::new(...)` across 14 files
- Fixes move-out-of-Arc patterns (`*inner.clone()` -> `inner.as_ref().clone()`) where owned Types are needed

This makes cloning Type trees a cheap refcount bump instead of a deep copy, which matters during type inference. Also a prerequisite for `Arc<RefCell<TypeVar>>` unification (#1118).

## Test plan

- [x] All 1473 workspace tests pass
- [x] Clippy clean (zero warnings)
- [x] `floe check` passes on both example apps
- [x] `floe build` passes on both example apps
- [x] No behavior changes - pure internal optimization

Closes #1108

🤖 Generated with [Claude Code](https://claude.com/claude-code)