### PR TITLE
feat: [#1118] add Hindley Milner unification with hydrator and typed vars

### DIFF
--- a/crates/floe-core/src/checker.rs
+++ b/crates/floe-core/src/checker.rs
@@ -2,6 +2,7 @@ mod attach;
 mod environment;
 pub mod error_codes;
 mod expr;
+mod hydrator;
 mod imports;
 mod items;
 mod match_check;
@@ -14,7 +15,9 @@ mod traits;
 mod type_compat;
 mod type_registration;
 mod type_resolve;
+mod type_var;
 mod types;
+mod unify;
 
 pub use attach::{
     attach_trait_decl_shallow, attach_type_decl_shallow, attach_types, lower_to_typed,
@@ -187,7 +190,7 @@ pub struct Checker {
     /// Expressions that produced a type error — `attach_types` converts
     /// them to `ExprKind::Invalid` so codegen skips broken subtrees.
     invalid_exprs: HashSet<ExprId>,
-    next_var: usize,
+    next_var: u64,
     /// Standard library function registry.
     stdlib: StdlibRegistry,
     /// Maps expression IDs to their resolved types.
@@ -241,6 +244,10 @@ pub struct Checker {
     /// Import sources that resolve to `.ts`/`.tsx` files but could not be
     /// resolved because tsgo is not installed.
     ts_imports_missing_tsgo: HashSet<String>,
+    /// User-written generic type parameter names mapped to the `Generic`
+    /// variables minted for them. Populated at the top of each fn decl
+    /// (see `hydrator::Hydrator`) and cleared when the fn scope pops.
+    active_type_params: HashMap<String, Type>,
 }
 
 /// Signature of a trait method (for checking implementations).
@@ -445,6 +452,7 @@ impl Checker {
             jsx_children_hints: HashMap::new(),
             ambient_types: HashMap::new(),
             ts_imports_missing_tsgo: HashSet::new(),
+            active_type_params: HashMap::new(),
         }
     }
 
@@ -825,7 +833,7 @@ impl Checker {
     fn fresh_type_var(&mut self) -> Type {
         let id = self.next_var;
         self.next_var += 1;
-        Type::Var(id)
+        Type::unbound(id)
     }
 
     /// Emit an error if `name` is already defined in any scope (no shadowing allowed).

--- a/crates/floe-core/src/checker/expr.rs
+++ b/crates/floe-core/src/checker/expr.rs
@@ -33,10 +33,7 @@ fn extract_chain_key(object: &Expr, field: &str) -> Option<String> {
     }
 }
 
-/// Check if a string is a single uppercase letter (generic type parameter).
-fn is_generic_param(s: &str) -> bool {
-    s.len() == 1 && s.chars().next().is_some_and(|c| c.is_ascii_uppercase())
-}
+use super::hydrator::is_single_uppercase as is_generic_param;
 
 /// When a destructured param's type is unresolved, use heuristics for known field names.
 /// The "error" field maps to Error because Floe's error-handling callbacks (use blocks,
@@ -713,6 +710,20 @@ impl Checker {
         for el in elements {
             let ty = self.check_expr(el);
             if let Some(ref prev) = elem_type {
+                // Unify each element with the running type so unbound vars
+                // get pinned down. `fn bad(x) { [x, bad(x)] }` tries to unify
+                // `x: a` with `bad(x): Array<a>` — the occurs check rejects
+                // the infinite `a = Array<a>` that would result.
+                if let Err(super::unify::UnifyError::InfiniteType) = super::unify::unify(prev, &ty)
+                {
+                    self.emit_error(
+                        "infinite type: a type variable would have to contain itself",
+                        el.span,
+                        ErrorCode::TypeMismatch,
+                        "recursive type has no finite form",
+                    );
+                    return Type::Array(Arc::new(Type::Error));
+                }
                 if !self.types_compatible(prev, &ty)
                     && !ty.is_undetermined()
                     && !prev.is_undetermined()
@@ -726,7 +737,7 @@ impl Checker {
         if mixed {
             Type::Array(Arc::new(Type::Unknown))
         } else {
-            Type::Array(Arc::new(elem_type.unwrap_or(Type::Unknown)))
+            Type::Array(Arc::new(elem_type.unwrap_or(Type::Unknown).deep_resolved()))
         }
     }
 
@@ -744,46 +755,45 @@ impl Checker {
             && let ExprKind::Identifier(module) = &object.kind
             && let Some(stdlib_fn) = self.stdlib.lookup(module, field)
         {
-            let ret = stdlib_fn.return_type.clone();
-            let expected_param_count = stdlib_fn.params.len();
+            let stdlib_params_src = stdlib_fn.params.clone();
+            let stdlib_ret_src = stdlib_fn.return_type.clone();
+            let expected_param_count = stdlib_params_src.len();
             let variadic = stdlib_fn.is_variadic();
-            let stdlib_params = stdlib_fn.params.clone();
             let display = format!("{module}.{field}");
             self.unused.used_names.insert(module.clone());
 
-            // Two-pass argument checking: first check non-arrow args to resolve
-            // type variables, then check arrow args with lambda_param_hints set.
-            // This allows `use x <- Option.guard(opt, default)` to infer the
-            // callback parameter type from the option's inner type.
-            let mut type_var_bindings: HashMap<usize, Type> = HashMap::new();
+            // Instantiate the stdlib signature: turn `Generic(id)` into fresh
+            // `Unbound` vars so each call site specializes independently.
+            let (inst_params, inst_ret) = hydrator::instantiate_signature(
+                &stdlib_params_src,
+                &stdlib_ret_src,
+                &mut self.next_var,
+            );
+
+            // Two-pass argument checking: first check non-arrow args (they
+            // carry concrete types that unify into the fresh vars), then
+            // check arrow args with lambda_param_hints set — by that point
+            // the vars are bound, so hints carry concrete types.
             let mut arg_count = 0;
 
-            // Pass 1: check non-arrow args and collect type var bindings
+            // Pass 1: check non-arrow args and unify each with the matching param.
             let mut non_arrow_args: Vec<(usize, Type, Span)> = Vec::new();
             for (i, arg) in args.iter().enumerate() {
                 let (Arg::Positional(e) | Arg::Named { value: e, .. }) = arg;
                 if !matches!(e.kind, ExprKind::Arrow { .. }) {
                     let actual_ty = self.check_expr(e);
-                    if let Some(param_ty) = stdlib_params.get(i) {
-                        Self::collect_type_var_bindings(
-                            param_ty,
-                            &actual_ty,
-                            &mut type_var_bindings,
-                        );
+                    if let Some(param_ty) = inst_params.get(i) {
+                        let _ = unify::unify(param_ty, &actual_ty);
                     }
                     non_arrow_args.push((i, actual_ty, e.span));
                     arg_count += 1;
                 }
             }
 
-            // Validate non-arrow args against fully-resolved param types
+            // Validate non-arrow args against the now-resolved param types.
             for &(i, ref actual_ty, arg_span) in &non_arrow_args {
-                if let Some(param_ty) = stdlib_params.get(i) {
-                    let resolved_param = if type_var_bindings.is_empty() {
-                        param_ty.clone()
-                    } else {
-                        Self::substitute_type_vars(param_ty, &type_var_bindings)
-                    };
+                if let Some(param_ty) = inst_params.get(i) {
+                    let resolved_param = param_ty.resolved();
                     if !self.types_compatible(&resolved_param, actual_ty) {
                         let (msg, label) = self.type_mismatch_detail(&resolved_param, actual_ty);
                         self.emit_error(
@@ -796,21 +806,20 @@ impl Checker {
                 }
             }
 
-            // Pass 2: check arrow args with resolved lambda_param_hints
+            // Pass 2: check arrow args with lambda_param_hints derived from the
+            // resolved instantiated params.
             for (i, arg) in args.iter().enumerate() {
                 let (Arg::Positional(e) | Arg::Named { value: e, .. }) = arg;
                 if matches!(e.kind, ExprKind::Arrow { .. }) {
-                    if let Some(Type::Function { params, .. }) = stdlib_params.get(i) {
-                        self.ctx.lambda_param_hints = if type_var_bindings.is_empty() {
-                            params.clone()
-                        } else {
-                            params
-                                .iter()
-                                .map(|p| Self::substitute_type_vars(p, &type_var_bindings))
-                                .collect()
-                        };
+                    if let Some(inst_param) = inst_params.get(i)
+                        && let Type::Function { params, .. } = inst_param.resolved()
+                    {
+                        self.ctx.lambda_param_hints = params.iter().map(|p| p.resolved()).collect();
                     }
-                    self.check_expr(e);
+                    let actual_ty = self.check_expr(e);
+                    if let Some(param_ty) = inst_params.get(i) {
+                        let _ = unify::unify(param_ty, &actual_ty);
+                    }
                     self.ctx.lambda_param_hints.clear();
                     arg_count += 1;
                 }
@@ -830,7 +839,7 @@ impl Checker {
                 );
             }
 
-            return ret;
+            return inst_ret.deep_resolved();
         }
 
         // Save pipe context before checking callee (which would consume it)
@@ -911,6 +920,16 @@ impl Checker {
         // to their concrete types so function aliases are callable like bare functions.
         let callee_ty = if let Type::Named(_) = &callee_ty {
             self.resolve_type_to_concrete(&callee_ty)
+        } else {
+            callee_ty
+        };
+
+        // Instantiate the callee's generic type parameters (let-polymorphism):
+        // each call site gets its own fresh `Unbound` vars for the callee's
+        // `Generic` vars so multiple calls to a polymorphic function can use
+        // different types without the first call fixing the second.
+        let callee_ty = if matches!(callee_ty, Type::Function { .. }) {
+            hydrator::instantiate(&callee_ty, &mut self.next_var)
         } else {
             callee_ty
         };
@@ -1085,10 +1104,15 @@ impl Checker {
                         }
                     }
 
-                    // Normal call: check all argument types
+                    // Normal call: unify each arg with its param so the callee's
+                    // instantiated type vars pick up the arg types, then check.
+                    for (arg_ty, param_ty) in arg_types.iter().zip(params.iter()) {
+                        let _ = unify::unify(param_ty, arg_ty);
+                    }
                     for (i, (arg_ty, param_ty)) in arg_types.iter().zip(params.iter()).enumerate() {
-                        if !self.types_compatible(param_ty, arg_ty) {
-                            let (msg, label) = self.type_mismatch_detail(param_ty, arg_ty);
+                        let resolved_param = param_ty.deep_resolved();
+                        if !self.types_compatible(&resolved_param, arg_ty) {
+                            let (msg, label) = self.type_mismatch_detail(&resolved_param, arg_ty);
                             self.emit_error(
                                 format!("argument {} to `{callee_name}`: {}", i + 1, msg),
                                 span,
@@ -1097,7 +1121,7 @@ impl Checker {
                             );
                         }
                     }
-                    return_type
+                    return_type.deep_resolved()
                 }
             }
             // Foreign member access (chained call on opaque npm type like
@@ -1817,209 +1841,93 @@ impl Checker {
         left_ty: &Type,
         right: &Expr,
     ) -> Type {
-        if let Some(first_param) = stdlib_fn.params.first()
-            && !self.types_compatible(first_param, left_ty)
-            && !self.is_untrusted_result_mismatch(first_param, left_ty)
-        {
-            let (msg, label) = self.type_mismatch_detail(first_param, left_ty);
-            self.emit_error(
-                format!("argument 1 to `{display_name}`: {}", msg),
-                right.span,
-                ErrorCode::TypeMismatch,
-                label,
-            );
+        // Instantiate the stdlib signature so Generics become fresh Unbounds.
+        let (inst_params, inst_ret) = hydrator::instantiate_signature(
+            &stdlib_fn.params,
+            &stdlib_fn.return_type,
+            &mut self.next_var,
+        );
+
+        // Unify the first param with the piped-in type so type vars pick up
+        // the piped-in type's shape (e.g. Array<T> unified with Array<Todo>
+        // binds T → Todo).
+        if let Some(first_param) = inst_params.first() {
+            let unified = unify::unify(first_param, left_ty).is_ok();
+            if !unified
+                && !self.types_compatible(&first_param.resolved(), left_ty)
+                && !self.is_untrusted_result_mismatch(&first_param.resolved(), left_ty)
+            {
+                let resolved_first = first_param.resolved();
+                let (msg, label) = self.type_mismatch_detail(&resolved_first, left_ty);
+                self.emit_error(
+                    format!("argument 1 to `{display_name}`: {}", msg),
+                    right.span,
+                    ErrorCode::TypeMismatch,
+                    label,
+                );
+            }
         }
+
+        // Lambda param hints: pull from resolved first param when the piped value
+        // is an array/option so `|> map(x -> ...)` knows x's type.
         if let Type::Array(elem) = left_ty {
             self.ctx.lambda_param_hints = vec![(**elem).clone()];
         } else if let Some(inner) = left_ty.option_inner() {
             self.ctx.lambda_param_hints = vec![inner.clone()];
         }
 
-        // Check lambda args and capture return type for generic inference
-        let lambda_return = self.check_pipe_right_args_with_return(right);
-        self.ctx.lambda_param_hints.clear();
-
-        // Resolve return type: if the stdlib fn's return type uses a different
-        // type var than the input (e.g. map: Array<T> -> Array<U>), infer U
-        // from the lambda's actual return type.
-        let infer_from_lambda = lambda_return.is_some()
-            && match (&stdlib_fn.return_type, stdlib_fn.params.first()) {
-                (Type::Array(ret_elem), Some(Type::Array(in_elem))) => ret_elem != in_elem,
-                (ret, Some(inp)) if ret.is_option() && inp.is_option() => {
-                    ret.option_inner() != inp.option_inner()
-                }
-                _ => false,
-            };
-        // Resolve return type by substituting type variables from the piped input.
-        let mut var_bindings: HashMap<usize, Type> = HashMap::new();
-        if let Some(first_param) = stdlib_fn.params.first() {
-            Self::collect_type_var_bindings(first_param, left_ty, &mut var_bindings);
-        }
-        // If the return type uses a different type var (e.g. map: Array<T> -> Array<U>),
-        // infer it from the lambda's actual return type.
-        if infer_from_lambda {
-            match &stdlib_fn.return_type {
-                Type::Array(_) => Type::Array(Arc::new(lambda_return.unwrap())),
-                ret if ret.is_option() => Type::option_of(lambda_return.unwrap()),
-                _ => Self::substitute_type_vars(&stdlib_fn.return_type, &var_bindings),
-            }
-        } else if !var_bindings.is_empty() {
-            Self::substitute_type_vars(&stdlib_fn.return_type, &var_bindings)
-        } else {
-            // No type var bindings resolved — match concrete types directly
-            match (&stdlib_fn.return_type, left_ty) {
-                (Type::Array(_), Type::Array(elem)) => Type::Array(elem.clone()),
-                (ret, actual) if ret.is_option() && actual.is_option() => actual.clone(),
-                // Foreign input: generics can't be resolved, propagate Foreign
-                // so chained calls like db.insert(...).values(...).returning() |> await
-                // don't collapse to Unknown
-                (_, Type::Foreign(_)) => left_ty.clone(),
-                // Result<Foreign, _> from an untrusted chain (e.g. untrusted db chain
-                // wrapped at each call): propagate the Result as-is so the user can
-                // unwrap and access the Foreign result rather than getting `?T0`.
-                _ if left_ty.is_result()
-                    && matches!(left_ty.result_ok(), Some(Type::Foreign(_))) =>
-                {
-                    left_ty.clone()
-                }
-                _ => stdlib_fn.return_type.clone(),
-            }
-        }
-    }
-
-    /// Check arguments in the right side of a pipe and return the lambda's return type.
-    fn check_pipe_right_args_with_return(&mut self, right: &Expr) -> Option<Type> {
-        let mut lambda_return = None;
+        // Check each right-side arg. The piped-in counts as arg 0, so the
+        // first right-side arg unifies with inst_params[1], etc. Capture the
+        // lambda return (first right-side arg's fn return) and unify it with
+        // the matching instantiated param's return type.
+        let mut lambda_return: Option<Type> = None;
         if let ExprKind::Call { args, .. } = &right.kind {
             for (i, arg) in args.iter().enumerate() {
-                match arg {
-                    Arg::Positional(e) | Arg::Named { value: e, .. } => {
-                        let ty = self.check_expr(e);
-                        if i == 0
-                            && let Type::Function { return_type, .. } = &ty
-                        {
-                            lambda_return = Some(return_type.as_ref().clone());
-                        }
-                    }
+                let (Arg::Positional(e) | Arg::Named { value: e, .. }) = arg;
+                // Hints for lambda args: if the matching inst param is a
+                // Function, pre-populate lambda_param_hints so the inner
+                // params know their types.
+                let inst_param = inst_params.get(i + 1).cloned();
+                if matches!(e.kind, ExprKind::Arrow { .. })
+                    && let Some(p) = &inst_param
+                    && let Type::Function { params, .. } = p.resolved()
+                {
+                    self.ctx.lambda_param_hints = params.iter().map(|p| p.resolved()).collect();
+                }
+                let actual_ty = self.check_expr(e);
+                self.ctx.lambda_param_hints.clear();
+
+                if i == 0
+                    && let Type::Function { return_type, .. } = &actual_ty
+                {
+                    lambda_return = Some(return_type.as_ref().clone());
+                }
+                if let Some(p) = &inst_param {
+                    let _ = unify::unify(p, &actual_ty);
                 }
             }
         }
-        lambda_return
-    }
 
-    /// Unify a stdlib parameter type against an actual argument type to resolve
-    /// `Type::Var(n)` bindings. E.g. `Option<Var(0)>` unified with `Option<IssueDto>`
-    /// binds `Var(0) → IssueDto`.
-    fn collect_type_var_bindings(
-        param_ty: &Type,
-        actual_ty: &Type,
-        bindings: &mut HashMap<usize, Type>,
-    ) {
-        match (param_ty, actual_ty) {
-            (Type::Var(n), _) if !actual_ty.is_undetermined() => {
-                bindings.insert(*n, actual_ty.clone());
-            }
-            (Type::Array(p), Type::Array(a))
-            | (Type::Promise(p), Type::Promise(a))
-            | (Type::Settable(p), Type::Settable(a))
-            | (Type::Set { element: p }, Type::Set { element: a }) => {
-                Self::collect_type_var_bindings(p, a, bindings);
-            }
-            (Type::Map { key: pk, value: pv }, Type::Map { key: ak, value: av })
-            | (Type::RecordMap { key: pk, value: pv }, Type::RecordMap { key: ak, value: av }) => {
-                Self::collect_type_var_bindings(pk, ak, bindings);
-                Self::collect_type_var_bindings(pv, av, bindings);
-            }
-            (Type::Tuple(ps), Type::Tuple(as_)) if ps.len() == as_.len() => {
-                for (p, a) in ps.iter().zip(as_.iter()) {
-                    Self::collect_type_var_bindings(p, a, bindings);
-                }
-            }
-            (Type::Union { variants: pv, .. }, Type::Union { variants: av, .. }) => {
-                for (pvar, avar) in pv.iter().zip(av.iter()) {
-                    for (p, a) in pvar.1.iter().zip(avar.1.iter()) {
-                        Self::collect_type_var_bindings(p, a, bindings);
-                    }
-                }
-            }
-            (
-                Type::Function {
-                    params: pp,
-                    return_type: pr,
-                    ..
-                },
-                Type::Function {
-                    params: ap,
-                    return_type: ar,
-                    ..
-                },
-            ) => {
-                for (p, a) in pp.iter().zip(ap.iter()) {
-                    Self::collect_type_var_bindings(p, a, bindings);
-                }
-                Self::collect_type_var_bindings(pr, ar, bindings);
-            }
-            _ => {}
+        if let (Some(actual_ret), Some(Type::Function { return_type, .. })) = (
+            lambda_return.as_ref(),
+            inst_params.get(1).map(|p| p.resolved()),
+        ) {
+            let _ = unify::unify(&return_type, actual_ret);
         }
-    }
 
-    /// Substitute `Type::Var(n)` with resolved types from the bindings map.
-    fn substitute_type_vars(ty: &Type, bindings: &HashMap<usize, Type>) -> Type {
-        match ty {
-            Type::Var(n) => bindings.get(n).cloned().unwrap_or_else(|| ty.clone()),
-            Type::Array(inner) => {
-                Type::Array(Arc::new(Self::substitute_type_vars(inner, bindings)))
+        // Foreign input: generics can't be resolved, propagate Foreign
+        // so chained calls like db.insert(...).values(...).returning() |> await
+        // don't collapse to Unknown.
+        let resolved_ret = inst_ret.deep_resolved();
+        match (&resolved_ret, left_ty) {
+            (_, Type::Foreign(_)) if matches!(resolved_ret, Type::Var(_)) => left_ty.clone(),
+            _ if left_ty.is_result()
+                && matches!(left_ty.result_ok(), Some(Type::Foreign(_)))
+                && matches!(resolved_ret, Type::Var(_)) =>
+            {
+                left_ty.clone()
             }
-            Type::Promise(inner) => {
-                Type::Promise(Arc::new(Self::substitute_type_vars(inner, bindings)))
-            }
-            Type::Settable(inner) => {
-                Type::Settable(Arc::new(Self::substitute_type_vars(inner, bindings)))
-            }
-            Type::Set { element } => Type::Set {
-                element: Arc::new(Self::substitute_type_vars(element, bindings)),
-            },
-            Type::Map { key, value } => Type::Map {
-                key: Arc::new(Self::substitute_type_vars(key, bindings)),
-                value: Arc::new(Self::substitute_type_vars(value, bindings)),
-            },
-            Type::RecordMap { key, value } => Type::RecordMap {
-                key: Arc::new(Self::substitute_type_vars(key, bindings)),
-                value: Arc::new(Self::substitute_type_vars(value, bindings)),
-            },
-            Type::Tuple(types) => Type::Tuple(
-                types
-                    .iter()
-                    .map(|t| Self::substitute_type_vars(t, bindings))
-                    .collect(),
-            ),
-            Type::Union { name, variants } => Type::Union {
-                name: name.clone(),
-                variants: variants
-                    .iter()
-                    .map(|(n, ts)| {
-                        (
-                            n.clone(),
-                            ts.iter()
-                                .map(|t| Self::substitute_type_vars(t, bindings))
-                                .collect(),
-                        )
-                    })
-                    .collect(),
-            },
-            Type::Function {
-                params,
-                return_type,
-                required_params,
-            } => Type::Function {
-                params: params
-                    .iter()
-                    .map(|t| Self::substitute_type_vars(t, bindings))
-                    .collect(),
-                return_type: Arc::new(Self::substitute_type_vars(return_type, bindings)),
-                required_params: *required_params,
-            },
-            other => other.clone(),
+            _ => resolved_ret,
         }
     }
 

--- a/crates/floe-core/src/checker/hydrator.rs
+++ b/crates/floe-core/src/checker/hydrator.rs
@@ -1,0 +1,210 @@
+//! Hydration: translate user-written type names into the internal representation.
+//!
+//! When the parser sees a name like `a` or `T` in a function signature, it
+//! shows up in the CST as `Type::Named("a")`. To participate in Hindley-Milner
+//! inference, those names need to be mapped to actual type variables.
+//!
+//! The `Hydrator` is a small per-scope map from lowercase identifier (the
+//! user-facing generic name) to a `Generic` type variable. The first time a
+//! name is seen, a fresh `Generic` is minted. Subsequent occurrences reuse it,
+//! so `fn id(x: a) -> a` binds both `a`s to the same variable.
+//!
+//! Tree-walking is delegated to `type_var::map_children` so the three surface
+//! operations here — `instantiate`, `generalise`, `hydrate_single_letter_generics`
+//! — are each a single leaf-replacement rule, not a 60-line match per walker.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use super::type_var::{self, TypeVar, TypeVarRef, map_children};
+use super::types::Type;
+
+/// Maps user-written type-parameter names to `Generic` variables during
+/// signature hydration.
+#[derive(Default)]
+pub struct Hydrator {
+    by_name: HashMap<String, TypeVarRef>,
+}
+
+impl Hydrator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Look up or mint a fresh `Generic` variable for `name`. Uses `next_id`
+    /// to allocate fresh ids (the caller threads in a global counter).
+    pub fn generic_for(&mut self, name: &str, next_id: &mut u64) -> Type {
+        if let Some(var) = self.by_name.get(name) {
+            return Type::Var(Arc::clone(var));
+        }
+        let id = *next_id;
+        *next_id += 1;
+        let var = type_var::generic(id);
+        self.by_name.insert(name.to_string(), Arc::clone(&var));
+        Type::Var(var)
+    }
+}
+
+/// Single uppercase ASCII letter (`T`, `U`, `E`, …) — the `.d.ts` convention
+/// for generic parameter names.
+pub fn is_single_uppercase(n: &str) -> bool {
+    n.len() == 1 && n.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+}
+
+fn fresh_unbound(next_id: &mut u64) -> TypeVarRef {
+    let id = *next_id;
+    *next_id += 1;
+    type_var::unbound(id)
+}
+
+/// Walk `ty` and replace every `Generic` variable with a fresh `Unbound` one,
+/// using a shared id-keyed mapping so the *same* generic (by id) becomes the
+/// *same* unbound across the produced tree. This is the let-polymorphism step:
+/// each call site gets its own copy of the signature's variables.
+pub fn instantiate(ty: &Type, next_id: &mut u64) -> Type {
+    let mut mapping: HashMap<u64, TypeVarRef> = HashMap::new();
+    instantiate_with(ty, next_id, &mut mapping)
+}
+
+fn instantiate_with(ty: &Type, next_id: &mut u64, mapping: &mut HashMap<u64, TypeVarRef>) -> Type {
+    map_children(ty, &mut |t| match t {
+        Type::Var(var) => match type_var::snapshot(var) {
+            TypeVar::Generic { id } => {
+                let fresh = mapping
+                    .entry(id)
+                    .or_insert_with(|| fresh_unbound(next_id))
+                    .clone();
+                Some(Type::Var(fresh))
+            }
+            TypeVar::Link { type_ } => Some(instantiate_with(&type_, next_id, mapping)),
+            TypeVar::Unbound { .. } => Some(t.clone()),
+        },
+        _ => None,
+    })
+}
+
+/// Instantiate a whole function signature (params + return type) with a shared
+/// mapping so each `Generic` id maps to the *same* fresh `Unbound` variable
+/// across both the parameters and the return. Use this at call sites where
+/// the params and return should share type-var bindings.
+pub fn instantiate_signature(
+    params: &[Type],
+    return_type: &Type,
+    next_id: &mut u64,
+) -> (Vec<Type>, Type) {
+    let mut mapping: HashMap<u64, TypeVarRef> = HashMap::new();
+    let inst_params = params
+        .iter()
+        .map(|p| instantiate_with(p, next_id, &mut mapping))
+        .collect();
+    let inst_ret = instantiate_with(return_type, next_id, &mut mapping);
+    (inst_params, inst_ret)
+}
+
+/// Walk `ty` and replace every `Unbound` variable with a `Generic` one,
+/// reusing ids so shared variables remain shared. Used to freeze a function's
+/// signature after its body has been checked.
+pub fn generalise(ty: &Type) -> Type {
+    let mut mapping: HashMap<u64, TypeVarRef> = HashMap::new();
+    map_children(ty, &mut |t| match t {
+        Type::Var(var) => match type_var::snapshot(var) {
+            TypeVar::Unbound { id } => {
+                let g = mapping
+                    .entry(id)
+                    .or_insert_with(|| type_var::generic(id))
+                    .clone();
+                Some(Type::Var(g))
+            }
+            TypeVar::Link { type_ } => Some(generalise(&type_)),
+            TypeVar::Generic { .. } => Some(t.clone()),
+        },
+        _ => None,
+    })
+}
+
+/// Walk `ty` replacing every `Type::Named(n)` where `n` is a single uppercase
+/// ASCII letter (`T`, `U`, `E`, …) with a `Generic` type variable. Uppercase
+/// single letters are the convention used by TypeScript `.d.ts` signatures for
+/// generics — by hydrating them here, imported function signatures plug into
+/// the same HM unification pipeline as native Floe functions. Same letters
+/// share the same Generic id across the walk so `(T) -> T` stays tied.
+pub fn hydrate_single_letter_generics(ty: &Type, next_id: &mut u64) -> Type {
+    let mut mapping: HashMap<String, TypeVarRef> = HashMap::new();
+    map_children(ty, &mut |t| match t {
+        Type::Named(n) if is_single_uppercase(n) => {
+            let var = mapping
+                .entry(n.clone())
+                .or_insert_with(|| {
+                    let id = *next_id;
+                    *next_id += 1;
+                    type_var::generic(id)
+                })
+                .clone();
+            Some(Type::Var(var))
+        }
+        _ => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hydrator_reuses_same_variable_for_same_name() {
+        let mut h = Hydrator::new();
+        let mut next = 0u64;
+        let a1 = h.generic_for("a", &mut next);
+        let a2 = h.generic_for("a", &mut next);
+        assert_eq!(a1.var_id(), a2.var_id());
+        assert_eq!(next, 1);
+    }
+
+    #[test]
+    fn hydrator_mints_new_variable_for_new_name() {
+        let mut h = Hydrator::new();
+        let mut next = 0u64;
+        let a = h.generic_for("a", &mut next);
+        let b = h.generic_for("b", &mut next);
+        assert_ne!(a.var_id(), b.var_id());
+    }
+
+    #[test]
+    fn instantiate_replaces_generics_with_fresh_unbounds() {
+        let mut next = 10u64;
+        let mut h = Hydrator::new();
+        let a = h.generic_for("a", &mut next);
+        let sig = Type::Function {
+            params: vec![a.clone()],
+            required_params: 1,
+            return_type: Arc::new(a.clone()),
+        };
+        assert!(a.is_generic_var());
+
+        let inst = instantiate(&sig, &mut next);
+        if let Type::Function {
+            params,
+            return_type,
+            ..
+        } = &inst
+        {
+            assert!(params[0].is_unbound());
+            assert!(return_type.is_unbound());
+            // Both point to the same Unbound var.
+            if let (Type::Var(p), Type::Var(r)) = (&params[0], return_type.as_ref()) {
+                assert!(Arc::ptr_eq(p, r));
+            } else {
+                panic!("expected Type::Var on both sides");
+            }
+        } else {
+            panic!("expected Type::Function");
+        }
+    }
+
+    #[test]
+    fn generalise_turns_unbound_back_to_generic() {
+        let v = Type::unbound(7);
+        let g = generalise(&v);
+        assert!(g.is_generic_var());
+    }
+}

--- a/crates/floe-core/src/checker/imports.rs
+++ b/crates/floe-core/src/checker/imports.rs
@@ -78,7 +78,14 @@ impl Checker {
                                 .insert(effective_name.to_string(), required);
                         }
                     }
-                    let ty = interop::wrap_boundary_type(&dts_export.ts_type);
+                    let raw_ty = interop::wrap_boundary_type(&dts_export.ts_type);
+                    // Hydrate single-letter type params (`T`, `S`, …) into Generic
+                    // vars so the imported signature participates in real HM
+                    // unification at call sites instead of string-matching by letter.
+                    let ty = super::hydrator::hydrate_single_letter_generics(
+                        &raw_ty,
+                        &mut self.next_var,
+                    );
                     // npm imports that resolve to Unknown (unrecognized primitive,
                     // type-only exports, overloaded signatures tsgo can't map)
                     // should fall back to Foreign. They're at an explicit npm

--- a/crates/floe-core/src/checker/items.rs
+++ b/crates/floe-core/src/checker/items.rs
@@ -391,6 +391,25 @@ impl Checker {
             );
         }
 
+        // Hydrate the fn's generic type parameters into `Generic` vars. Each
+        // unconstrained name (`T`, `U`, …) becomes a unique Generic variable
+        // shared across every occurrence inside the signature. Trait-bounded
+        // params (`R: Repo`) keep their `Named(name)` resolution so trait
+        // method dispatch and codegen continue to fire on them — the bound
+        // carries structural requirements that current inference doesn't
+        // model, and the static dispatch path relies on the name.
+        let prev_type_params = std::mem::take(&mut self.active_type_params);
+        {
+            let mut hydrator = super::hydrator::Hydrator::new();
+            for tp in &decl.type_params {
+                if !tp.bounds.is_empty() {
+                    continue;
+                }
+                let g = hydrator.generic_for(&tp.name, &mut self.next_var);
+                self.active_type_params.insert(tp.name.clone(), g);
+            }
+        }
+
         // Register generic type parameters so they're recognized during type resolution
         for tp in &decl.type_params {
             self.env.define(&tp.name, Type::Named(tp.name.clone()));
@@ -536,8 +555,36 @@ impl Checker {
         let body_type = self.check_expr(&decl.body);
         let uses_await = super::body_has_promise_await(&decl.body);
 
-        // When no return type annotation, infer from body and update the function type
-        if decl.return_type.is_none() && !body_type.is_undetermined() {
+        // Unify the body type with the declared/fresh return type. This
+        // propagates inference into the return var and triggers the occurs
+        // check on recursive types like `fn bad(x) { [x, bad(x)] }` where
+        // unifying `return_var` with `Array<return_var>` would build an
+        // infinite type.
+        let effective_body_type = if decl.async_fn {
+            Type::Promise(Arc::new(body_type.clone()))
+        } else {
+            body_type.clone()
+        };
+        if let Err(super::unify::UnifyError::InfiniteType) =
+            super::unify::unify(&return_type, &effective_body_type)
+        {
+            self.emit_error(
+                format!(
+                    "function `{}` has an infinite type — a type variable would have to contain itself",
+                    decl.name
+                ),
+                last_expr_span(&decl.body),
+                ErrorCode::TypeMismatch,
+                "recursive type has no finite form",
+            );
+        }
+
+        // When no return type annotation, infer from body and update the function type.
+        // Body type may itself be an unbound type variable (e.g. `fn id(x) { x }`);
+        // we still want to register and generalise in that case so the fn becomes
+        // polymorphic at call sites.
+        let body_is_error = matches!(body_type, Type::Error);
+        if decl.return_type.is_none() && !body_is_error {
             // If the body uses await, or the function is declared `async`,
             // wrap the inferred return type in Promise<T>
             let inferred_return = if uses_await || decl.async_fn {
@@ -545,11 +592,16 @@ impl Checker {
             } else {
                 body_type.clone()
             };
-            let fn_type = Type::Function {
+            // Generalise: any `Unbound` vars still in the signature become
+            // `Generic` so each call site gets its own fresh instantiation
+            // (let-polymorphism). This is what makes `fn id(x) { x }` behave
+            // as `(a) -> a` at multiple call sites with different argument
+            // types.
+            let fn_type = super::hydrator::generalise(&Type::Function {
                 params: param_types.clone(),
                 return_type: Arc::new(inferred_return),
                 required_params,
-            };
+            });
             // Update in the name_types map for hover display
             self.name_types
                 .insert(decl.name.clone(), fn_type.to_string());
@@ -644,6 +696,7 @@ impl Checker {
         self.env.pop_scope();
         self.ctx.current_return_type = prev_return_type;
         self.ctx.expected_type = prev_expected;
+        self.active_type_params = prev_type_params;
     }
 
     pub(crate) fn check_for_block(&mut self, block: &ForBlock, _span: Span) {

--- a/crates/floe-core/src/checker/printer.rs
+++ b/crates/floe-core/src/checker/printer.rs
@@ -7,6 +7,7 @@
 
 use std::fmt;
 
+use super::type_var::{self, TypeVar};
 use super::types::Type;
 
 /// Controls how types are formatted as strings.
@@ -27,7 +28,7 @@ pub struct TypeDisplay<'a> {
 }
 
 /// Pretty-print a type variable index as a letter (0 -> T, 1 -> U, 2 -> V, ...).
-fn type_var_letter(index: usize) -> &'static str {
+fn type_var_letter(index: u64) -> &'static str {
     match index {
         0 => "T",
         1 => "U",
@@ -158,9 +159,12 @@ pub(crate) fn fmt_type(
             Ok(())
         }
         Type::StringLiteral(s) => write!(f, "\"{s}\""),
-        Type::Var(id) => match style {
-            TypeDisplayStyle::Stdlib => f.write_str(type_var_letter(*id)),
-            TypeDisplayStyle::Default => write!(f, "?T{id}"),
+        Type::Var(var) => match type_var::snapshot(var) {
+            TypeVar::Link { type_ } => fmt_type(&type_, style, f),
+            TypeVar::Unbound { id } | TypeVar::Generic { id } => match style {
+                TypeDisplayStyle::Stdlib => f.write_str(type_var_letter(id)),
+                TypeDisplayStyle::Default => write!(f, "?T{id}"),
+            },
         },
         Type::Unknown => f.write_str("unknown"),
         Type::Error => f.write_str("<error>"),

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -7568,3 +7568,72 @@ const _s = id("x")
     assert!(!has_error(&diags_annotated, ErrorCode::TypeMismatch));
     assert!(!has_error(&diags_inferred, ErrorCode::TypeMismatch));
 }
+
+#[test]
+fn inferred_return_type_flows_to_caller() {
+    // After inferring `id : (a) -> a`, `id(42) + 1` must typecheck: the
+    // return type has to resolve to `number` at the call site, not stay
+    // an unbound var that gets accepted permissively.
+    let diags = check(
+        r#"
+fn id(x) { x }
+const _n = id(42) + 1
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::TypeMismatch),
+        "call-site return type failed to resolve, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn polymorphic_return_rejects_concrete_mismatch() {
+    // `id(42)` must resolve to `number` at the call site. Passing that
+    // to a `string`-typed param has to error — the old wildcard hack
+    // swallowed this because Var(_) compared as compatible with anything.
+    let diags = check(
+        r#"
+fn id(x) { x }
+fn takesString(s: string) -> string { s }
+const _x = takesString(id(42))
+"#,
+    );
+    assert!(
+        has_error(&diags, ErrorCode::TypeMismatch),
+        "polymorphic return type didn't propagate — the old wildcard path is still live"
+    );
+}
+
+#[test]
+fn occurs_check_fires_inside_tuple() {
+    // Occurs check must catch the cycle through any container, not only
+    // arrays.
+    let diags = check(
+        r#"
+fn bad(x) { (x, bad(x)) }
+"#,
+    );
+    assert!(
+        has_error(&diags, ErrorCode::TypeMismatch),
+        "occurs-check through tuple not caught"
+    );
+}
+
+#[test]
+fn stdlib_let_polymorphism_across_element_types() {
+    // `Array.map` in one program used with `number -> string` at one call
+    // site and `string -> number` at another — each call has to get its
+    // own fresh instantiation.
+    let diags = check(
+        r#"
+const _ns = [1, 2, 3] |> Array.map((n) => Number.toString(n))
+const _ls = ["a", "bb", "ccc"] |> Array.map((s) => String.length(s))
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::TypeMismatch),
+        "stdlib let-polymorphism failed, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -7487,3 +7487,84 @@ export fn ok() -> Route {
     );
     assert!(!has_error(&diags, ErrorCode::TypeUsedAsValue));
 }
+
+// ── Hindley-Milner inference ────────────────────────────────
+
+#[test]
+fn identity_without_annotations_infers_polymorphic_type() {
+    let diags = check(
+        r#"
+fn id(x) { x }
+const _n = id(42)
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::TypeMismatch),
+        "expected no errors, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn identity_let_polymorphism_allows_different_types() {
+    let diags = check(
+        r#"
+fn id(x) { x }
+const _n = id(42)
+const _s = id("hello")
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::TypeMismatch),
+        "expected let-polymorphism, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn recursive_infinite_type_is_rejected_by_occurs_check() {
+    let diags = check(
+        r#"
+fn bad(x) { [x, bad(x)] }
+"#,
+    );
+    assert!(
+        has_error(&diags, ErrorCode::TypeMismatch),
+        "expected occurs-check failure, got no errors"
+    );
+}
+
+#[test]
+fn deep_resolve_follows_links_through_arrays() {
+    use super::types::Type;
+    use std::sync::Arc;
+
+    let v = Type::unbound(0);
+    let arr = Type::Array(Arc::new(v.clone()));
+    super::unify::unify(&v, &Type::Number).unwrap();
+    match &arr.deep_resolved() {
+        Type::Array(inner) => assert_eq!(**inner, Type::Number),
+        other => panic!("expected Array<Number>, got {:?}", other),
+    }
+    assert_eq!(v.resolved(), Type::Number);
+}
+
+#[test]
+fn annotated_generic_fn_matches_inferred_generic_fn() {
+    let diags_annotated = check(
+        r#"
+fn id<T>(x: T) -> T { x }
+const _n = id(1)
+const _s = id("x")
+"#,
+    );
+    let diags_inferred = check(
+        r#"
+fn id(x) { x }
+const _n = id(1)
+const _s = id("x")
+"#,
+    );
+    assert!(!has_error(&diags_annotated, ErrorCode::TypeMismatch));
+    assert!(!has_error(&diags_inferred, ErrorCode::TypeMismatch));
+}

--- a/crates/floe-core/src/checker/type_compat.rs
+++ b/crates/floe-core/src/checker/type_compat.rs
@@ -154,21 +154,6 @@ impl Checker {
             return false;
         }
 
-        // Generic type parameters (single uppercase letter like T, U, E, S)
-        // are wildcards that match any type — used in stdlib function signatures
-        if let Type::Named(n) = expected
-            && n.len() == 1
-            && n.chars().next().is_some_and(|c| c.is_ascii_uppercase())
-        {
-            return true;
-        }
-        if let Type::Named(n) = actual
-            && n.len() == 1
-            && n.chars().next().is_some_and(|c| c.is_ascii_uppercase())
-        {
-            return true;
-        }
-
         // Foreign types: reject primitives, permissive otherwise.
         // Foreign-vs-Foreign is permissive because npm types often have subtype
         // relationships (e.g. SQLiteColumn extends SQLWrapper) that Floe can't verify.

--- a/crates/floe-core/src/checker/type_resolve.rs
+++ b/crates/floe-core/src/checker/type_resolve.rs
@@ -116,6 +116,16 @@ impl Checker {
         let root = name.split('.').next().unwrap_or(name);
         self.unused.used_names.insert(root.to_string());
 
+        // A user-declared generic type parameter (`T`, `U`, …) resolves to
+        // its hydrated `Generic` variable — each occurrence of the same name
+        // inside the signature gets the same Generic, so inference sees them
+        // as tied together.
+        if type_args.is_empty()
+            && let Some(g) = self.active_type_params.get(name)
+        {
+            return g.clone();
+        }
+
         match name {
             type_layout::TYPE_NUMBER => Type::Number,
             type_layout::TYPE_STRING => Type::String,

--- a/crates/floe-core/src/checker/type_var.rs
+++ b/crates/floe-core/src/checker/type_var.rs
@@ -1,0 +1,188 @@
+//! Type variables for Hindley-Milner inference.
+//!
+//! A `TypeVar` is held behind an `Arc<Mutex<_>>` so unification can
+//! destructively update it without needing a separate substitution map.
+//! Three variants model the life-cycle of a type variable:
+//!
+//! - `Unbound { id }` — fresh inference variable, not yet resolved.
+//! - `Link { type_ }` — resolved: the real type lives on the far side of the link.
+//! - `Generic { id }` — the marker form used for generalized type parameters in
+//!   polymorphic signatures. At each call site, `instantiate` replaces every
+//!   `Generic(id)` with a fresh `Unbound` so inference can specialize them.
+//!
+//! Identity across a `Type` tree is done with `Arc::ptr_eq` — two vars with the
+//! same `id` but different allocations are *different* variables.
+//!
+//! The `Mutex` (over `RefCell`) is what keeps the rest of the codebase's
+//! `Sync` statics (`UNKNOWN`, `EMPTY_TYPES`) happy — the checker is single-
+//! threaded so contention never happens in practice.
+
+use std::sync::{Arc, Mutex};
+
+use super::types::Type;
+
+#[derive(Debug, Clone)]
+pub enum TypeVar {
+    Unbound { id: u64 },
+    Link { type_: Arc<Type> },
+    Generic { id: u64 },
+}
+
+impl TypeVar {
+    pub fn id(&self) -> Option<u64> {
+        match self {
+            TypeVar::Unbound { id } | TypeVar::Generic { id } => Some(*id),
+            TypeVar::Link { .. } => None,
+        }
+    }
+}
+
+pub type TypeVarRef = Arc<Mutex<TypeVar>>;
+
+/// Construct a fresh `Unbound` type variable wrapped in an `Arc<Mutex<_>>`.
+pub fn unbound(id: u64) -> TypeVarRef {
+    Arc::new(Mutex::new(TypeVar::Unbound { id }))
+}
+
+/// Construct a fresh `Generic` type variable wrapped in an `Arc<Mutex<_>>`.
+pub fn generic(id: u64) -> TypeVarRef {
+    Arc::new(Mutex::new(TypeVar::Generic { id }))
+}
+
+/// Snapshot the inner `TypeVar` by cloning it out of the mutex. Prefer this
+/// over repeatedly calling `lock()` — poisoned mutexes are recovered silently
+/// since the checker never panics while holding a var lock.
+pub fn snapshot(var: &TypeVarRef) -> TypeVar {
+    match var.lock() {
+        Ok(g) => g.clone(),
+        Err(poison) => poison.into_inner().clone(),
+    }
+}
+
+/// Set the inner `TypeVar` — used by unification when linking an unbound
+/// variable to a concrete type.
+pub fn set(var: &TypeVarRef, value: TypeVar) {
+    match var.lock() {
+        Ok(mut g) => *g = value,
+        Err(poison) => *poison.into_inner() = value,
+    }
+}
+
+/// Follow `Link` chains to the underlying type. Returns the original type when
+/// it is not a `Type::Var`, or a `Type::Var` holding an `Unbound` / `Generic`
+/// variable when the chain terminates at an unbound variable.
+pub fn resolve(ty: &Type) -> Type {
+    match ty {
+        Type::Var(var) => match snapshot(var) {
+            TypeVar::Link { type_ } => resolve(&type_),
+            _ => ty.clone(),
+        },
+        _ => ty.clone(),
+    }
+}
+
+/// Rebuild a `Type` tree by recursing into every compound constructor,
+/// applying `f` at each node. `f` returns `Some(replacement)` to short-
+/// circuit the recursion at that node, or `None` to let `map_children`
+/// recurse into the children.
+///
+/// Every structural walker in the checker (instantiate, generalise,
+/// deep-resolve, hydrate, occurs-in) collapses to "at each Type node,
+/// decide whether to replace or descend". Centralising the recursion here
+/// means new `Type` variants only need one update instead of five.
+pub fn map_children<F>(ty: &Type, f: &mut F) -> Type
+where
+    F: FnMut(&Type) -> Option<Type>,
+{
+    use std::sync::Arc;
+    if let Some(replacement) = f(ty) {
+        return replacement;
+    }
+    match ty {
+        Type::Promise(inner) => Type::Promise(Arc::new(map_children(inner, f))),
+        Type::Array(inner) => Type::Array(Arc::new(map_children(inner, f))),
+        Type::Settable(inner) => Type::Settable(Arc::new(map_children(inner, f))),
+        Type::Set { element } => Type::Set {
+            element: Arc::new(map_children(element, f)),
+        },
+        Type::Map { key, value } => Type::Map {
+            key: Arc::new(map_children(key, f)),
+            value: Arc::new(map_children(value, f)),
+        },
+        Type::RecordMap { key, value } => Type::RecordMap {
+            key: Arc::new(map_children(key, f)),
+            value: Arc::new(map_children(value, f)),
+        },
+        Type::Tuple(items) => Type::Tuple(items.iter().map(|t| map_children(t, f)).collect()),
+        Type::Record(fields) => Type::Record(
+            fields
+                .iter()
+                .map(|(n, t)| (n.clone(), map_children(t, f)))
+                .collect(),
+        ),
+        Type::Union { name, variants } => Type::Union {
+            name: name.clone(),
+            variants: variants
+                .iter()
+                .map(|(n, fs)| (n.clone(), fs.iter().map(|t| map_children(t, f)).collect()))
+                .collect(),
+        },
+        Type::TsUnion(ms) => Type::TsUnion(ms.iter().map(|t| map_children(t, f)).collect()),
+        Type::Function {
+            params,
+            required_params,
+            return_type,
+        } => Type::Function {
+            params: params.iter().map(|t| map_children(t, f)).collect(),
+            required_params: *required_params,
+            return_type: Arc::new(map_children(return_type, f)),
+        },
+        Type::Opaque { name, base } => Type::Opaque {
+            name: name.clone(),
+            base: Arc::new(map_children(base, f)),
+        },
+        _ => ty.clone(),
+    }
+}
+
+/// Recursively resolve all `Type::Var` `Link` chains in a type tree. Unlike
+/// `resolve`, which only follows the outermost link, `deep_resolve` rebuilds
+/// the entire tree so nested unbound-then-linked vars (like `Array<Unbound>`
+/// where `Unbound → CartItem`) surface as `Array<CartItem>` to downstream
+/// consumers that walk the tree structurally (pattern matching, codegen,
+/// hover).
+pub fn deep_resolve(ty: &Type) -> Type {
+    map_children(ty, &mut |t| match t {
+        Type::Var(var) => match snapshot(var) {
+            TypeVar::Link { type_ } => Some(deep_resolve(&type_)),
+            _ => Some(t.clone()),
+        },
+        _ => None,
+    })
+}
+
+/// Return `true` if `ty` resolves to an `Unbound` type variable.
+pub fn is_unbound(ty: &Type) -> bool {
+    match ty {
+        Type::Var(var) => matches!(snapshot(var), TypeVar::Unbound { .. }),
+        _ => false,
+    }
+}
+
+/// Return `true` if `ty` resolves to a `Generic` type variable.
+pub fn is_generic(ty: &Type) -> bool {
+    match ty {
+        Type::Var(var) => matches!(snapshot(var), TypeVar::Generic { .. }),
+        _ => false,
+    }
+}
+
+/// Return the variable's id if `ty` is a `Type::Var` holding an `Unbound` or
+/// `Generic` variable. Returns `None` for `Link` chains or non-vars.
+pub fn var_id(ty: &Type) -> Option<u64> {
+    if let Type::Var(var) = ty {
+        snapshot(var).id()
+    } else {
+        None
+    }
+}

--- a/crates/floe-core/src/checker/types.rs
+++ b/crates/floe-core/src/checker/types.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 
 use super::printer::{TypeDisplay, TypeDisplayStyle};
+use super::type_var::{self, TypeVarRef};
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -14,7 +15,7 @@ use super::printer::{TypeDisplay, TypeDisplayStyle};
 /// Sub-types are stored behind `Arc<Type>` for cheap cloning — type trees
 /// are cloned frequently during inference. Arc refcount bumps replace the
 /// deep copies that `Box<Type>` required.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub enum Type {
     /// Primitive types: number, string, boolean
     Number,
@@ -78,8 +79,10 @@ pub enum Type {
     TsUnion(Vec<Type>),
     /// String literal type: `"GET"`, `"POST"`, etc.
     StringLiteral(String),
-    /// Type variable (for inference)
-    Var(usize),
+    /// Type variable for Hindley-Milner inference. Unbound vars get Linked to
+    /// concrete types by `unify`; Generic vars are polymorphic markers that
+    /// `instantiate` replaces with fresh Unbound vars at each call site.
+    Var(TypeVarRef),
     /// The unknown/any escape hatch — used for genuinely unknown external types
     /// (e.g. npm imports without type probes). Compatible with everything as expected,
     /// but not as actual (same as TypeScript's `unknown`).
@@ -95,6 +98,45 @@ pub enum Type {
 }
 
 impl Type {
+    /// Construct a fresh unbound type variable with the given id.
+    pub fn unbound(id: u64) -> Type {
+        Type::Var(type_var::unbound(id))
+    }
+
+    /// Construct a polymorphic (generalized) type variable with the given id.
+    pub fn generic(id: u64) -> Type {
+        Type::Var(type_var::generic(id))
+    }
+
+    /// Follow any `Link` chain on this type, returning the underlying type.
+    /// Returns the original type when no links exist.
+    pub fn resolved(&self) -> Type {
+        type_var::resolve(self)
+    }
+
+    /// Recursively resolve all `Type::Var` `Link` chains in the tree — use
+    /// when passing a type across a boundary (pattern binding, error message,
+    /// stored type map) so downstream consumers don't walk past unresolved
+    /// links.
+    pub fn deep_resolved(&self) -> Type {
+        type_var::deep_resolve(self)
+    }
+
+    /// Is this an unbound type variable after resolving links?
+    pub fn is_unbound(&self) -> bool {
+        type_var::is_unbound(&self.resolved())
+    }
+
+    /// Is this a generic (polymorphic) type variable after resolving links?
+    pub fn is_generic_var(&self) -> bool {
+        type_var::is_generic(&self.resolved())
+    }
+
+    /// The id of the underlying unbound or generic variable, if this is one.
+    pub fn var_id(&self) -> Option<u64> {
+        type_var::var_id(&self.resolved())
+    }
+
     /// Construct an Option<T> as a Union type.
     pub fn option_of(inner: Type) -> Type {
         Type::Union {
@@ -197,20 +239,21 @@ impl Type {
     /// variable). Guards on this pattern prevent emitting cascading diagnostics when
     /// there is not yet enough type information to report a meaningful error.
     pub(crate) fn is_undetermined(&self) -> bool {
-        matches!(self, Type::Unknown | Type::Error | Type::Var(_))
+        let r = self.resolved();
+        matches!(r, Type::Unknown | Type::Error | Type::Var(_))
     }
 
     pub(crate) fn is_numeric(&self) -> bool {
-        matches!(self, Type::Number)
+        matches!(self.resolved(), Type::Number)
     }
 
     pub(crate) fn is_boolean(&self) -> bool {
-        matches!(self, Type::Bool)
+        matches!(self.resolved(), Type::Bool)
     }
 
     pub(crate) fn is_primitive(&self) -> bool {
         matches!(
-            self,
+            self.resolved(),
             Type::Number
                 | Type::String
                 | Type::Bool
@@ -255,6 +298,66 @@ impl Type {
         TypeDisplay {
             ty: self,
             style: TypeDisplayStyle::Stdlib,
+        }
+    }
+}
+
+impl PartialEq for Type {
+    fn eq(&self, other: &Self) -> bool {
+        // Resolve both sides through any `Link` chains before comparing.
+        let a = self.resolved();
+        let b = other.resolved();
+        match (&a, &b) {
+            (Type::Number, Type::Number)
+            | (Type::String, Type::String)
+            | (Type::Bool, Type::Bool)
+            | (Type::Undefined, Type::Undefined)
+            | (Type::Unknown, Type::Unknown)
+            | (Type::Error, Type::Error)
+            | (Type::Unit, Type::Unit)
+            | (Type::Never, Type::Never) => true,
+            (Type::Named(a), Type::Named(b)) => a == b,
+            (Type::Foreign(a), Type::Foreign(b)) => a == b,
+            (Type::Promise(a), Type::Promise(b)) => **a == **b,
+            (Type::Opaque { name: na, base: ba }, Type::Opaque { name: nb, base: bb }) => {
+                na == nb && **ba == **bb
+            }
+            (Type::Settable(a), Type::Settable(b)) => **a == **b,
+            (
+                Type::Function {
+                    params: pa,
+                    required_params: ra,
+                    return_type: rta,
+                },
+                Type::Function {
+                    params: pb,
+                    required_params: rb,
+                    return_type: rtb,
+                },
+            ) => pa == pb && ra == rb && **rta == **rtb,
+            (Type::Array(a), Type::Array(b)) => **a == **b,
+            (Type::Map { key: ka, value: va }, Type::Map { key: kb, value: vb })
+            | (Type::RecordMap { key: ka, value: va }, Type::RecordMap { key: kb, value: vb }) => {
+                **ka == **kb && **va == **vb
+            }
+            (Type::Set { element: a }, Type::Set { element: b }) => **a == **b,
+            (Type::Tuple(a), Type::Tuple(b)) => a == b,
+            (Type::Record(a), Type::Record(b)) => a == b,
+            (
+                Type::Union {
+                    name: na,
+                    variants: va,
+                },
+                Type::Union {
+                    name: nb,
+                    variants: vb,
+                },
+            ) => na == nb && va == vb,
+            (Type::TsUnion(a), Type::TsUnion(b)) => a == b,
+            (Type::StringLiteral(a), Type::StringLiteral(b)) => a == b,
+            // Type variables compare by identity: same Arc means same variable.
+            (Type::Var(a), Type::Var(b)) => Arc::ptr_eq(a, b),
+            _ => false,
         }
     }
 }

--- a/crates/floe-core/src/checker/unify.rs
+++ b/crates/floe-core/src/checker/unify.rs
@@ -1,0 +1,353 @@
+//! Hindley-Milner unification.
+//!
+//! `unify(a, b)` makes two types equal by:
+//! - Following `Link` chains on any `Type::Var` to their resolved type.
+//! - When one side is an `Unbound` variable, destructively updating it to
+//!   `Link { type_: other }` so every previous reference to that variable
+//!   now sees the resolved type.
+//! - Recursing through matching type constructors (`Array(a)` vs `Array(b)`,
+//!   tuples, functions, records, …).
+//!
+//! The occurs check prevents constructing an infinite type. If `a` appears
+//! inside `b`, `unify(a, b)` returns `UnifyError::InfiniteType` so a recursive
+//! type like `fn bad(x) { [x, bad(x)] }` is rejected cleanly instead of
+//! silently building an infinite tree.
+
+use std::sync::Arc;
+
+use super::type_var::{self, TypeVar};
+use super::types::Type;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum UnifyError {
+    /// Occurs check failure: one variable appears inside the other side.
+    InfiniteType,
+    /// Two concrete types don't match.
+    Mismatch { expected: Type, actual: Type },
+    /// Function arities differ.
+    FunctionArity { expected: usize, actual: usize },
+    /// Tuple arities differ.
+    TupleArity { expected: usize, actual: usize },
+}
+
+/// Unify two types, destructively updating any `Unbound` variables on either
+/// side so they point to the other type. Returns `Ok(())` when the two types
+/// are made equal, or a `UnifyError` when they cannot be reconciled.
+pub fn unify(a: &Type, b: &Type) -> Result<(), UnifyError> {
+    // Fast-path: follow `Link` chains so the outer match never sees them.
+    let a = a.resolved();
+    let b = b.resolved();
+
+    // Errors suppress cascading diagnostics — unify with anything.
+    if matches!(a, Type::Error) || matches!(b, Type::Error) {
+        return Ok(());
+    }
+
+    // Unknown widens on either side (TypeScript-ish assignability).
+    if matches!(a, Type::Unknown) || matches!(b, Type::Unknown) {
+        return Ok(());
+    }
+
+    // Never is the bottom type and unifies with anything.
+    if matches!(a, Type::Never) || matches!(b, Type::Never) {
+        return Ok(());
+    }
+
+    match (&a, &b) {
+        // Two vars: same allocation → already equal.
+        (Type::Var(va), Type::Var(vb)) if Arc::ptr_eq(va, vb) => Ok(()),
+
+        // One side is an unbound var — link it to the other side after occurs check.
+        (Type::Var(var), other) | (other, Type::Var(var))
+            if matches!(type_var::snapshot(var), TypeVar::Unbound { .. }) =>
+        {
+            if occurs_in(var, other) {
+                return Err(UnifyError::InfiniteType);
+            }
+            type_var::set(
+                var,
+                TypeVar::Link {
+                    type_: Arc::new(other.clone()),
+                },
+            );
+            Ok(())
+        }
+
+        // Two Generic vars with the same id → equal. Different ids → mismatch.
+        (Type::Var(va), Type::Var(vb)) => {
+            let ida = type_var::snapshot(va).id();
+            let idb = type_var::snapshot(vb).id();
+            if ida.is_some() && ida == idb {
+                Ok(())
+            } else {
+                Err(UnifyError::Mismatch {
+                    expected: a.clone(),
+                    actual: b.clone(),
+                })
+            }
+        }
+
+        // Generic var on one side, concrete on the other: generics shouldn't reach
+        // here after `instantiate`. Treat as a mismatch (the caller forgot to
+        // instantiate) rather than silently binding.
+        (Type::Var(_), _) | (_, Type::Var(_)) => Err(UnifyError::Mismatch {
+            expected: a.clone(),
+            actual: b.clone(),
+        }),
+
+        // Concrete types: match by constructor.
+        (Type::Number, Type::Number)
+        | (Type::Bool, Type::Bool)
+        | (Type::String, Type::String)
+        | (Type::Unit, Type::Unit)
+        | (Type::Undefined, Type::Undefined) => Ok(()),
+
+        (Type::StringLiteral(x), Type::StringLiteral(y)) if x == y => Ok(()),
+        // A string literal unifies with `String` (widen): useful when a literal
+        // flows into a param typed `String`.
+        (Type::StringLiteral(_), Type::String) | (Type::String, Type::StringLiteral(_)) => Ok(()),
+
+        (Type::Named(x), Type::Named(y)) if x == y => Ok(()),
+        (Type::Foreign(_), _) | (_, Type::Foreign(_)) => Ok(()),
+
+        (Type::Promise(x), Type::Promise(y)) => unify(x, y),
+        (Type::Array(x), Type::Array(y)) => unify(x, y),
+        (Type::Settable(x), Type::Settable(y)) => unify(x, y),
+        (Type::Set { element: x }, Type::Set { element: y }) => unify(x, y),
+
+        (Type::Map { key: k1, value: v1 }, Type::Map { key: k2, value: v2 })
+        | (Type::RecordMap { key: k1, value: v1 }, Type::RecordMap { key: k2, value: v2 })
+        | (Type::Map { key: k1, value: v1 }, Type::RecordMap { key: k2, value: v2 })
+        | (Type::RecordMap { key: k1, value: v1 }, Type::Map { key: k2, value: v2 }) => {
+            unify(k1, k2)?;
+            unify(v1, v2)
+        }
+
+        (Type::Tuple(xs), Type::Tuple(ys)) => {
+            if xs.len() != ys.len() {
+                return Err(UnifyError::TupleArity {
+                    expected: xs.len(),
+                    actual: ys.len(),
+                });
+            }
+            for (x, y) in xs.iter().zip(ys.iter()) {
+                unify(x, y)?;
+            }
+            Ok(())
+        }
+
+        (
+            Type::Function {
+                params: p1,
+                return_type: r1,
+                ..
+            },
+            Type::Function {
+                params: p2,
+                return_type: r2,
+                ..
+            },
+        ) => {
+            if p1.len() != p2.len() {
+                return Err(UnifyError::FunctionArity {
+                    expected: p1.len(),
+                    actual: p2.len(),
+                });
+            }
+            for (x, y) in p1.iter().zip(p2.iter()) {
+                unify(x, y)?;
+            }
+            unify(r1, r2)
+        }
+
+        (Type::Record(fa), Type::Record(fb)) => {
+            if fa.len() != fb.len() {
+                return Err(UnifyError::Mismatch {
+                    expected: a.clone(),
+                    actual: b.clone(),
+                });
+            }
+            for ((na, ta), (nb, tb)) in fa.iter().zip(fb.iter()) {
+                if na != nb {
+                    return Err(UnifyError::Mismatch {
+                        expected: a.clone(),
+                        actual: b.clone(),
+                    });
+                }
+                unify(ta, tb)?;
+            }
+            Ok(())
+        }
+
+        (
+            Type::Union {
+                name: na,
+                variants: vs_a,
+            },
+            Type::Union {
+                name: nb,
+                variants: vs_b,
+            },
+        ) if na == nb && vs_a.len() == vs_b.len() => {
+            for ((n1, fs1), (n2, fs2)) in vs_a.iter().zip(vs_b.iter()) {
+                if n1 != n2 || fs1.len() != fs2.len() {
+                    return Err(UnifyError::Mismatch {
+                        expected: a.clone(),
+                        actual: b.clone(),
+                    });
+                }
+                for (f1, f2) in fs1.iter().zip(fs2.iter()) {
+                    unify(f1, f2)?;
+                }
+            }
+            Ok(())
+        }
+
+        (Type::TsUnion(members), concrete) | (concrete, Type::TsUnion(members)) => {
+            // TsUnion accepts if any member unifies. Note: this doesn't perform a
+            // backtracking search through all members — it takes the first that
+            // unifies, which is enough for the cases Floe uses TsUnion for
+            // (string literal unions, `Date | number | string`).
+            for m in members {
+                if unify(m, concrete).is_ok() {
+                    return Ok(());
+                }
+            }
+            Err(UnifyError::Mismatch {
+                expected: a.clone(),
+                actual: b.clone(),
+            })
+        }
+
+        (Type::Opaque { name: na, .. }, Type::Opaque { name: nb, .. }) if na == nb => Ok(()),
+
+        _ => Err(UnifyError::Mismatch {
+            expected: a.clone(),
+            actual: b.clone(),
+        }),
+    }
+}
+
+/// Return `true` if the unbound variable `var` appears anywhere inside `ty`.
+/// Used by unification to reject recursive bindings like `X = List(X)`.
+fn occurs_in(var: &super::type_var::TypeVarRef, ty: &Type) -> bool {
+    let resolved = ty.resolved();
+    match &resolved {
+        Type::Var(other) => {
+            if Arc::ptr_eq(var, other) {
+                return true;
+            }
+            // Only interesting vars are Unbound — Link was resolved above,
+            // Generic can't contain anything.
+            false
+        }
+        Type::Promise(inner)
+        | Type::Array(inner)
+        | Type::Settable(inner)
+        | Type::Set { element: inner } => occurs_in(var, inner),
+        Type::Map { key, value } | Type::RecordMap { key, value } => {
+            occurs_in(var, key) || occurs_in(var, value)
+        }
+        Type::Tuple(items) => items.iter().any(|t| occurs_in(var, t)),
+        Type::Record(fields) => fields.iter().any(|(_, t)| occurs_in(var, t)),
+        Type::Union { variants, .. } => variants
+            .iter()
+            .any(|(_, fs)| fs.iter().any(|t| occurs_in(var, t))),
+        Type::TsUnion(ms) => ms.iter().any(|t| occurs_in(var, t)),
+        Type::Function {
+            params,
+            return_type,
+            ..
+        } => params.iter().any(|t| occurs_in(var, t)) || occurs_in(var, return_type),
+        Type::Opaque { base, .. } => occurs_in(var, base),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unify_same_primitive() {
+        assert_eq!(unify(&Type::Number, &Type::Number), Ok(()));
+    }
+
+    #[test]
+    fn unify_different_primitives() {
+        assert!(unify(&Type::Number, &Type::String).is_err());
+    }
+
+    #[test]
+    fn unify_unbound_to_concrete() {
+        let var = Type::unbound(0);
+        assert_eq!(unify(&var, &Type::Number), Ok(()));
+        // After unification, the var resolves to Number.
+        assert_eq!(var.resolved(), Type::Number);
+    }
+
+    #[test]
+    fn unify_concrete_to_unbound() {
+        let var = Type::unbound(0);
+        assert_eq!(unify(&Type::Number, &var), Ok(()));
+        assert_eq!(var.resolved(), Type::Number);
+    }
+
+    #[test]
+    fn unify_two_unbound_links_one_to_the_other() {
+        let a = Type::unbound(0);
+        let b = Type::unbound(1);
+        assert_eq!(unify(&a, &b), Ok(()));
+        // Now unifying either with Number resolves both.
+        assert_eq!(unify(&a, &Type::Number), Ok(()));
+        assert_eq!(a.resolved(), Type::Number);
+        assert_eq!(b.resolved(), Type::Number);
+    }
+
+    #[test]
+    fn unify_occurs_check_catches_infinite_type() {
+        let v = Type::unbound(0);
+        let list_of_v = Type::Array(Arc::new(v.clone()));
+        assert_eq!(unify(&v, &list_of_v), Err(UnifyError::InfiniteType));
+    }
+
+    #[test]
+    fn unify_recursive_through_tuple_is_rejected() {
+        let v = Type::unbound(0);
+        let tup = Type::Tuple(vec![Type::Number, v.clone()]);
+        assert_eq!(unify(&v, &tup), Err(UnifyError::InfiniteType));
+    }
+
+    #[test]
+    fn unify_arrays_recurses() {
+        let v = Type::unbound(0);
+        let a = Type::Array(Arc::new(v.clone()));
+        let b = Type::Array(Arc::new(Type::Number));
+        assert_eq!(unify(&a, &b), Ok(()));
+        assert_eq!(v.resolved(), Type::Number);
+    }
+
+    #[test]
+    fn unify_tuple_length_mismatch_is_error() {
+        let a = Type::Tuple(vec![Type::Number]);
+        let b = Type::Tuple(vec![Type::Number, Type::String]);
+        assert!(matches!(unify(&a, &b), Err(UnifyError::TupleArity { .. })));
+    }
+
+    #[test]
+    fn unify_functions_check_arity_and_recurse() {
+        let r = Type::unbound(0);
+        let f = Type::Function {
+            params: vec![Type::Number],
+            required_params: 1,
+            return_type: Arc::new(r.clone()),
+        };
+        let g = Type::Function {
+            params: vec![Type::Number],
+            required_params: 1,
+            return_type: Arc::new(Type::Bool),
+        };
+        assert_eq!(unify(&f, &g), Ok(()));
+        assert_eq!(r.resolved(), Type::Bool);
+    }
+}

--- a/crates/floe-core/src/stdlib/mod.rs
+++ b/crates/floe-core/src/stdlib/mod.rs
@@ -96,9 +96,10 @@ impl StdlibRegistry {
     }
 }
 
-/// Type variable helpers for generic signatures.
-fn tv(n: usize) -> Type {
-    Type::Var(n)
+/// Type variable helpers for generic signatures. Produces a `Generic`
+/// variable so each call site specializes via `instantiate`.
+fn tv(n: u64) -> Type {
+    Type::generic(n)
 }
 fn array_of(t: Type) -> Type {
     Type::Array(Arc::new(t))


### PR DESCRIPTION
closes #1118

## Summary

Replaces string-substring "generics" with real Hindley-Milner type inference. Stdlib and user functions now share one inference pipeline: `Generic` vars in polymorphic signatures, instantiated to fresh `Unbound` vars at each call site, destructively updated via `unify` with an occurs check.

- `TypeVar` enum with `Unbound{id}`, `Link{type_}`, `Generic{id}` variants behind `Arc<Mutex<TypeVar>>` (Mutex over RefCell to keep the checker's `Sync` statics happy — single-threaded semantics are identical).
- `unify(a, b)` with occurs check; destructive link updates so every holder of an `Arc` sees the resolved type.
- `Hydrator` maps user-written generic names (`T`, `a`) to `Generic` vars shared across the signature.
- `instantiate` replaces `Generic` with fresh `Unbound` per call site (let-polymorphism); `generalise` freezes leftover `Unbound` as `Generic` after body check.
- Deletes the single-uppercase-letter `Named("T")` wildcard hack from `type_compat.rs`; `.d.ts` single-letter generics hydrate at import time, so the hack is no longer load-bearing.
- Trait-bounded generics (`<R: Repo>`) keep their `Named` resolution so the existing static-dispatch codegen path continues to fire.
- All four tree walkers (`instantiate`, `generalise`, `deep_resolve`, `hydrate_single_letter_generics`) share a single `type_var::map_children` helper so new `Type` variants only need one update.

## Test plan

- [x] `fn id(x) { x }` checks without annotations
- [x] `id(42)` and `id("hello")` both succeed (let-polymorphism)
- [x] `fn bad(x) { [x, bad(x)] }` errors with occurs check ("infinite type")
- [x] `fn id<T>(x: T) -> T { x }` behaves identically to the inferred version
- [x] All 1336 pre-existing checker tests unchanged
- [x] 5 new HM tests pass
- [x] Unit tests in `unify.rs` and `hydrator.rs`
- [x] `examples/store/`, `examples/todo-app/` check cleanly
- [x] `cargo clippy -p floe-core --lib -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)