### PR TITLE
refactor: [#1123] harden .d.ts parser to cover the full audit

### DIFF
--- a/crates/floe-core/src/interop/dts.rs
+++ b/crates/floe-core/src/interop/dts.rs
@@ -4,7 +4,8 @@ use std::collections::HashSet;
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
-    Declaration, ExportNamedDeclaration, FormalParameters, PropertyKey, Statement,
+    Class, ClassElement, Declaration, ExportDefaultDeclarationKind, ExportNamedDeclaration,
+    FormalParameters, MethodDefinitionKind, PropertyKey, Statement, TSEnumDeclaration,
     TSModuleDeclarationBody, TSModuleDeclarationName, TSPropertySignature, TSSignature,
     TSTupleElement, TSType as OxcTSType, TSTypeName, VariableDeclarator,
 };
@@ -86,6 +87,8 @@ fn resolve_dts_source(parent_dir: &Path, source: &str) -> Option<PathBuf> {
             (".mjs", ".d.mts"),
             (".cjs", ".d.cts"),
             (".jsx", ".d.ts"),
+            (".tsx", ".d.ts"),
+            (".ts", ".d.ts"),
         ] {
             if let Some(stripped) = base_str.strip_suffix(ext) {
                 let dts_path = PathBuf::from(format!("{stripped}{dts_ext}"));
@@ -96,17 +99,22 @@ fn resolve_dts_source(parent_dir: &Path, source: &str) -> Option<PathBuf> {
         }
     }
 
-    // Try adding .d.ts directly
-    let with_dts = parent_dir.join(format!("{source}.d.ts"));
-    if with_dts.exists() {
-        return Some(with_dts);
+    // Try adding .d.ts / .d.mts / .d.cts directly (barrel exports often
+    // omit extensions entirely).
+    for dts_ext in &[".d.ts", ".d.mts", ".d.cts"] {
+        let with_dts = parent_dir.join(format!("{source}{dts_ext}"));
+        if with_dts.exists() {
+            return Some(with_dts);
+        }
     }
 
-    // Try as directory with index.d.ts
+    // Try as directory with index.d.ts / index.d.mts / index.d.cts
     if base.is_dir() {
-        let index = base.join("index.d.ts");
-        if index.exists() {
-            return Some(index);
+        for idx in &["index.d.ts", "index.d.mts", "index.d.cts"] {
+            let index = base.join(idx);
+            if index.exists() {
+                return Some(index);
+            }
         }
     }
 
@@ -132,47 +140,81 @@ fn parse_dts_content(content: &str) -> Result<ParseResult, String> {
     let mut seen_names: HashSet<String> = HashSet::new();
     let mut export_assignment_name: Option<String> = None;
     let mut namespace_exports: HashMap<String, Vec<DtsExport>> = HashMap::new();
-    let mut reexport_sources = Vec::new();
-    // Collect all function declarations for resolving `typeof X` references
-    let mut fn_declarations: HashMap<String, TsType> = HashMap::new();
+    // `/// <reference path="..." />` directives are consumed by the parser
+    // without surfacing — we rescan the raw source to pull them back out.
+    let mut reexport_sources = extract_triple_slash_references(content);
+    // All top-level declarations by name — used to resolve `export default X`,
+    // `export { X as Y }`, and `typeof X` against the declared types.
+    let mut local_types: HashMap<String, TsType> = HashMap::new();
+    let mut aliased_reexports: Vec<(String, String)> = Vec::new();
+    let mut default_export_target: Option<String> = None;
 
-    // First pass: collect all info
     for stmt in &ret.program.body {
-        // `export = X;` - remember the namespace name for later
         if let Statement::TSExportAssignment(assign) = stmt
             && let oxc_ast::ast::Expression::Identifier(ident) = &assign.expression
         {
             export_assignment_name = Some(ident.name.to_string());
         }
 
-        // `export function/const/type/interface ...`
         if let Statement::ExportNamedDeclaration(export_decl) = stmt {
             extract_from_export_named(export_decl, &mut exports, &mut seen_names);
 
-            // Also record function declarations for typeof resolution
-            if let Some(ref decl) = export_decl.declaration
-                && let Declaration::FunctionDeclaration(func) = decl
-                && let Some(ref id) = func.id
-            {
-                let ts_type = convert_function(&func.params, &func.return_type);
-                fn_declarations.insert(id.name.to_string(), ts_type);
+            if let Some(ref decl) = export_decl.declaration {
+                record_local_type(decl, &mut local_types);
+            }
+
+            // `export { X as Y }` without a declaration — collected here,
+            // resolved against local_types once the full file is scanned.
+            if export_decl.declaration.is_none() {
+                for spec in &export_decl.specifiers {
+                    let exported_name = spec.exported.name().to_string();
+                    let local_name = spec.local.name().to_string();
+                    if !exported_name.is_empty()
+                        && !local_name.is_empty()
+                        && exported_name != local_name
+                    {
+                        aliased_reexports.push((exported_name, local_name));
+                    }
+                }
             }
         }
 
-        // Non-exported function declarations (for typeof resolution)
-        if let Statement::FunctionDeclaration(func) = stmt
-            && let Some(ref id) = func.id
-        {
-            let ts_type = convert_function(&func.params, &func.return_type);
-            fn_declarations.insert(id.name.to_string(), ts_type);
+        if let Statement::ExportDefaultDeclaration(default_decl) = stmt {
+            match &default_decl.declaration {
+                ExportDefaultDeclarationKind::Identifier(ident) => {
+                    default_export_target = Some(ident.name.to_string());
+                }
+                ExportDefaultDeclarationKind::FunctionDeclaration(func) => {
+                    let ts_type = convert_function(&func.params, &func.return_type);
+                    if seen_names.insert("default".to_string()) {
+                        exports.push(DtsExport {
+                            name: "default".to_string(),
+                            ts_type,
+                        });
+                    }
+                }
+                ExportDefaultDeclarationKind::ClassDeclaration(class) => {
+                    if let Some(mut export) = convert_class_declaration(class) {
+                        export.name = "default".to_string();
+                        if seen_names.insert(export.name.clone()) {
+                            exports.push(export);
+                        }
+                    }
+                }
+                _ => {}
+            }
         }
 
-        // `export * from "./X.js"`
+        // Non-exported top-level declarations are recorded for `typeof X`,
+        // `export default X`, and `export { X as Y }` resolution.
+        for (name, ts_type) in statement_entries(stmt) {
+            local_types.entry(name).or_insert(ts_type);
+        }
+
         if let Statement::ExportAllDeclaration(export_all) = stmt {
             reexport_sources.push(export_all.source.value.to_string());
         }
 
-        // `declare namespace X { ... }` (top-level)
         if let Statement::TSModuleDeclaration(ns_decl) = stmt {
             let ns_name = match &ns_decl.id {
                 TSModuleDeclarationName::Identifier(ident) => ident.name.to_string(),
@@ -183,6 +225,31 @@ fn parse_dts_content(content: &str) -> Result<ParseResult, String> {
                 .entry(ns_name)
                 .or_default()
                 .extend(ns_exports);
+        }
+    }
+
+    // Resolve `export default X` against locally-declared types.
+    if let Some(ref target) = default_export_target
+        && let Some(ts_type) = local_types.get(target)
+        && seen_names.insert("default".to_string())
+    {
+        exports.push(DtsExport {
+            name: "default".to_string(),
+            ts_type: ts_type.clone(),
+        });
+    }
+
+    // Resolve aliased re-exports (`export { X as Y }`) for every declaration kind.
+    for (exported_name, local_name) in &aliased_reexports {
+        if seen_names.contains(exported_name) {
+            continue;
+        }
+        if let Some(ts_type) = local_types.get(local_name) {
+            seen_names.insert(exported_name.clone());
+            exports.push(DtsExport {
+                name: exported_name.clone(),
+                ts_type: ts_type.clone(),
+            });
         }
     }
 
@@ -198,11 +265,13 @@ fn parse_dts_content(content: &str) -> Result<ParseResult, String> {
         }
     }
 
-    // Second pass: resolve `typeof X` references against local declarations
+    // Second pass: resolve `typeof X` references against local declarations.
+    // Uses the full `local_types` map so `typeof someConst` works for any
+    // declaration kind, not just functions.
     for export in &mut exports {
         if let TsType::Named(ref s) = export.ts_type
             && let Some(ref_name) = s.strip_prefix("typeof ")
-            && let Some(resolved_type) = fn_declarations.get(ref_name)
+            && let Some(resolved_type) = local_types.get(ref_name)
         {
             export.ts_type = resolved_type.clone();
         }
@@ -306,7 +375,7 @@ pub(super) fn parse_all_types_from_str(content: &str) -> Result<Vec<DtsExport>, 
         if let Statement::TSInterfaceDeclaration(iface) = stmt {
             let name = iface.id.name.to_string();
             if seen_names.insert(name.clone()) {
-                let ts_type = convert_interface_body(&iface.body.body);
+                let ts_type = convert_interface_body_named(&iface.body.body, Some(&name));
                 types.push(DtsExport { name, ts_type });
             }
         }
@@ -325,7 +394,7 @@ pub(super) fn parse_all_types_from_str(content: &str) -> Result<Vec<DtsExport>, 
             if let Declaration::TSInterfaceDeclaration(iface) = decl {
                 let name = iface.id.name.to_string();
                 if seen_names.insert(name.clone()) {
-                    let ts_type = convert_interface_body(&iface.body.body);
+                    let ts_type = convert_interface_body_named(&iface.body.body, Some(&name));
                     types.push(DtsExport { name, ts_type });
                 }
             }
@@ -342,7 +411,7 @@ pub(super) fn parse_all_types_from_str(content: &str) -> Result<Vec<DtsExport>, 
     Ok(types)
 }
 
-/// Extract exports from an `export` declaration (export function/const/type/interface).
+/// Extract exports from an `export` declaration (export function/const/type/interface/class/enum).
 fn extract_from_export_named(
     export_decl: &ExportNamedDeclaration<'_>,
     exports: &mut Vec<DtsExport>,
@@ -351,46 +420,269 @@ fn extract_from_export_named(
     let Some(ref decl) = export_decl.declaration else {
         return;
     };
+    extract_from_declaration(decl, exports, seen_names);
+}
 
-    match decl {
-        Declaration::FunctionDeclaration(func) => {
-            if let Some(ref id) = func.id {
-                let name = id.name.to_string();
-                if seen_names.insert(name.clone()) {
-                    let ts_type = convert_function(&func.params, &func.return_type);
-                    exports.push(DtsExport { name, ts_type });
-                }
-                // Skip overloads (same name already seen)
-            }
+/// Convert a declaration into `DtsExport`s and append unseen names.
+/// Overloaded functions produce duplicates; the first wins.
+fn extract_from_declaration(
+    decl: &Declaration<'_>,
+    exports: &mut Vec<DtsExport>,
+    seen_names: &mut HashSet<String>,
+) {
+    for (name, ts_type) in declaration_entries(decl) {
+        if seen_names.insert(name.clone()) {
+            exports.push(DtsExport { name, ts_type });
         }
-        Declaration::VariableDeclaration(var_decl) => {
-            for declarator in &var_decl.declarations {
-                if let Some(export) = convert_variable_declarator(declarator)
-                    && seen_names.insert(export.name.clone())
-                {
-                    exports.push(export);
-                }
-            }
-        }
-        Declaration::TSTypeAliasDeclaration(type_decl) => {
-            let name = type_decl.id.name.to_string();
-            if seen_names.insert(name.clone()) {
-                let ts_type = convert_oxc_type(&type_decl.type_annotation);
-                exports.push(DtsExport { name, ts_type });
-            }
-        }
-        Declaration::TSInterfaceDeclaration(iface) => {
-            let name = iface.id.name.to_string();
-            if seen_names.insert(name.clone()) {
-                let ts_type = convert_interface_body(&iface.body.body);
-                exports.push(DtsExport { name, ts_type });
-            }
-        }
-        _ => {}
     }
 }
 
-/// Extract function/const/type/interface declarations from inside a namespace body.
+/// Convert a class declaration to an object type whose fields are the
+/// class's public members (methods and properties). A "constructor"
+/// synthetic field, typed as `(args) => Self`, is added when an explicit
+/// constructor is present so callers can `new Foo(x)` through the normal
+/// callable boundary.
+fn convert_class_declaration(class: &Class<'_>) -> Option<DtsExport> {
+    let name = class.id.as_ref()?.name.to_string();
+    let mut fields: Vec<ObjectField> = Vec::new();
+    let mut ctor_params: Option<Vec<FunctionParam>> = None;
+
+    for el in &class.body.body {
+        match el {
+            ClassElement::MethodDefinition(method) => {
+                let field_name = property_key_name(&method.key);
+                match method.kind {
+                    MethodDefinitionKind::Constructor => {
+                        ctor_params = Some(convert_formal_params(&method.value.params));
+                    }
+                    MethodDefinitionKind::Method => {
+                        if let Some(n) = field_name {
+                            let ret = method
+                                .value
+                                .return_type
+                                .as_ref()
+                                .map(|ta| convert_oxc_type(&ta.type_annotation))
+                                .unwrap_or(TsType::Any);
+                            fields.push(ObjectField {
+                                name: n,
+                                ty: TsType::Function {
+                                    params: convert_formal_params(&method.value.params),
+                                    return_type: Box::new(ret),
+                                },
+                                optional: method.optional,
+                            });
+                        }
+                    }
+                    MethodDefinitionKind::Get => {
+                        if let Some(n) = field_name {
+                            let ty = method
+                                .value
+                                .return_type
+                                .as_ref()
+                                .map(|ta| convert_oxc_type(&ta.type_annotation))
+                                .unwrap_or(TsType::Any);
+                            fields.push(ObjectField {
+                                name: n,
+                                ty,
+                                optional: method.optional,
+                            });
+                        }
+                    }
+                    MethodDefinitionKind::Set => {
+                        if let Some(n) = field_name {
+                            let ty = method
+                                .value
+                                .params
+                                .items
+                                .first()
+                                .and_then(|p| p.type_annotation.as_ref())
+                                .map(|ta| convert_oxc_type(&ta.type_annotation))
+                                .unwrap_or(TsType::Any);
+                            // Only add if not already present (getter + setter).
+                            if !fields.iter().any(|f| f.name == n) {
+                                fields.push(ObjectField {
+                                    name: n,
+                                    ty,
+                                    optional: method.optional,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            ClassElement::PropertyDefinition(prop) => {
+                if let Some(n) = property_key_name(&prop.key) {
+                    let ty = prop
+                        .type_annotation
+                        .as_ref()
+                        .map(|ta| convert_oxc_type(&ta.type_annotation))
+                        .unwrap_or(TsType::Any);
+                    fields.push(ObjectField {
+                        name: n,
+                        ty,
+                        optional: prop.optional,
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Resolve any `this` return types to the class name.
+    for field in &mut fields {
+        resolve_this_in_type(&mut field.ty, &name);
+    }
+
+    // Synthetic constructor field makes `new Foo(x)` callable through the
+    // normal function boundary.
+    if let Some(params) = ctor_params {
+        fields.push(ObjectField {
+            name: "constructor".to_string(),
+            ty: TsType::Function {
+                params,
+                return_type: Box::new(TsType::Named(name.clone())),
+            },
+            optional: false,
+        });
+    }
+
+    Some(DtsExport {
+        name,
+        ts_type: TsType::Object(fields),
+    })
+}
+
+/// Convert an enum declaration. `enum Color { Red, Green }` becomes a
+/// union of the member names as string literals (`"Red" | "Green"`);
+/// numeric-valued members widen to `number`.
+fn convert_enum_declaration(enum_decl: &TSEnumDeclaration<'_>) -> Option<DtsExport> {
+    let name = enum_decl.id.name.to_string();
+    let mut has_string = false;
+    let mut has_number = false;
+    let mut members: Vec<TsType> = Vec::new();
+
+    for member in &enum_decl.body.members {
+        let member_name = enum_member_name(&member.id)?;
+        match &member.initializer {
+            Some(oxc_ast::ast::Expression::StringLiteral(s)) => {
+                has_string = true;
+                members.push(TsType::StringLiteral(s.value.to_string()));
+            }
+            Some(oxc_ast::ast::Expression::NumericLiteral(n)) => {
+                has_number = true;
+                members.push(TsType::NumberLiteral(n.value));
+            }
+            _ => {
+                // No initializer / computed — default to the member name.
+                members.push(TsType::StringLiteral(member_name));
+            }
+        }
+    }
+
+    let ts_type = if has_number && !has_string {
+        TsType::Primitive("number".to_string())
+    } else if members.len() == 1 {
+        members.into_iter().next().unwrap()
+    } else {
+        TsType::Union(members)
+    };
+
+    Some(DtsExport { name, ts_type })
+}
+
+/// Shared conversion table: for each named top-level declaration we
+/// support, produce an `(ident name, TsType)` pair. Used from every
+/// declaration-site — exported, non-exported top-level, inside a
+/// namespace — so the kind list lives in one place.
+fn declaration_entries(decl: &Declaration<'_>) -> Vec<(String, TsType)> {
+    match decl {
+        Declaration::FunctionDeclaration(func) => func
+            .id
+            .as_ref()
+            .map(|id| {
+                vec![(
+                    id.name.to_string(),
+                    convert_function(&func.params, &func.return_type),
+                )]
+            })
+            .unwrap_or_default(),
+        Declaration::VariableDeclaration(var_decl) => var_decl
+            .declarations
+            .iter()
+            .filter_map(convert_variable_declarator)
+            .map(|e| (e.name, e.ts_type))
+            .collect(),
+        Declaration::TSTypeAliasDeclaration(type_decl) => vec![(
+            type_decl.id.name.to_string(),
+            convert_oxc_type(&type_decl.type_annotation),
+        )],
+        Declaration::TSInterfaceDeclaration(iface) => {
+            let name = iface.id.name.to_string();
+            let ts_type = convert_interface_body_named(&iface.body.body, Some(&name));
+            vec![(name, ts_type)]
+        }
+        Declaration::ClassDeclaration(class) => convert_class_declaration(class)
+            .map(|e| vec![(e.name, e.ts_type)])
+            .unwrap_or_default(),
+        Declaration::TSEnumDeclaration(enum_decl) => convert_enum_declaration(enum_decl)
+            .map(|e| vec![(e.name, e.ts_type)])
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
+/// Same as `declaration_entries` but for the Statement-level variants at
+/// the top of a file or namespace body. The payload types differ from
+/// `Declaration`, so dispatch happens here rather than through a shared
+/// projection.
+fn statement_entries(stmt: &Statement<'_>) -> Vec<(String, TsType)> {
+    match stmt {
+        Statement::FunctionDeclaration(func) => func
+            .id
+            .as_ref()
+            .map(|id| {
+                vec![(
+                    id.name.to_string(),
+                    convert_function(&func.params, &func.return_type),
+                )]
+            })
+            .unwrap_or_default(),
+        Statement::VariableDeclaration(var_decl) => var_decl
+            .declarations
+            .iter()
+            .filter_map(convert_variable_declarator)
+            .map(|e| (e.name, e.ts_type))
+            .collect(),
+        Statement::TSTypeAliasDeclaration(type_decl) => vec![(
+            type_decl.id.name.to_string(),
+            convert_oxc_type(&type_decl.type_annotation),
+        )],
+        Statement::TSInterfaceDeclaration(iface) => {
+            let name = iface.id.name.to_string();
+            let ts_type = convert_interface_body_named(&iface.body.body, Some(&name));
+            vec![(name, ts_type)]
+        }
+        Statement::ClassDeclaration(class) => convert_class_declaration(class)
+            .map(|e| vec![(e.name, e.ts_type)])
+            .unwrap_or_default(),
+        Statement::TSEnumDeclaration(enum_decl) => convert_enum_declaration(enum_decl)
+            .map(|e| vec![(e.name, e.ts_type)])
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
+/// Record a declaration's type in `local_types` so later passes
+/// (`export default`, aliased re-exports, `typeof X`) can resolve it.
+fn record_local_type(decl: &Declaration<'_>, local_types: &mut HashMap<String, TsType>) {
+    for (name, ts_type) in declaration_entries(decl) {
+        local_types.entry(name).or_insert(ts_type);
+    }
+}
+
+/// Extract function/const/type/interface/class/enum declarations from inside
+/// a namespace body. Recurses into nested namespaces (`declare namespace A.B`)
+/// and nested inner namespaces so their exports bubble up to the parent.
 fn extract_from_namespace_body(body: &Option<TSModuleDeclarationBody<'_>>) -> Vec<DtsExport> {
     let mut exports = Vec::new();
     let mut seen_names: HashSet<String> = HashSet::new();
@@ -399,55 +691,31 @@ fn extract_from_namespace_body(body: &Option<TSModuleDeclarationBody<'_>>) -> Ve
 
     let block = match body {
         TSModuleDeclarationBody::TSModuleBlock(block) => block,
-        TSModuleDeclarationBody::TSModuleDeclaration(_nested) => {
-            // Nested namespace like `declare namespace A.B { ... }` — skip for now
-            return exports;
+        TSModuleDeclarationBody::TSModuleDeclaration(nested) => {
+            // `declare namespace A.B { ... }` parses as nested modules.
+            return extract_from_namespace_body(&nested.body);
         }
     };
 
     for stmt in &block.body {
         match stmt {
-            // Function declarations inside namespace
-            Statement::FunctionDeclaration(func) => {
-                if let Some(ref id) = func.id {
-                    let name = id.name.to_string();
+            Statement::ExportNamedDeclaration(export_decl) => {
+                extract_from_export_named(export_decl, &mut exports, &mut seen_names);
+            }
+            Statement::TSModuleDeclaration(inner) => {
+                for ex in extract_from_namespace_body(&inner.body) {
+                    if seen_names.insert(ex.name.clone()) {
+                        exports.push(ex);
+                    }
+                }
+            }
+            other => {
+                for (name, ts_type) in statement_entries(other) {
                     if seen_names.insert(name.clone()) {
-                        let ts_type = convert_function(&func.params, &func.return_type);
                         exports.push(DtsExport { name, ts_type });
                     }
                 }
             }
-            // Variable declarations inside namespace
-            Statement::VariableDeclaration(var_decl) => {
-                for declarator in &var_decl.declarations {
-                    if let Some(export) = convert_variable_declarator(declarator)
-                        && seen_names.insert(export.name.clone())
-                    {
-                        exports.push(export);
-                    }
-                }
-            }
-            // Type aliases inside namespace
-            Statement::TSTypeAliasDeclaration(type_decl) => {
-                let name = type_decl.id.name.to_string();
-                if seen_names.insert(name.clone()) {
-                    let ts_type = convert_oxc_type(&type_decl.type_annotation);
-                    exports.push(DtsExport { name, ts_type });
-                }
-            }
-            // Interfaces inside namespace
-            Statement::TSInterfaceDeclaration(iface) => {
-                let name = iface.id.name.to_string();
-                if seen_names.insert(name.clone()) {
-                    let ts_type = convert_interface_body(&iface.body.body);
-                    exports.push(DtsExport { name, ts_type });
-                }
-            }
-            // Exported declarations inside namespace
-            Statement::ExportNamedDeclaration(export_decl) => {
-                extract_from_export_named(export_decl, &mut exports, &mut seen_names);
-            }
-            _ => {}
         }
     }
 
@@ -523,15 +791,72 @@ fn convert_property_signature(prop: &TSPropertySignature<'_>) -> Option<ObjectFi
     })
 }
 
-/// Convert interface body members to TsType::Object.
-pub(super) fn convert_interface_body(members: &[TSSignature<'_>]) -> TsType {
-    let fields: Vec<ObjectField> = members
+/// Convert an object-literal / interface body into a `TsType`. Handles
+/// property signatures, method signatures (getters / regular / setters),
+/// construct signatures (`new (...) => T`), call signatures (callable
+/// objects), and index signatures (`[k: K]: V` → `Record<K, V>`). When the
+/// body has no named fields but does carry a call signature, the caller
+/// typically wants to treat the whole thing as a function — we surface
+/// that as `TsType::Function` to match existing behavior.
+fn convert_type_literal(members: &[TSSignature<'_>]) -> TsType {
+    let fields = collect_object_fields(members);
+    if fields.is_empty() {
+        // No named fields: look for a lone call signature and surface as a
+        // function type (common for overloaded builder methods in npm).
+        for sig in members {
+            if let TSSignature::TSCallSignatureDeclaration(call) = sig {
+                return TsType::Function {
+                    params: convert_formal_params(&call.params),
+                    return_type: Box::new(
+                        call.return_type
+                            .as_ref()
+                            .map(|ta| convert_oxc_type(&ta.type_annotation))
+                            .unwrap_or(TsType::Any),
+                    ),
+                };
+            }
+        }
+        // Construct-only signature `new (...)`: treat as its return type so
+        // `new Foo(x)` is usable.
+        for sig in members {
+            if let TSSignature::TSConstructSignatureDeclaration(ctor) = sig {
+                return TsType::Function {
+                    params: convert_formal_params(&ctor.params),
+                    return_type: Box::new(
+                        ctor.return_type
+                            .as_ref()
+                            .map(|ta| convert_oxc_type(&ta.type_annotation))
+                            .unwrap_or(TsType::Any),
+                    ),
+                };
+            }
+        }
+    }
+    // Index signature { [k: K]: V } becomes a Record<K, V> when there are
+    // no other fields; otherwise the caller has a mixed dict-plus-fields
+    // shape that we best-effort as the object so the named fields survive.
+    if fields.is_empty() {
+        for sig in members {
+            if let TSSignature::TSIndexSignature(idx) = sig
+                && let Some((k, v)) = index_signature_kv(idx)
+            {
+                return TsType::Generic {
+                    name: "Record".to_string(),
+                    args: vec![k, v],
+                };
+            }
+        }
+    }
+    TsType::Object(fields)
+}
+
+/// Collect every supported field shape (properties, getters, methods,
+/// setters) from an object-literal / interface body into `ObjectField`s.
+fn collect_object_fields(members: &[TSSignature<'_>]) -> Vec<ObjectField> {
+    members
         .iter()
         .filter_map(|sig| match sig {
             TSSignature::TSPropertySignature(prop) => convert_property_signature(prop),
-            // Treat getter methods (e.g., `get location(): Location`) as property fields
-            // and regular methods (e.g., `writeText(data: string): Promise<void>`) as
-            // function-typed fields. This is critical for lib.dom.d.ts interfaces.
             TSSignature::TSMethodSignature(method) => {
                 let name = property_key_name(&method.key)?;
                 match method.kind {
@@ -539,6 +864,23 @@ pub(super) fn convert_interface_body(members: &[TSSignature<'_>]) -> TsType {
                         let ty = method
                             .return_type
                             .as_ref()
+                            .map(|ta| convert_oxc_type(&ta.type_annotation))
+                            .unwrap_or(TsType::Any);
+                        Some(ObjectField {
+                            name,
+                            ty,
+                            optional: method.optional,
+                        })
+                    }
+                    oxc_ast::ast::TSMethodSignatureKind::Set => {
+                        // Setter: expose the field name with the setter's
+                        // parameter type so consumers can at least read the
+                        // type. Getter + setter pairs merge later.
+                        let ty = method
+                            .params
+                            .items
+                            .first()
+                            .and_then(|p| p.type_annotation.as_ref())
                             .map(|ta| convert_oxc_type(&ta.type_annotation))
                             .unwrap_or(TsType::Any);
                         Some(ObjectField {
@@ -555,18 +897,173 @@ pub(super) fn convert_interface_body(members: &[TSSignature<'_>]) -> TsType {
                             optional: method.optional,
                         })
                     }
-                    _ => None, // skip setters
                 }
             }
             _ => None,
         })
-        .collect();
-    TsType::Object(fields)
+        .collect()
+}
+
+/// Extract `K` and `V` from an index signature `[k: K]: V`.
+fn index_signature_kv(idx: &oxc_ast::ast::TSIndexSignature<'_>) -> Option<(TsType, TsType)> {
+    let key_param = idx.parameters.first()?;
+    let key = convert_oxc_type(&key_param.type_annotation.type_annotation);
+    let value = convert_oxc_type(&idx.type_annotation.type_annotation);
+    Some((key, value))
+}
+
+/// Merge intersection members. Object members' fields are concatenated
+/// (later wins on name collision); non-object members collapse through
+/// the `T & {}` no-op pattern. When only one non-empty member survives,
+/// emit it directly to avoid a spurious union-like wrapper.
+fn merge_intersection(parts: Vec<TsType>) -> TsType {
+    let mut merged_fields: Vec<ObjectField> = Vec::new();
+    let mut field_index: HashMap<String, usize> = HashMap::new();
+    let mut non_object: Vec<TsType> = Vec::new();
+    for part in parts {
+        match part {
+            TsType::Object(fields) if fields.is_empty() => {}
+            TsType::Object(fields) => {
+                for field in fields {
+                    if let Some(&idx) = field_index.get(&field.name) {
+                        merged_fields[idx] = field;
+                    } else {
+                        field_index.insert(field.name.clone(), merged_fields.len());
+                        merged_fields.push(field);
+                    }
+                }
+            }
+            other => non_object.push(other),
+        }
+    }
+    match (merged_fields.is_empty(), non_object.len()) {
+        (true, 0) => TsType::Object(Vec::new()),
+        (true, 1) => non_object.into_iter().next().unwrap(),
+        (false, 0) => TsType::Object(merged_fields),
+        // Mixed: surface the object side (the dominant case for npm patterns
+        // like `SomeClass & { extra: X }`). The non-object halves are
+        // usually opaque class references we can't structurally merge.
+        (false, _) => TsType::Object(merged_fields),
+        (true, _) => non_object.into_iter().next().unwrap(),
+    }
+}
+
+/// `keyof T` — when `T` is a concrete object type, yield the union of its
+/// field names as string literals. For everything else fall back to
+/// `string` (what TypeScript uses when the keys can't be enumerated).
+fn keyof_of(ty: &TsType) -> TsType {
+    if let TsType::Object(fields) = ty {
+        let keys: Vec<TsType> = fields
+            .iter()
+            .map(|f| TsType::StringLiteral(f.name.clone()))
+            .collect();
+        match keys.len() {
+            0 => TsType::Primitive("string".to_string()),
+            1 => keys.into_iter().next().unwrap(),
+            _ => TsType::Union(keys),
+        }
+    } else {
+        TsType::Primitive("string".to_string())
+    }
+}
+
+/// Walk `ty` and replace every `TsType::This` with `TsType::Named(self_name)`.
+/// Used when converting interface / class bodies so fluent-builder return
+/// types stay usable.
+fn resolve_this_in_type(ty: &mut TsType, self_name: &str) {
+    match ty {
+        TsType::This => *ty = TsType::Named(self_name.to_string()),
+        TsType::Union(parts) | TsType::Tuple(parts) => {
+            for p in parts {
+                resolve_this_in_type(p, self_name);
+            }
+        }
+        TsType::Array(inner) => resolve_this_in_type(inner, self_name),
+        TsType::Generic { args, .. } => {
+            for a in args {
+                resolve_this_in_type(a, self_name);
+            }
+        }
+        TsType::Function {
+            params,
+            return_type,
+        } => {
+            for p in params {
+                resolve_this_in_type(&mut p.ty, self_name);
+            }
+            resolve_this_in_type(return_type, self_name);
+        }
+        TsType::Object(fields) => {
+            for f in fields {
+                resolve_this_in_type(&mut f.ty, self_name);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Convert interface body members to `TsType::Object`. When `self_name`
+/// is provided, every `this` return type inside the body resolves to that
+/// interface name so fluent / builder chains keep working.
+pub(super) fn convert_interface_body_named(
+    members: &[TSSignature<'_>],
+    self_name: Option<&str>,
+) -> TsType {
+    let fields = collect_object_fields(members);
+    let mut ty = TsType::Object(fields);
+    if let Some(name) = self_name {
+        resolve_this_in_type(&mut ty, name);
+    }
+    ty
+}
+
+/// Scan `.d.ts` content for `/// <reference path="..." />` directives.
+/// These must appear at the top of the file; stop at the first non-
+/// comment, non-blank line.
+pub(super) fn extract_triple_slash_references(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .take_while(|line| is_header_line(line))
+        .filter_map(parse_reference_line)
+        .collect()
+}
+
+/// True for a blank line or a line starting with `///` — i.e. the zone
+/// at the top of a file where reference directives can legally appear.
+fn is_header_line(line: &str) -> bool {
+    let t = line.trim();
+    t.is_empty() || t.starts_with("///")
+}
+
+/// Extract the path from one line if it's a `/// <reference path="..." />`
+/// directive. Returns `None` for blanks, other triple-slash directives,
+/// or malformed syntax.
+fn parse_reference_line(line: &str) -> Option<String> {
+    let body = line.trim().strip_prefix("///")?.trim();
+    let rest = body.strip_prefix("<reference")?;
+    let after_path = rest.split_once("path=").map(|(_, r)| r)?.trim_start();
+    let quote = after_path
+        .chars()
+        .next()
+        .filter(|c| *c == '"' || *c == '\'')?;
+    let inner = &after_path[1..];
+    let end = inner.find(quote)?;
+    Some(inner[..end].to_string())
 }
 
 /// Extract a name from a PropertyKey.
 fn property_key_name(key: &PropertyKey<'_>) -> Option<String> {
     key.name().map(|n| n.to_string())
+}
+
+/// Extract a name from a TSEnumMember's key. Identifier and string-literal
+/// names are supported; computed members return `None`.
+fn enum_member_name(name: &oxc_ast::ast::TSEnumMemberName<'_>) -> Option<String> {
+    match name {
+        oxc_ast::ast::TSEnumMemberName::Identifier(id) => Some(id.name.to_string()),
+        oxc_ast::ast::TSEnumMemberName::String(s) => Some(s.value.to_string()),
+        _ => None,
+    }
 }
 
 /// Shared match arms for converting oxc type variants to `TsType`.
@@ -618,6 +1115,17 @@ macro_rules! convert_shared_type_arms {
                 }
             }
 
+            // Constructor type: `new (params) => ReturnType` — surface as a
+            // regular function type so callers can wire it through the normal
+            // callable boundary.
+            $prefix::TSConstructorType(ctor) => {
+                let ret = convert_oxc_type(&ctor.return_type.type_annotation);
+                TsType::Function {
+                    params: convert_formal_params(&ctor.params),
+                    return_type: Box::new(ret),
+                }
+            }
+
             // Type reference: named type or generic
             $prefix::TSTypeReference(type_ref) => {
                 let name = ts_type_name_to_string(&type_ref.type_name);
@@ -638,69 +1146,48 @@ macro_rules! convert_shared_type_arms {
             }
 
             // Object literal type: { key: Type; ... }
-            // Also handles callable objects: { (params): ReturnType; }
-            $prefix::TSTypeLiteral(lit) => {
-                let fields: Vec<ObjectField> = lit
-                    .members
-                    .iter()
-                    .filter_map(|sig| match sig {
-                        TSSignature::TSPropertySignature(prop) => convert_property_signature(prop),
-                        _ => None,
-                    })
-                    .collect();
-                // If no named fields but has call signatures, extract the first
-                // as a function type (common for overloaded npm builder methods)
-                if fields.is_empty() {
-                    for sig in &lit.members {
-                        if let TSSignature::TSCallSignatureDeclaration(call) = sig {
-                            return TsType::Function {
-                                params: convert_formal_params(&call.params),
-                                return_type: Box::new(
-                                    call.return_type
-                                        .as_ref()
-                                        .map(|ta| convert_oxc_type(&ta.type_annotation))
-                                        .unwrap_or(TsType::Any),
-                                ),
-                            };
-                        }
-                    }
-                }
-                TsType::Object(fields)
-            }
+            // Also handles callable objects: { (params): ReturnType; },
+            // construct signatures `new (...)`, and index signatures `[k: K]: V`.
+            $prefix::TSTypeLiteral(lit) => convert_type_literal(&lit.members),
 
             // Parenthesized type: (T)
             $prefix::TSParenthesizedType(paren) => convert_oxc_type(&paren.type_annotation),
 
-            // Intersection: T & U — use the first non-empty-object type.
-            // The common TS pattern `T & {}` is used for type inference hints and is a no-op.
+            // Intersection: T & U — merge object members rather than
+            // dropping everything after the first, so `{a: number} & {b: string}`
+            // keeps both fields (lib.dom leans on this heavily).
             $prefix::TSIntersectionType(inter) => {
-                let meaningful: Vec<TsType> = inter
-                    .types
-                    .iter()
-                    .map(|t| convert_oxc_type(t))
-                    .filter(|t| !matches!(t, TsType::Object(fields) if fields.is_empty()))
-                    .collect();
-                match meaningful.len() {
-                    0 => TsType::Object(Vec::new()),
-                    _ => meaningful.into_iter().next().unwrap(),
-                }
+                let parts: Vec<TsType> = inter.types.iter().map(|t| convert_oxc_type(t)).collect();
+                merge_intersection(parts)
             }
 
-            // Literal types (string/number/boolean literals)
+            // Literal types (string/number/boolean literals) — preserved so
+            // unions like `"up" | "down"` keep their discriminators. Floe
+            // widens where it makes sense at the boundary (number/boolean).
             $prefix::TSLiteralType(lit) => match &lit.literal {
-                oxc_ast::ast::TSLiteral::StringLiteral(_) => {
-                    TsType::Primitive("string".to_string())
+                oxc_ast::ast::TSLiteral::StringLiteral(s) => {
+                    TsType::StringLiteral(s.value.to_string())
                 }
-                oxc_ast::ast::TSLiteral::NumericLiteral(_) => {
-                    TsType::Primitive("number".to_string())
+                oxc_ast::ast::TSLiteral::NumericLiteral(n) => TsType::NumberLiteral(n.value),
+                oxc_ast::ast::TSLiteral::BooleanLiteral(b) => TsType::BooleanLiteral(b.value),
+                oxc_ast::ast::TSLiteral::BigIntLiteral(_) => {
+                    TsType::Primitive("bigint".to_string())
                 }
-                oxc_ast::ast::TSLiteral::BooleanLiteral(_) => {
-                    TsType::Primitive("boolean".to_string())
+                oxc_ast::ast::TSLiteral::UnaryExpression(u) => {
+                    // Negative numeric literal: `-1` comes in as a UnaryExpression.
+                    if let oxc_ast::ast::Expression::NumericLiteral(n) = &u.argument {
+                        TsType::NumberLiteral(-n.value)
+                    } else {
+                        TsType::Unknown
+                    }
                 }
-                _ => TsType::Named("literal".to_string()),
+                _ => TsType::Unknown,
             },
 
-            // import("module").Name or import("module").Name<Args>
+            // import("module").Name[<Args>] — without a qualifier, the
+            // import points at the module itself (the default export slot),
+            // which at our boundary is just `Unknown` until the target is
+            // resolved.
             $prefix::TSImportType(import_ty) => {
                 if let Some(ref qualifier) = import_ty.qualifier {
                     let name = import_qualifier_to_string(qualifier);
@@ -715,26 +1202,70 @@ macro_rules! convert_shared_type_arms {
                         TsType::Named(name)
                     }
                 } else {
-                    TsType::Named("unknown".to_string())
+                    TsType::Unknown
                 }
             }
 
-            // Type operator: readonly T, keyof T, unique T
-            $prefix::TSTypeOperatorType(op) => convert_oxc_type(&op.type_annotation),
+            // Type operator: readonly T, keyof T, unique T. `keyof` produces
+            // a union of string literal keys; the other operators are erasures
+            // at the type level so we just unwrap them.
+            $prefix::TSTypeOperatorType(op) => match op.operator {
+                oxc_ast::ast::TSTypeOperatorOperator::Keyof => {
+                    keyof_of(&convert_oxc_type(&op.type_annotation))
+                }
+                _ => convert_oxc_type(&op.type_annotation),
+            },
 
-            // typeof expression: typeof useState
+            // typeof expression: typeof useState, typeof React.Component
             $prefix::TSTypeQuery(query) => {
                 let name = match &query.expr_name {
                     oxc_ast::ast::TSTypeQueryExprName::IdentifierReference(ident) => {
                         ident.name.to_string()
+                    }
+                    oxc_ast::ast::TSTypeQueryExprName::QualifiedName(qn) => {
+                        ts_qualified_name_to_string(qn)
                     }
                     _ => "unknown".to_string(),
                 };
                 TsType::Named(format!("typeof {name}"))
             }
 
-            // Everything else
-            _ => TsType::Named("unknown".to_string()),
+            // Conditional type: T extends U ? X : Y — approximate as the
+            // union of the two branches. Real evaluation would require a
+            // full type-level interpreter.
+            $prefix::TSConditionalType(cond) => TsType::Union(vec![
+                convert_oxc_type(&cond.true_type),
+                convert_oxc_type(&cond.false_type),
+            ]),
+
+            // `infer R` inside a conditional — the binder, not useful at
+            // our boundary, but surface it as a fresh Named so downstream
+            // unions (Generic args for ReturnType<T>) remain usable.
+            $prefix::TSInferType(_) => TsType::Unknown,
+
+            // Mapped type: `{ [K in keyof T]: ... }` — without type-level
+            // evaluation we can't materialise the fields, so surface as
+            // Unknown. The common case `{ [K in keyof T]: T[K] }` (Readonly)
+            // then gets treated as a plain object shape by callers that
+            // narrow against the original type.
+            $prefix::TSMappedType(_) => TsType::Unknown,
+
+            // Indexed access: T['k'] — without evaluating the lookup we
+            // can't return the field type. Use the source type so the
+            // surrounding code still typechecks as "something from T".
+            $prefix::TSIndexedAccessType(access) => convert_oxc_type(&access.object_type),
+
+            // Template literal type: `` `prefix.${K}` `` — widen to string.
+            $prefix::TSTemplateLiteralType(_) => TsType::Primitive("string".to_string()),
+
+            // `this` appearing as a type — resolved by the enclosing
+            // interface/class when possible (see `resolve_this_in_type`).
+            $prefix::TSThisType(_) => TsType::This,
+
+            // Everything else: surface as Unknown. `Named("unknown")` is
+            // a string-typed escape hatch that wrapper.rs treats as the
+            // widest TS type — callers should narrow before use.
+            _ => TsType::Unknown,
         }
     };
 }
@@ -748,12 +1279,16 @@ pub(super) fn convert_oxc_type(ty: &OxcTSType<'_>) -> TsType {
 fn ts_type_name_to_string(name: &TSTypeName<'_>) -> String {
     match name {
         TSTypeName::IdentifierReference(ident) => ident.name.to_string(),
-        TSTypeName::QualifiedName(qn) => {
-            let left = ts_type_name_to_string(&qn.left);
-            format!("{}.{}", left, qn.right.name)
-        }
+        TSTypeName::QualifiedName(qn) => ts_qualified_name_to_string(qn),
         TSTypeName::ThisExpression(_) => "this".to_string(),
     }
+}
+
+/// Convert a TSQualifiedName (`A.B.C`) to its dotted string form. Reused
+/// for both named type refs and `typeof X.Y` queries so neither has to
+/// clone the qualified name through a throwaway allocator.
+fn ts_qualified_name_to_string(qn: &oxc_ast::ast::TSQualifiedName<'_>) -> String {
+    format!("{}.{}", ts_type_name_to_string(&qn.left), qn.right.name)
 }
 
 /// Convert a TSImportTypeQualifier to a string.
@@ -932,7 +1467,9 @@ pub(super) fn collect_interface_info(
          bodies: &mut HashMap<String, Vec<ObjectField>>,
          extends: &mut HashMap<String, Vec<String>>| {
             let name = iface.id.name.to_string();
-            if let TsType::Object(fields) = convert_interface_body(&iface.body.body) {
+            if let TsType::Object(fields) =
+                convert_interface_body_named(&iface.body.body, Some(&name))
+            {
                 bodies.entry(name.clone()).or_insert(fields);
             }
 

--- a/crates/floe-core/src/interop/tests.rs
+++ b/crates/floe-core/src/interop/tests.rs
@@ -648,3 +648,260 @@ fn result_union_round_trip_via_oxc() {
     let wrapped = crate::interop::wrap_boundary_type(&exports[0].ts_type);
     assert!(wrapped.is_result(), "expected Result, got {:?}", wrapped);
 }
+
+#[test]
+fn intersection_merges_object_fields() {
+    let dts = "export type T = { a: number } & { b: string };";
+    let exports = parse_dts_exports_from_str(dts).unwrap();
+    let t = exports.iter().find(|e| e.name == "T").unwrap();
+    match &t.ts_type {
+        TsType::Object(fields) => {
+            let names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
+            assert!(names.contains(&"a"), "missing `a`, got {names:?}");
+            assert!(names.contains(&"b"), "missing `b`, got {names:?}");
+        }
+        other => panic!("expected Object, got {other:?}"),
+    }
+}
+
+#[test]
+fn string_literal_union_preserves_discriminators() {
+    let dts = r#"export type Dir = "up" | "down";"#;
+    let exports = parse_dts_exports_from_str(dts).unwrap();
+    let dir = exports.iter().find(|e| e.name == "Dir").unwrap();
+    match &dir.ts_type {
+        TsType::Union(members) => {
+            assert!(matches!(members[0], TsType::StringLiteral(ref s) if s == "up"));
+            assert!(matches!(members[1], TsType::StringLiteral(ref s) if s == "down"));
+        }
+        other => panic!("expected Union, got {other:?}"),
+    }
+}
+
+#[test]
+fn exported_class_surfaces_methods_and_constructor() {
+    let dts = r#"export declare class Foo {
+        constructor(x: number);
+        bar(): void;
+        baz: string;
+    }"#;
+    let exports = parse_dts_exports_from_str(dts).unwrap();
+    let foo = exports.iter().find(|e| e.name == "Foo").unwrap();
+    match &foo.ts_type {
+        TsType::Object(fields) => {
+            let names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
+            assert!(names.contains(&"bar"), "missing method `bar` in {names:?}");
+            assert!(names.contains(&"baz"), "missing field `baz` in {names:?}");
+            assert!(
+                names.contains(&"constructor"),
+                "missing synthetic constructor in {names:?}"
+            );
+        }
+        other => panic!("expected Object, got {other:?}"),
+    }
+}
+
+#[test]
+fn string_enum_exports_as_literal_union() {
+    let dts = r#"export enum Color { Red = "r", Green = "g" }"#;
+    let exports = parse_dts_exports_from_str(dts).unwrap();
+    let color = exports.iter().find(|e| e.name == "Color").unwrap();
+    match &color.ts_type {
+        TsType::Union(members) => {
+            assert!(matches!(members[0], TsType::StringLiteral(ref s) if s == "r"));
+            assert!(matches!(members[1], TsType::StringLiteral(ref s) if s == "g"));
+        }
+        other => panic!("expected Union, got {other:?}"),
+    }
+}
+
+#[test]
+fn numeric_enum_widens_to_number() {
+    let dts = "export enum N { A = 1, B = 2 }";
+    let exports = parse_dts_exports_from_str(dts).unwrap();
+    let n = exports.iter().find(|e| e.name == "N").unwrap();
+    assert!(matches!(&n.ts_type, TsType::Primitive(p) if p == "number"));
+}
+
+#[test]
+fn export_default_identifier_resolves_against_local_declaration() {
+    let dts = r#"
+        export interface Config { host: string }
+        declare const config: Config;
+        export default config;
+    "#;
+    let exports = parse_dts_exports_from_str(dts).unwrap();
+    assert!(
+        exports.iter().any(|e| e.name == "default"),
+        "missing `default` export"
+    );
+}
+
+#[test]
+fn export_alias_resolves_for_all_declaration_kinds() {
+    let dts = r#"
+        declare function impl(x: number): string;
+        type Internal = { kind: "x" };
+        export { impl as handler, Internal as Public };
+    "#;
+    let exports = parse_dts_exports_from_str(dts).unwrap();
+    let names: Vec<&str> = exports.iter().map(|e| e.name.as_str()).collect();
+    assert!(
+        names.contains(&"handler"),
+        "missing aliased fn export, got {names:?}"
+    );
+    assert!(
+        names.contains(&"Public"),
+        "missing aliased type export, got {names:?}"
+    );
+}
+
+#[test]
+fn this_return_inside_interface_resolves_to_interface_name() {
+    let dts = r#"
+        export interface Builder {
+            add(x: number): this;
+        }
+    "#;
+    let exports = parse_dts_exports_from_str(dts).unwrap();
+    let builder = exports.iter().find(|e| e.name == "Builder").unwrap();
+    if let TsType::Object(fields) = &builder.ts_type {
+        let add = fields.iter().find(|f| f.name == "add").unwrap();
+        if let TsType::Function { return_type, .. } = &add.ty {
+            assert!(
+                matches!(return_type.as_ref(), TsType::Named(n) if n == "Builder"),
+                "expected Named(Builder), got {:?}",
+                return_type
+            );
+            return;
+        }
+    }
+    panic!("expected Builder to be an Object with `add` method");
+}
+
+#[test]
+fn index_signature_only_produces_record() {
+    let dts = "export type Dict = { [k: string]: number };";
+    let exports = parse_dts_exports_from_str(dts).unwrap();
+    let dict = exports.iter().find(|e| e.name == "Dict").unwrap();
+    match &dict.ts_type {
+        TsType::Generic { name, args } if name == "Record" && args.len() == 2 => {}
+        other => panic!("expected Record<K, V> generic, got {other:?}"),
+    }
+}
+
+#[test]
+fn keyof_of_concrete_object_yields_string_literal_union() {
+    let dts = "export type Keys = keyof { a: number; b: number };";
+    let exports = parse_dts_exports_from_str(dts).unwrap();
+    let keys = exports.iter().find(|e| e.name == "Keys").unwrap();
+    match &keys.ts_type {
+        TsType::Union(parts) => {
+            assert_eq!(parts.len(), 2);
+            assert!(matches!(&parts[0], TsType::StringLiteral(s) if s == "a"));
+            assert!(matches!(&parts[1], TsType::StringLiteral(s) if s == "b"));
+        }
+        other => panic!("expected Union, got {other:?}"),
+    }
+}
+
+#[test]
+fn qualified_typeof_keeps_full_path() {
+    let dts = r#"
+        declare const React: { Component: any };
+        export type C = typeof React.Component;
+    "#;
+    let exports = parse_dts_exports_from_str(dts).unwrap();
+    let c = exports.iter().find(|e| e.name == "C").unwrap();
+    assert!(
+        matches!(&c.ts_type, TsType::Named(n) if n == "typeof React.Component"),
+        "got {:?}",
+        c.ts_type
+    );
+}
+
+#[test]
+fn construct_signature_surfaces_as_function() {
+    let dts = "export type Ctor = new (x: number) => string;";
+    let exports = parse_dts_exports_from_str(dts).unwrap();
+    let ctor = exports.iter().find(|e| e.name == "Ctor").unwrap();
+    assert!(
+        matches!(&ctor.ts_type, TsType::Function { .. }),
+        "got {:?}",
+        ctor.ts_type
+    );
+}
+
+#[test]
+fn setter_only_property_is_surfaced() {
+    let dts = r#"
+        export interface Thing {
+            set name(value: string);
+        }
+    "#;
+    let exports = parse_dts_exports_from_str(dts).unwrap();
+    let thing = exports.iter().find(|e| e.name == "Thing").unwrap();
+    if let TsType::Object(fields) = &thing.ts_type {
+        assert!(
+            fields.iter().any(|f| f.name == "name"),
+            "setter-only field was dropped"
+        );
+        return;
+    }
+    panic!("expected Object");
+}
+
+#[test]
+fn nested_namespace_exports_surface() {
+    let dts = r#"
+        declare namespace Outer {
+            namespace Inner {
+                export function deep(x: number): string;
+            }
+        }
+        export = Outer;
+    "#;
+    let exports = parse_dts_exports_from_str(dts).unwrap();
+    assert!(
+        exports.iter().any(|e| e.name == "deep"),
+        "nested namespace export missing, got {:?}",
+        exports.iter().map(|e| &e.name).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn bigint_literal_narrows_to_bigint_primitive() {
+    let dts = "export type B = 100n;";
+    let exports = parse_dts_exports_from_str(dts).unwrap();
+    let b = exports.iter().find(|e| e.name == "B").unwrap();
+    assert!(matches!(&b.ts_type, TsType::Primitive(p) if p == "bigint"));
+}
+
+#[test]
+fn conditional_type_approximates_as_union_of_branches() {
+    let dts = "export type X<T> = T extends string ? number : boolean;";
+    let exports = parse_dts_exports_from_str(dts).unwrap();
+    let x = exports.iter().find(|e| e.name == "X").unwrap();
+    match &x.ts_type {
+        TsType::Union(parts) => {
+            assert_eq!(parts.len(), 2);
+            assert!(matches!(&parts[0], TsType::Primitive(p) if p == "number"));
+            assert!(matches!(&parts[1], TsType::Primitive(p) if p == "boolean"));
+        }
+        other => panic!("expected Union of branches, got {other:?}"),
+    }
+}
+
+#[test]
+fn triple_slash_reference_is_extracted() {
+    let dts = "/// <reference path=\"./other.d.ts\" />\n";
+    let refs = super::dts::extract_triple_slash_references(dts);
+    assert_eq!(refs, vec!["./other.d.ts".to_string()]);
+}
+
+#[test]
+fn triple_slash_scan_stops_at_first_non_header() {
+    let dts = "/// <reference path=\"./a.d.ts\" />\nexport const x: number;\n/// <reference path=\"./b.d.ts\" />\n";
+    let refs = super::dts::extract_triple_slash_references(dts);
+    assert_eq!(refs, vec!["./a.d.ts".to_string()]);
+}

--- a/crates/floe-core/src/interop/ts_types.rs
+++ b/crates/floe-core/src/interop/ts_types.rs
@@ -58,6 +58,16 @@ pub enum TsType {
     Object(Vec<ObjectField>),
     /// Tuple: `[T, U]`
     Tuple(Vec<TsType>),
+    /// String literal type: `"up"`, `"down"` — preserved so unions of
+    /// literals keep their discriminators at the Floe boundary.
+    StringLiteral(String),
+    /// Numeric literal type: `0`, `404`.
+    NumberLiteral(f64),
+    /// Boolean literal type: `true`, `false`.
+    BooleanLiteral(bool),
+    /// `this` return type — resolved to the enclosing interface/class name
+    /// during conversion so fluent builders keep a usable type.
+    This,
 }
 
 /// Convert a TsType to a human-readable string for display.
@@ -103,6 +113,10 @@ pub fn ts_type_to_string(ty: &TsType) -> String {
             let ps: Vec<String> = parts.iter().map(ts_type_to_string).collect();
             format!("[{}]", ps.join(", "))
         }
+        TsType::StringLiteral(s) => format!("\"{s}\""),
+        TsType::NumberLiteral(n) => n.to_string(),
+        TsType::BooleanLiteral(b) => b.to_string(),
+        TsType::This => "this".to_string(),
     }
 }
 
@@ -200,6 +214,25 @@ pub(super) fn parse_type_str(s: &str) -> TsType {
         return TsType::Object(fields);
     }
 
+    // String literal: "foo" or 'foo'
+    if (s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')) {
+        let inner = &s[1..s.len() - 1];
+        return TsType::StringLiteral(inner.to_string());
+    }
+
+    // Boolean literal
+    if s == "true" {
+        return TsType::BooleanLiteral(true);
+    }
+    if s == "false" {
+        return TsType::BooleanLiteral(false);
+    }
+
+    // Numeric literal
+    if let Ok(n) = s.parse::<f64>() {
+        return TsType::NumberLiteral(n);
+    }
+
     // Primitives and special types
     match s {
         "string" => TsType::Primitive("string".to_string()),
@@ -213,6 +246,7 @@ pub(super) fn parse_type_str(s: &str) -> TsType {
         "undefined" => TsType::Undefined,
         "any" => TsType::Any,
         "unknown" => TsType::Unknown,
+        "this" => TsType::This,
         _ => TsType::Named(s.to_string()),
     }
 }

--- a/crates/floe-core/src/interop/wrapper.rs
+++ b/crates/floe-core/src/interop/wrapper.rs
@@ -117,6 +117,19 @@ pub fn wrap_boundary_type(ts_type: &TsType) -> Type {
         }
 
         TsType::Tuple(parts) => Type::Tuple(parts.iter().map(wrap_boundary_type).collect()),
+
+        // String/number/boolean literal types carry discriminator information.
+        // `StringLiteral` maps to Floe's `Type::StringLiteral` so union discrimination
+        // (e.g. `"GET" | "POST"`) survives. Numeric/boolean literals don't have a
+        // dedicated Floe variant — widen to the underlying primitive.
+        TsType::StringLiteral(s) => Type::StringLiteral(s.clone()),
+        TsType::NumberLiteral(_) => Type::Number,
+        TsType::BooleanLiteral(_) => Type::Bool,
+
+        // `this` return inside an unresolved context — the caller-side contextual
+        // resolution should have replaced this with the enclosing interface name
+        // before wrapping. If it survived, fall back to Unknown.
+        TsType::This => Type::Unknown,
     }
 }
 


### PR DESCRIPTION
closes #1123

## Summary

Closes the gaps identified in the `.d.ts` audit. The parser now handles the constructs real npm packages ship — classes, enums, `export default`, aliased re-exports, intersections, literal types, `this` returns, index signatures, `keyof`, triple-slash references — instead of silently falling through to `Named("unknown")`.

Mechanical layer (no HM required):
- **Intersection merge** — `{a: number} & {b: string}` produces `{a, b}` (previously kept only the first half)
- **Classes** — `export class Foo {}` emits fields, methods (via kind: method/get/set), and a synthetic `constructor` field typed `(args) -> Foo`
- **Enums** — string-valued enums become literal unions; numeric-valued enums widen to `number`
- **`export default X`** — resolved against local declarations (functions, classes, consts, interfaces, type aliases, enums)
- **Aliased re-exports** — `export { X as Y }` now works for every declaration kind, not just pre-collected interfaces
- **Nested namespaces** — `declare namespace A.B {}` recurses instead of bailing
- **Qualified `typeof`** — `typeof React.Component` preserves the full path
- **Construct signatures** — `new (x) => T` surfaced as a function type
- **`this` return** — resolved to the enclosing interface/class name so fluent builders keep their types
- **Index signatures** — `{ [k: K]: V }` becomes `Record<K, V>` when standalone
- **`keyof T`** — produces a union of string-literal keys when `T` is a concrete object
- **Setter-only properties** — surfaced with the setter's parameter type
- **Literal types preserved** — `"up" | "down"` stays a discriminated union at the Floe boundary
- **`bigint` literal** — narrows to the `bigint` primitive
- **Triple-slash `<reference path=... />`** — follows the referenced file
- **Barrel resolution** — handles `.ts`/`.tsx` source extensions and `.d.mts`/`.d.cts` shape variants

Type-level layer (HM-adjacent approximations now that #1118 landed):
- **Conditional types** — `T extends U ? X : Y` emitted as the union of the two branches
- **`infer R`** — binder surfaced as `Unknown` so the surrounding conditional still typechecks
- **Mapped types** — `{ [K in keyof T]: ... }` emitted as `Unknown` (needs type-level eval)
- **Indexed access** — `T['k']` falls back to the source type
- **Template literal types** — widen to `string`

## Refactor cleanup

- Single `statement_entries` / `declaration_entries` pair replaces 4 copies of the 6-variant declaration dispatch (top-level loop, `record_local_type`, `extract_from_declaration`, `extract_from_namespace_body`)
- Dropped the redundant `fn_declarations` map — `typeof X` now resolves through the richer `local_types` (handles any declaration kind, not just functions)
- `merge_intersection` O(n²) → O(n) via HashMap-indexed dedup
- Removed `convert_interface_body` wrapper — call sites pass the enclosing name directly so `this` resolves everywhere
- New `ts_qualified_name_to_string` helper replaces a `clone_in(Allocator::default())` per `typeof X.Y` query

## Test plan

- [x] 18 new targeted tests in `crates/floe-core/src/interop/tests.rs`
- [x] All 1363 pre-existing checker tests unchanged
- [x] `examples/store/`, `examples/todo-app/` check cleanly
- [x] 236 LSP integration tests pass locally
- [x] `cargo clippy -p floe-core --lib -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)