### PR TITLE
feat: [#1158] thread per-dep resolve cache through LSP import resolution

### DIFF
--- a/crates/floe-core/src/resolve.rs
+++ b/crates/floe-core/src/resolve.rs
@@ -418,8 +418,10 @@ fn resolve_single_cached(
                     visited.insert(canonical);
                     return Some(cached_imports.clone());
                 }
-                // Cache miss — resolve normally and cache the result.
-                let resolved = resolve_single_import(base_dir, source, visited, tsconfig_paths)?;
+                // Cache miss — parse the already-read bytes (no second read).
+                let source_code = String::from_utf8(dep_bytes).ok()?;
+                let resolved =
+                    resolve_from_source(&dep_path, &source_code, visited, tsconfig_paths)?;
                 cache.insert(canonical, (hash, resolved.clone()));
                 return Some(resolved);
             }
@@ -442,13 +444,24 @@ fn resolve_single_import(
         .canonicalize()
         .unwrap_or(resolved_path.clone());
     if visited.contains(&canonical) {
-        // Circular import — return empty to avoid infinite recursion
         return Some(ResolvedImports::default());
     }
     visited.insert(canonical);
 
     let source_code = std::fs::read_to_string(&resolved_path).ok()?;
-    let program = Parser::new(&source_code).parse_program().ok()?;
+    resolve_from_source(&resolved_path, &source_code, visited, tsconfig_paths)
+}
+
+/// Core: given a dep's path and already-read source, parse and extract
+/// its exported symbols. Shared by `resolve_single_import` (reads from
+/// disk) and `resolve_single_cached` (reuses already-hashed bytes).
+fn resolve_from_source(
+    resolved_path: &Path,
+    source_code: &str,
+    visited: &mut HashSet<PathBuf>,
+    tsconfig_paths: &TsconfigPaths,
+) -> Option<ResolvedImports> {
+    let program = Parser::new(source_code).parse_program().ok()?;
 
     let mut imports = ResolvedImports::default();
 

--- a/crates/floe-core/src/resolve.rs
+++ b/crates/floe-core/src/resolve.rs
@@ -302,10 +302,35 @@ pub fn resolve_imports(
 /// cache) uses the path list to fingerprint dependencies for
 /// invalidation — without it, edits to an indirectly-imported file
 /// would be served stale from cache.
+/// Per-file cache of resolved exports keyed by (canonical_path, source_hash).
+/// Pass to `resolve_imports_cached` to skip re-parsing unchanged deps.
+pub type ResolveCache = HashMap<PathBuf, (u64, ResolvedImports)>;
+
+/// Like `resolve_imports_with_paths` but checks `cache` before parsing
+/// each dependency. Unchanged deps skip re-parsing entirely. The cache
+/// is updated with fresh entries for deps that were re-parsed.
+pub fn resolve_imports_cached(
+    file_path: &Path,
+    program: &Program,
+    tsconfig_paths: &TsconfigPaths,
+    cache: &mut ResolveCache,
+) -> (HashMap<String, ResolvedImports>, HashSet<PathBuf>) {
+    resolve_imports_inner_with_cache(file_path, program, tsconfig_paths, Some(cache))
+}
+
 pub fn resolve_imports_with_paths(
     file_path: &Path,
     program: &Program,
     tsconfig_paths: &TsconfigPaths,
+) -> (HashMap<String, ResolvedImports>, HashSet<PathBuf>) {
+    resolve_imports_inner_with_cache(file_path, program, tsconfig_paths, None)
+}
+
+fn resolve_imports_inner_with_cache(
+    file_path: &Path,
+    program: &Program,
+    tsconfig_paths: &TsconfigPaths,
+    mut cache: Option<&mut ResolveCache>,
 ) -> (HashMap<String, ResolvedImports>, HashSet<PathBuf>) {
     let mut results = HashMap::new();
     let mut visited = HashSet::new();
@@ -329,9 +354,13 @@ pub fn resolve_imports_with_paths(
             let is_relative = decl.source.starts_with('.');
 
             if is_relative {
-                if let Some(resolved) =
-                    resolve_single_import(base_dir, &decl.source, &mut visited, tsconfig_paths)
-                {
+                if let Some(resolved) = resolve_single_cached(
+                    base_dir,
+                    &decl.source,
+                    &mut visited,
+                    tsconfig_paths,
+                    cache.as_deref_mut(),
+                ) {
                     results.insert(decl.source.clone(), resolved);
                 }
             } else if let Some(resolved_path) = tsconfig_paths.resolve(&decl.source) {
@@ -341,11 +370,12 @@ pub fn resolve_imports_with_paths(
                 {
                     let alias_dir = resolved_path.parent().unwrap_or(Path::new("."));
                     let relative_source = format!("./{}", stem.to_string_lossy());
-                    if let Some(resolved) = resolve_single_import(
+                    if let Some(resolved) = resolve_single_cached(
                         alias_dir,
                         &relative_source,
                         &mut visited,
                         tsconfig_paths,
+                        cache.as_deref_mut(),
                     ) {
                         results.insert(decl.source.clone(), resolved);
                     }
@@ -363,6 +393,39 @@ pub fn resolve_imports_with_paths(
         visited.remove(file_path);
     }
     (results, visited)
+}
+
+/// Try the cache before falling through to `resolve_single_import`.
+/// Reads the dep file, hashes it, and returns the cached exports when
+/// the hash matches. On a miss, delegates to the full resolve and writes
+/// the fresh result back into the cache.
+fn resolve_single_cached(
+    base_dir: &Path,
+    source: &str,
+    visited: &mut HashSet<PathBuf>,
+    tsconfig_paths: &TsconfigPaths,
+    cache: Option<&mut ResolveCache>,
+) -> Option<ResolvedImports> {
+    if let Some(cache) = cache {
+        // Resolve the path without parsing to check the cache.
+        if let Some(dep_path) = resolve_path(base_dir, source) {
+            let canonical = dep_path.canonicalize().unwrap_or(dep_path.clone());
+            if let Ok(dep_bytes) = std::fs::read(&canonical) {
+                let hash = crate::build::cache::ModuleInterface::fingerprint(&dep_bytes);
+                if let Some((cached_hash, cached_imports)) = cache.get(&canonical)
+                    && *cached_hash == hash
+                {
+                    visited.insert(canonical);
+                    return Some(cached_imports.clone());
+                }
+                // Cache miss — resolve normally and cache the result.
+                let resolved = resolve_single_import(base_dir, source, visited, tsconfig_paths)?;
+                cache.insert(canonical, (hash, resolved.clone()));
+                return Some(resolved);
+            }
+        }
+    }
+    resolve_single_import(base_dir, source, visited, tsconfig_paths)
 }
 
 /// Resolve a single import source to its exported symbols.

--- a/crates/floe-lsp/src/lib.rs
+++ b/crates/floe-lsp/src/lib.rs
@@ -251,6 +251,12 @@ pub struct FloeLsp {
     dts_cache: Arc<RwLock<HashMap<String, Vec<floe_core::interop::DtsExport>>>>,
     /// Project directories we've already logged startup info for
     logged_projects: Arc<RwLock<HashSet<PathBuf>>>,
+    /// Per-file cache of .fl import resolution. Keyed by the
+    /// dep file's canonical path; stores (source_hash, exports).
+    /// When the dep's source matches the cached hash, its exports
+    /// are reused without re-parsing. Avoids re-walking every
+    /// imported `.fl` module on each keystroke.
+    resolve_cache: Arc<RwLock<HashMap<PathBuf, (u64, floe_core::resolve::ResolvedImports)>>>,
 }
 
 impl FloeLsp {
@@ -260,6 +266,7 @@ impl FloeLsp {
             documents: Arc::new(RwLock::new(HashMap::new())),
             dts_cache: Arc::new(RwLock::new(HashMap::new())),
             logged_projects: Arc::new(RwLock::new(HashSet::new())),
+            resolve_cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -311,6 +318,24 @@ impl FloeLsp {
             .await;
     }
 
+    /// Resolve imports with per-dep caching. Unchanged deps skip
+    /// re-parsing — only deps whose source hash changed are re-walked.
+    async fn resolve_imports_cached(
+        &self,
+        source_path: &Path,
+        program: &floe_core::parser::ast::Program,
+        tsconfig_paths: &floe_core::resolve::TsconfigPaths,
+    ) -> HashMap<String, floe_core::resolve::ResolvedImports> {
+        let mut cache = self.resolve_cache.write().await;
+        let (resolved, _dep_paths) = floe_core::resolve::resolve_imports_cached(
+            source_path,
+            program,
+            tsconfig_paths,
+            &mut cache,
+        );
+        resolved
+    }
+
     /// Parse and type-check a document, update symbol index, publish diagnostics.
     async fn update_document(&self, uri: Url, source: &str) {
         let (diagnostics, index, type_map, typed_program, references) = match Parser::new(source)
@@ -344,8 +369,9 @@ impl FloeLsp {
                     let project_dir = find_project_dir(&source_dir);
                     let paths = floe_core::resolve::TsconfigPaths::from_project_dir(&project_dir);
                     self.log_project_info(&project_dir, &paths).await;
-                    let resolved =
-                        floe_core::resolve::resolve_imports(&source_path, &program, &paths);
+                    let resolved = self
+                        .resolve_imports_cached(&source_path, &program, &paths)
+                        .await;
                     (resolved, Some(project_dir), paths)
                 } else {
                     (Default::default(), None, Default::default())

--- a/crates/floe-lsp/src/lib.rs
+++ b/crates/floe-lsp/src/lib.rs
@@ -326,13 +326,22 @@ impl FloeLsp {
         program: &floe_core::parser::ast::Program,
         tsconfig_paths: &floe_core::resolve::TsconfigPaths,
     ) -> HashMap<String, floe_core::resolve::ResolvedImports> {
-        let mut cache = self.resolve_cache.write().await;
+        // Snapshot the cache under a read lock so concurrent LSP
+        // handlers don't block on each other. The resolve function
+        // writes fresh entries into the snapshot; we merge them back
+        // under a write lock only if there were misses.
+        let snapshot = self.resolve_cache.read().await.clone();
+        let mut working = snapshot;
         let (resolved, _dep_paths) = floe_core::resolve::resolve_imports_cached(
             source_path,
             program,
             tsconfig_paths,
-            &mut cache,
+            &mut working,
         );
+        // Write back only if the cache grew (at least one miss).
+        if working.len() > self.resolve_cache.read().await.len() {
+            *self.resolve_cache.write().await = working;
+        }
         resolved
     }
 


### PR DESCRIPTION
closes #1158

## Summary

Adds per-dependency resolve caching so the LSP skips re-parsing unchanged `.fl` imports on every keystroke. Each dep file's canonical path + xxh3 hash is cached; when the hash matches, the cached `ResolvedImports` is returned without parsing or walking the AST.

### What ships

- **`floe-core/src/resolve.rs`** — new `ResolveCache` type alias + `resolve_imports_cached(path, program, tsconfig, &mut cache)`. Wraps `resolve_single_import` with a per-dep cache check. Hash match → skip parse; miss → resolve normally + cache the result.
- **`resolve_single_cached`** — wrapper that resolves the file path, reads + hashes the dep, checks the cache, falls through on miss.
- **`FloeLsp.resolve_cache`** — `Arc<RwLock<ResolveCache>>` shared across all open documents. On each keystroke, `update_document` calls `self.resolve_imports_cached(...)` instead of `floe_core::resolve::resolve_imports(...)`.

### How it works

1. For each `import { ... } from "./types"`, resolve the file path (cheap)
2. Read the dep file + xxh3 hash it (cheap)
3. Check `resolve_cache[canonical_path]` — if stored hash matches, return cached exports
4. On miss: fall through to `resolve_single_import` (parse + walk), write result to cache
5. First keystroke pays full cost; subsequent keystrokes with unchanged deps skip all parsing

### Invalidation

- Dep source changes → hash mismatch → re-resolve + overwrite cache entry
- New dep added → no cache entry → full resolve
- Dep deleted → `fs::read` fails → `None` → full resolve path

## Test plan

- [x] 236 LSP pytest tests pass
- [x] All 1404 + 98 + 29 workspace tests pass
- [x] `examples/store/`, `examples/todo-app/` check cleanly
- [x] `cargo clippy --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)