### PR TITLE
refactor: [#1116] simplify formatter internals

### DIFF
--- a/crates/floe-core/src/formatter.rs
+++ b/crates/floe-core/src/formatter.rs
@@ -6,7 +6,7 @@ mod tests;
 
 use crate::cst::CstParser;
 use crate::lexer::Lexer;
-use crate::parse::extra::ModuleExtra;
+use crate::parse::extra::{ModuleExtra, SrcSpan};
 use crate::pretty::{self, Document};
 use crate::syntax::{SyntaxKind, SyntaxNode};
 
@@ -45,22 +45,51 @@ fn strip_trailing_whitespace(s: &str) -> String {
     out
 }
 
+/// A comment popped from the side-channel.
+pub(crate) struct Comment {
+    pub start: u32,
+    pub end: u32,
+    pub text: String,
+}
+
+struct ProgramState {
+    first: bool,
+    prev_kind: Option<SyntaxKind>,
+    prev_was_comment: bool,
+    prev_end: u32,
+}
+
+impl ProgramState {
+    fn new() -> Self {
+        Self {
+            first: true,
+            prev_kind: None,
+            prev_was_comment: false,
+            prev_end: 0,
+        }
+    }
+}
+
 pub(crate) struct Formatter<'src> {
     source: &'src str,
-    extra: ModuleExtra,
-    comment_cursor: usize,
-    doc_comment_cursor: usize,
-    module_comment_cursor: usize,
+    /// Three category lists from `ModuleExtra` merged into one vector sorted
+    /// by `start` so the formatter only has to advance a single cursor.
+    comments: Vec<SrcSpan>,
+    cursor: usize,
+    empty_lines: Vec<u32>,
 }
 
 impl<'src> Formatter<'src> {
     fn new(source: &'src str, extra: ModuleExtra) -> Self {
+        let mut comments = extra.comments;
+        comments.extend(extra.doc_comments);
+        comments.extend(extra.module_comments);
+        comments.sort_by_key(|s| s.start);
         Self {
             source,
-            extra,
-            comment_cursor: 0,
-            doc_comment_cursor: 0,
-            module_comment_cursor: 0,
+            comments,
+            cursor: 0,
+            empty_lines: extra.empty_lines,
         }
     }
 
@@ -111,34 +140,17 @@ impl<'src> Formatter<'src> {
     fn fmt_program(&mut self, node: &SyntaxNode) -> Document {
         let children: Vec<_> = node.children().collect();
         let mut docs = Vec::new();
-        let mut first = true;
-        let mut prev_kind: Option<SyntaxKind> = None;
-        let mut prev_was_comment = false;
-        let mut prev_end: u32 = 0;
+        let mut state = ProgramState::new();
 
         for child in &children {
             let child_start: u32 = child.text_range().start().into();
-
-            // Pop comments before this child from the side-channel
             let comments = self.pop_comments_before(child_start);
-            for (c_start, c_end, comment_text) in &comments {
-                let had_blank_before = self.has_empty_line_between(prev_end, *c_start);
-                if !first && (!prev_was_comment || had_blank_before) {
-                    docs.push(pretty::line());
-                    docs.push(pretty::line());
-                } else if prev_was_comment {
-                    docs.push(pretty::line());
-                }
-                docs.push(pretty::str(comment_text.clone()));
-                first = false;
-                prev_was_comment = true;
-                prev_end = *c_end;
-            }
+            self.emit_program_comments(&mut docs, comments, &mut state);
 
             let child_inner_kind = self.inner_decl_kind(child);
 
-            if !first {
-                if prev_was_comment {
+            if !state.first {
+                if state.prev_was_comment {
                     docs.push(pretty::line());
                     docs.push(pretty::line());
                 } else {
@@ -146,13 +158,11 @@ impl<'src> Formatter<'src> {
                         matches!(k, SyntaxKind::IMPORT_DECL | SyntaxKind::REEXPORT_DECL)
                     };
                     let want_blank = !matches!(
-                        (prev_kind, child_inner_kind),
+                        (state.prev_kind, child_inner_kind),
                         (Some(a), Some(b)) if is_import_like(a) && is_import_like(b)
                     );
+                    docs.push(pretty::line());
                     if want_blank {
-                        docs.push(pretty::line());
-                        docs.push(pretty::line());
-                    } else {
                         docs.push(pretty::line());
                     }
                 }
@@ -160,29 +170,37 @@ impl<'src> Formatter<'src> {
 
             docs.push(self.fmt_node(child));
 
-            prev_was_comment = false;
-            prev_kind = child_inner_kind;
-            prev_end = child.text_range().end().into();
-            first = false;
+            state.prev_was_comment = false;
+            state.prev_kind = child_inner_kind;
+            state.prev_end = child.text_range().end().into();
+            state.first = false;
         }
 
-        // Pop any remaining comments after the last item
         let remaining = self.pop_comments_before(u32::MAX);
-        for (c_start, c_end, comment_text) in &remaining {
-            let had_blank_before = self.has_empty_line_between(prev_end, *c_start);
-            if !first && (!prev_was_comment || had_blank_before) {
-                docs.push(pretty::line());
-                docs.push(pretty::line());
-            } else if prev_was_comment {
-                docs.push(pretty::line());
-            }
-            docs.push(pretty::str(comment_text.clone()));
-            first = false;
-            prev_was_comment = true;
-            prev_end = *c_end;
-        }
+        self.emit_program_comments(&mut docs, remaining, &mut state);
 
         pretty::concat(docs)
+    }
+
+    fn emit_program_comments(
+        &self,
+        docs: &mut Vec<Document>,
+        comments: Vec<Comment>,
+        state: &mut ProgramState,
+    ) {
+        for c in comments {
+            let had_blank_before = self.has_empty_line_between(state.prev_end, c.start);
+            if !state.first && (!state.prev_was_comment || had_blank_before) {
+                docs.push(pretty::line());
+                docs.push(pretty::line());
+            } else if state.prev_was_comment {
+                docs.push(pretty::line());
+            }
+            docs.push(pretty::str(c.text));
+            state.first = false;
+            state.prev_was_comment = true;
+            state.prev_end = c.end;
+        }
     }
 
     fn inner_decl_kind(&self, node: &SyntaxNode) -> Option<SyntaxKind> {
@@ -203,119 +221,46 @@ impl<'src> Formatter<'src> {
 
     // ── Comment handling ────────────────────────────────────────
 
-    /// Pop all unconsumed comments whose start byte < `to`.
-    /// Returns `(start, end, text)` tuples in source order. Advances cursors
-    /// past everything consumed.
-    pub(crate) fn pop_comments_before(&mut self, to: u32) -> Vec<(u32, u32, String)> {
-        let mut results: Vec<(u32, u32, String)> = Vec::new();
-
-        while self.comment_cursor < self.extra.comments.len() {
-            let span = self.extra.comments[self.comment_cursor];
+    /// Drain comments whose `start` lies in `[from, to)`, advancing the
+    /// cursor past `to`. Comments before `from` that the cursor still points
+    /// at are skipped silently — they should have been emitted by an
+    /// enclosing context already (or are inside a node that handles its own
+    /// comments via CST traversal).
+    fn drain_comments(&mut self, from: u32, to: u32) -> Vec<Comment> {
+        let mut results = Vec::new();
+        while self.cursor < self.comments.len() {
+            let span = self.comments[self.cursor];
             if span.start >= to {
                 break;
             }
-            results.push((
-                span.start,
-                span.end,
-                self.source[span.start as usize..span.end as usize].to_string(),
-            ));
-            self.comment_cursor += 1;
-        }
-
-        while self.doc_comment_cursor < self.extra.doc_comments.len() {
-            let span = self.extra.doc_comments[self.doc_comment_cursor];
-            if span.start >= to {
-                break;
+            if span.start >= from {
+                results.push(Comment {
+                    start: span.start,
+                    end: span.end,
+                    text: self.source[span.start as usize..span.end as usize].to_string(),
+                });
             }
-            results.push((
-                span.start,
-                span.end,
-                self.source[span.start as usize..span.end as usize].to_string(),
-            ));
-            self.doc_comment_cursor += 1;
+            self.cursor += 1;
         }
-
-        while self.module_comment_cursor < self.extra.module_comments.len() {
-            let span = self.extra.module_comments[self.module_comment_cursor];
-            if span.start >= to {
-                break;
-            }
-            results.push((
-                span.start,
-                span.end,
-                self.source[span.start as usize..span.end as usize].to_string(),
-            ));
-            self.module_comment_cursor += 1;
-        }
-
-        results.sort_by_key(|(pos, _, _)| *pos);
         results
+    }
+
+    pub(crate) fn pop_comments_before(&mut self, to: u32) -> Vec<Comment> {
+        self.drain_comments(0, to)
+    }
+
+    pub(crate) fn pop_comments_in_range(&mut self, from: u32, to: u32) -> Vec<Comment> {
+        self.drain_comments(from, to)
+    }
+
+    pub(crate) fn advance_comment_cursor_to(&mut self, pos: u32) {
+        let _ = self.drain_comments(0, pos);
     }
 
     /// Check if the source has a blank line in `(from, to)` (exclusive both ends).
     pub(crate) fn has_empty_line_between(&self, from: u32, to: u32) -> bool {
-        self.extra
-            .empty_lines
-            .iter()
-            .any(|&off| off > from && off < to)
-    }
-
-    /// Pop comments whose start is in `[from, to)`, advancing cursors past
-    /// `to`. Comments before `from` that haven't been consumed yet are skipped
-    /// silently — they should have been emitted by enclosing context already.
-    pub(crate) fn pop_comments_in_range(&mut self, from: u32, to: u32) -> Vec<String> {
-        let mut results: Vec<(u32, String)> = Vec::new();
-
-        while self.comment_cursor < self.extra.comments.len() {
-            let span = self.extra.comments[self.comment_cursor];
-            if span.start >= to {
-                break;
-            }
-            if span.start >= from {
-                results.push((
-                    span.start,
-                    self.source[span.start as usize..span.end as usize].to_string(),
-                ));
-            }
-            self.comment_cursor += 1;
-        }
-        while self.doc_comment_cursor < self.extra.doc_comments.len() {
-            let span = self.extra.doc_comments[self.doc_comment_cursor];
-            if span.start >= to {
-                break;
-            }
-            if span.start >= from {
-                results.push((
-                    span.start,
-                    self.source[span.start as usize..span.end as usize].to_string(),
-                ));
-            }
-            self.doc_comment_cursor += 1;
-        }
-
-        results.sort_by_key(|(p, _)| *p);
-        results.into_iter().map(|(_, t)| t).collect()
-    }
-
-    /// Advance all comment cursors past `pos`. Used after recursing into a
-    /// node that handles its own comments via CST traversal, so the program
-    /// loop doesn't re-emit the same comments from the side-channel.
-    pub(crate) fn advance_comment_cursor_to(&mut self, pos: u32) {
-        while self.comment_cursor < self.extra.comments.len()
-            && self.extra.comments[self.comment_cursor].start < pos
-        {
-            self.comment_cursor += 1;
-        }
-        while self.doc_comment_cursor < self.extra.doc_comments.len()
-            && self.extra.doc_comments[self.doc_comment_cursor].start < pos
-        {
-            self.doc_comment_cursor += 1;
-        }
-        while self.module_comment_cursor < self.extra.module_comments.len()
-            && self.extra.module_comments[self.module_comment_cursor].start < pos
-        {
-            self.module_comment_cursor += 1;
-        }
+        let idx = self.empty_lines.partition_point(|&off| off <= from);
+        idx < self.empty_lines.len() && self.empty_lines[idx] < to
     }
 
     // ── CST query helpers ───────────────────────────────────────

--- a/crates/floe-core/src/formatter/expr.rs
+++ b/crates/floe-core/src/formatter/expr.rs
@@ -48,8 +48,7 @@ impl Formatter<'_> {
                     if child.kind() == SyntaxKind::ITEM
                         || child.kind() == SyntaxKind::EXPR_ITEM =>
                 {
-                    let trailing_comments = self.trailing_comments_in(&child);
-                    let trailing_blank = self.has_trailing_blank_line(&child);
+                    let (trailing_comments, trailing_blank) = self.trailing_trivia(&child);
                     entries.push(BlockEntry::Item(child, saw_blank));
                     saw_blank = trailing_blank;
                     for comment in trailing_comments {
@@ -107,38 +106,26 @@ impl Formatter<'_> {
         ])
     }
 
-    /// Check if a node has trailing whitespace containing a blank line (2+ newlines).
-    fn has_trailing_blank_line(&self, node: &SyntaxNode) -> bool {
-        let all_tokens: Vec<_> = node
+    /// Single reverse-walk over descendants to extract both trailing comments
+    /// and whether there was a blank line in the trailing trivia. Replaces
+    /// separate `trailing_comments_in` + `has_trailing_blank_line`.
+    fn trailing_trivia(&self, node: &SyntaxNode) -> (Vec<String>, bool) {
+        let mut comments = Vec::new();
+        let mut has_blank = false;
+
+        for tok in node
             .descendants_with_tokens()
             .filter_map(|t| t.into_token())
-            .collect();
-
-        for tok in all_tokens.into_iter().rev() {
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+        {
             match tok.kind() {
                 SyntaxKind::WHITESPACE => {
                     if tok.text().chars().filter(|&c| c == '\n').count() >= 2 {
-                        return true;
+                        has_blank = true;
                     }
                 }
-                k if k.is_trivia() => continue,
-                _ => break,
-            }
-        }
-        false
-    }
-
-    /// Collect trailing comment tokens from a node's descendants
-    /// (comments after the last non-trivia content).
-    fn trailing_comments_in(&self, node: &SyntaxNode) -> Vec<String> {
-        let mut comments = Vec::new();
-        let all_tokens: Vec<_> = node
-            .descendants_with_tokens()
-            .filter_map(|t| t.into_token())
-            .collect();
-
-        for tok in all_tokens.into_iter().rev() {
-            match tok.kind() {
                 SyntaxKind::COMMENT | SyntaxKind::BLOCK_COMMENT => {
                     comments.push(tok.text().to_string());
                 }
@@ -147,7 +134,7 @@ impl Formatter<'_> {
             }
         }
         comments.reverse();
-        comments
+        (comments, has_blank)
     }
 
     // ── Pipe ────────────────────────────────────────────────────
@@ -167,12 +154,10 @@ impl Formatter<'_> {
         let first = self.fmt_pipe_segment(&segments[0]);
         let mut docs = vec![first];
         for i in 1..segments.len() {
+            let op_with_space = if ops[i - 1] == "|>" { "|> " } else { "|>? " };
             docs.push(pretty::nest(
                 4,
-                pretty::concat(vec![
-                    pretty::break_("", " "),
-                    pretty::str(format!("{} ", ops[i - 1])),
-                ]),
+                pretty::concat(vec![pretty::break_("", " "), pretty::str(op_with_space)]),
             ));
             docs.push(self.fmt_pipe_segment(&segments[i]));
         }
@@ -712,9 +697,8 @@ impl Formatter<'_> {
             }
 
             if let Some(prev) = prev_end {
-                let comments = self.pop_comments_in_range(prev, item_start);
-                for comment_text in comments {
-                    inner.push(pretty::str(comment_text));
+                for c in self.pop_comments_in_range(prev, item_start) {
+                    inner.push(pretty::str(c.text));
                     inner.push(pretty::line());
                     has_comment = true;
                 }
@@ -724,16 +708,13 @@ impl Formatter<'_> {
             prev_end = Some(item.text_range().end().into());
         }
 
-        let mut docs = vec![pretty::str(open.to_string())];
-        // ForceBroken marker INSIDE the group when comments are present —
-        // makes the group's fits() return false and thus break. Renders as
-        // nothing.
+        let mut docs = vec![pretty::str(open)];
         if has_comment {
-            docs.push(pretty::force_broken(pretty::nil()));
+            docs.push(pretty::force_break());
         }
         docs.push(pretty::nest(4, pretty::concat(inner)));
         docs.push(pretty::break_(",", ""));
-        docs.push(pretty::str(close.to_string()));
+        docs.push(pretty::str(close));
         pretty::group(pretty::concat(docs))
     }
 
@@ -871,9 +852,8 @@ impl Formatter<'_> {
                 inner.push(pretty::break_(",", ", "));
             }
             if let Some(prev) = prev_end {
-                let comments = self.pop_comments_in_range(prev, arg_start);
-                for comment_text in comments {
-                    inner.push(pretty::str(comment_text));
+                for c in self.pop_comments_in_range(prev, arg_start) {
+                    inner.push(pretty::str(c.text));
                     inner.push(pretty::line());
                     has_comment = true;
                 }
@@ -885,7 +865,7 @@ impl Formatter<'_> {
 
         let mut group_parts = vec![pretty::str("(")];
         if has_comment {
-            group_parts.push(pretty::force_broken(pretty::nil()));
+            group_parts.push(pretty::force_break());
         }
         group_parts.push(pretty::nest(4, pretty::concat(inner)));
         group_parts.push(pretty::break_(",", ""));
@@ -1162,9 +1142,8 @@ impl Formatter<'_> {
                 inner.push(pretty::break_(",", ", "));
             }
             if let Some(prev) = prev_end {
-                let comments = self.pop_comments_in_range(prev, elem.start);
-                for comment_text in comments {
-                    inner.push(pretty::str(comment_text));
+                for c in self.pop_comments_in_range(prev, elem.start) {
+                    inner.push(pretty::str(c.text));
                     inner.push(pretty::line());
                     has_comment = true;
                 }
@@ -1175,7 +1154,7 @@ impl Formatter<'_> {
 
         let mut group_parts = vec![pretty::str("[")];
         if has_comment {
-            group_parts.push(pretty::force_broken(pretty::nil()));
+            group_parts.push(pretty::force_break());
         }
         group_parts.push(pretty::nest(4, pretty::concat(inner)));
         group_parts.push(pretty::break_(",", ""));
@@ -1228,11 +1207,7 @@ impl Formatter<'_> {
     }
 
     pub(crate) fn fmt_wrapper_expr(&mut self, node: &SyntaxNode) -> Document {
-        let keyword = match node.kind() {
-            SyntaxKind::VALUE_EXPR => "Value",
-            _ => unreachable!(),
-        };
-        let mut parts = vec![pretty::str(keyword), pretty::str("(")];
+        let mut parts = vec![pretty::str("Value"), pretty::str("(")];
         if let Some(child) = node.children().next() {
             parts.push(self.fmt_node(&child));
         } else {

--- a/crates/floe-core/src/formatter/items.rs
+++ b/crates/floe-core/src/formatter/items.rs
@@ -225,8 +225,6 @@ impl Formatter<'_> {
         let return_type = node.children().find(|c| c.kind() == SyntaxKind::TYPE_EXPR);
         let block = node.children().find(|c| c.kind() == SyntaxKind::BLOCK_EXPR);
 
-        // Build the signature group: (params) -> ReturnType. Pop any
-        // inter-parameter comments from the side-channel and interleave them.
         let mut sig = Vec::new();
         sig.push(pretty::str("("));
         let mut has_comment = false;
@@ -239,9 +237,8 @@ impl Formatter<'_> {
                     inner.push(pretty::break_(",", ", "));
                 }
                 if let Some(prev) = prev_end {
-                    let comments = self.pop_comments_in_range(prev, p_start);
-                    for comment_text in comments {
-                        inner.push(pretty::str(comment_text));
+                    for c in self.pop_comments_in_range(prev, p_start) {
+                        inner.push(pretty::str(c.text));
                         inner.push(pretty::line());
                         has_comment = true;
                     }
@@ -250,7 +247,7 @@ impl Formatter<'_> {
                 prev_end = Some(p.text_range().end().into());
             }
             if has_comment {
-                sig.push(pretty::force_broken(pretty::nil()));
+                sig.push(pretty::force_break());
             }
             sig.push(pretty::nest(4, pretty::concat(inner)));
             sig.push(pretty::break_(",", ""));
@@ -504,10 +501,9 @@ impl Formatter<'_> {
         for member in &members {
             let m_start: u32 = member.text_range().start().into();
             if let Some(prev) = prev_end {
-                let comments = self.pop_comments_in_range(prev, m_start);
-                for comment_text in comments {
+                for c in self.pop_comments_in_range(prev, m_start) {
                     inner.push(pretty::line());
-                    inner.push(pretty::str(comment_text));
+                    inner.push(pretty::str(c.text));
                 }
             }
             inner.push(pretty::line());

--- a/crates/floe-core/src/pretty.rs
+++ b/crates/floe-core/src/pretty.rs
@@ -259,6 +259,12 @@ pub fn force_broken(doc: Document) -> Document {
     Document::ForceBroken(Box::new(doc))
 }
 
+/// Sentinel that forces the enclosing Group to break without rendering
+/// anything itself. Place inside a Group to unconditionally break it.
+pub fn force_break() -> Document {
+    force_broken(nil())
+}
+
 // -- Tests ------------------------------------------------------------------
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Post-merge cleanup of the #1116 formatter rewrite (`/simplify` pass).

- Merged 3 comment cursors (`comment_cursor`, `doc_comment_cursor`, `module_comment_cursor`) into a single pre-sorted `Vec<SrcSpan>`, reducing 9 near-identical while-loops across the cursor methods to 1
- Unified `pop_comments_before`, `pop_comments_in_range`, and `advance_comment_cursor_to` into one `drain_comments(from, to)` primitive
- Introduced `Comment { start, end, text }` struct to replace anonymous `(u32, u32, String)` tuples
- Added `pretty::force_break()` shorthand for the `force_broken(nil())` sentinel pattern
- Combined `trailing_comments_in` + `has_trailing_blank_line` into a single `trailing_trivia()` walk per block child
- Used `partition_point` for `empty_lines` lookup (O(log n) vs O(n) linear scan)
- Replaced `format!("{} ", op)` in pipe formatting with static `&str` match
- Extracted `emit_program_comments` method, simplified `fmt_wrapper_expr`
- Net -78 lines

## Test plan

- [x] All 109 formatter tests pass
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)