### PR TITLE
fix: [#1133] rename tagged-union discriminator from `tag` to `__tag`

### DIFF
--- a/crates/floe-core/src/codegen/tests.rs
+++ b/crates/floe-core/src/codegen/tests.rs
@@ -1247,7 +1247,7 @@ type Filter { | All | Active | Completed }
 const _f = Filter.All
 "#,
     );
-    assert!(result.contains(r#"{ tag: "All" }"#));
+    assert!(result.contains(r#"{ __tag: "All" }"#));
 }
 
 #[test]
@@ -1272,7 +1272,7 @@ const _f = Validation
 "#,
     );
     assert!(
-        result.contains(r#"(errors) => ({ tag: "Validation", errors })"#),
+        result.contains(r#"(errors) => ({ __tag: "Validation", errors })"#),
         "got: {result}"
     );
 }
@@ -1285,7 +1285,7 @@ type Filter { | All | Active | Completed }
 const _f = All
 "#,
     );
-    assert!(result.contains(r#"{ tag: "All" }"#), "got: {result}");
+    assert!(result.contains(r#"{ __tag: "All" }"#), "got: {result}");
     assert!(
         !result.contains("=>"),
         "should not emit arrow function, got: {result}"
@@ -1305,7 +1305,7 @@ const _f = SaveError.Validation
 "#,
     );
     assert!(
-        result.contains(r#"(errors) => ({ tag: "Validation", errors })"#),
+        result.contains(r#"(errors) => ({ __tag: "Validation", errors })"#),
         "got: {result}"
     );
 }
@@ -1323,7 +1323,7 @@ const _e = Validation(message: "bad")
 "#,
     );
     assert!(
-        result.contains(r#"{ tag: "Validation", message: "bad" }"#),
+        result.contains(r#"{ __tag: "Validation", message: "bad" }"#),
         "got: {result}"
     );
 }
@@ -1341,7 +1341,7 @@ const _f = Rect
 "#,
     );
     assert!(
-        result.contains(r#"(width, height) => ({ tag: "Rect", width, height })"#),
+        result.contains(r#"(width, height) => ({ __tag: "Rect", width, height })"#),
         "got: {result}"
     );
 }
@@ -2232,7 +2232,7 @@ export fn describe(b: Bag) -> string {
         "user-defined `Ok` variant must not use Result-style dispatch, got: {result}"
     );
     assert!(
-        result.contains(r#".tag === "Ok""#),
+        result.contains(r#".__tag === "Ok""#),
         "expected tagged-union dispatch, got: {result}"
     );
 }
@@ -2252,6 +2252,37 @@ export fn describe(r: Result<number, string>) -> string {
     assert!(
         result.contains(".ok === true"),
         "Result match should use `.ok === true`, got: {result}"
+    );
+}
+
+#[test]
+fn user_record_tag_field_does_not_collide_with_union_discriminator() {
+    // The discriminator is `__tag` so user records can keep a `tag`
+    // field (HTML attributes, git tag IDs, etc.) without colliding with
+    // the compiler's emitted union shape.
+    let result = emit_typed(
+        r#"
+type Button = { tag: string, label: string }
+type Route { | Home | Profile(id: string) }
+
+const btn = Button(tag: "nav-button", label: "Home")
+const r = Home
+"#,
+    );
+    // User's `tag` field survives as-is.
+    assert!(
+        result.contains(r#"tag: "nav-button""#),
+        "user-defined `tag` should still appear, got:\n{result}"
+    );
+    // Discriminator is emitted as `__tag`.
+    assert!(
+        result.contains(r#"__tag: "Home""#),
+        "union discriminator should use `__tag`, got:\n{result}"
+    );
+    // And they don't collide — the Button literal shouldn't sprout a `__tag`.
+    assert!(
+        !result.contains(r#"{ __tag: "nav-button""#),
+        "user record should not get a discriminator, got:\n{result}"
     );
 }
 

--- a/crates/floe-core/src/type_layout.rs
+++ b/crates/floe-core/src/type_layout.rs
@@ -6,8 +6,12 @@
 
 // ── Runtime field names ──────────────────────────────────────────
 
-/// Discriminant field for tagged union variants: `{ tag: "VariantName", ... }`
-pub const TAG_FIELD: &str = "tag";
+/// Discriminant field for tagged union variants: `{ __tag: "VariantName", ... }`.
+/// Prefixed with `__` so it (1) doesn't collide with user-defined record
+/// fields named `tag`, and (2) visually marks the field as Floe-generated
+/// in the emitted TypeScript — matching the `__` convention Floe already
+/// uses for for-block method mangling (`User__display`).
+pub const TAG_FIELD: &str = "__tag";
 /// Discriminant field for Result/Option types: `{ ok: true/false, ... }`
 pub const OK_FIELD: &str = "ok";
 /// Value field for Ok/Some: `{ ok: true, value: ... }`

--- a/crates/floe-core/tests/snapshots/snapshot_codegen__snapshot_match_expr.snap
+++ b/crates/floe-core/tests/snapshots/snapshot_codegen__snapshot_match_expr.snap
@@ -1,18 +1,18 @@
 ---
-source: tests/snapshot_codegen.rs
+source: crates/floe-core/tests/snapshot_codegen.rs
 expression: output
 ---
-type Route = { tag: "Home" } | { tag: "Profile"; id: string } | { tag: "NotFound" };
+type Route = { __tag: "Home" } | { __tag: "Profile"; id: string } | { __tag: "NotFound" };
 
-const route = { tag: "Home" };
+const route = { __tag: "Home" };
 
-const _page = route.tag === "Home" ? "home" : route.tag === "Profile" ? (() => { const id = route.id; return id; })() : route.tag === "NotFound" ? "404" : (() => { throw new Error("non-exhaustive match"); })();
+const _page = route.__tag === "Home" ? "home" : route.__tag === "Profile" ? (() => { const id = route.id; return id; })() : route.__tag === "NotFound" ? "404" : (() => { throw new Error("non-exhaustive match"); })();
 
-type User = { tag: "Adult"; age: number } | { tag: "Child"; age: number };
+type User = { __tag: "Adult"; age: number } | { __tag: "Child"; age: number };
 
-const user = { tag: "Adult", age: 25 };
+const user = { __tag: "Adult", age: 25 };
 
-const _label = user.tag === "Adult" ? (() => { const age = user.age; if (age >= 65) { return "senior"; } return user.tag === "Adult" ? (() => { const age = user.age; return "adult"; })() : user.tag === "Child" ? (() => { const age = user.age; if (age < 5) { return "toddler"; } return user.tag === "Child" ? (() => { const age = user.age; return "child"; })() : (() => { throw new Error("non-exhaustive match"); })(); })() : user.tag === "Child" ? (() => { const age = user.age; return "child"; })() : (() => { throw new Error("non-exhaustive match"); })(); })() : user.tag === "Adult" ? (() => { const age = user.age; return "adult"; })() : user.tag === "Child" ? (() => { const age = user.age; if (age < 5) { return "toddler"; } return user.tag === "Child" ? (() => { const age = user.age; return "child"; })() : (() => { throw new Error("non-exhaustive match"); })(); })() : user.tag === "Child" ? (() => { const age = user.age; return "child"; })() : (() => { throw new Error("non-exhaustive match"); })();
+const _label = user.__tag === "Adult" ? (() => { const age = user.age; if (age >= 65) { return "senior"; } return user.__tag === "Adult" ? (() => { const age = user.age; return "adult"; })() : user.__tag === "Child" ? (() => { const age = user.age; if (age < 5) { return "toddler"; } return user.__tag === "Child" ? (() => { const age = user.age; return "child"; })() : (() => { throw new Error("non-exhaustive match"); })(); })() : user.__tag === "Child" ? (() => { const age = user.age; return "child"; })() : (() => { throw new Error("non-exhaustive match"); })(); })() : user.__tag === "Adult" ? (() => { const age = user.age; return "adult"; })() : user.__tag === "Child" ? (() => { const age = user.age; if (age < 5) { return "toddler"; } return user.__tag === "Child" ? (() => { const age = user.age; return "child"; })() : (() => { throw new Error("non-exhaustive match"); })(); })() : user.__tag === "Child" ? (() => { const age = user.age; return "child"; })() : (() => { throw new Error("non-exhaustive match"); })();
 
 const n = 42;
 

--- a/crates/floe-core/tests/snapshots/snapshot_codegen__snapshot_positional_variants.snap
+++ b/crates/floe-core/tests/snapshots/snapshot_codegen__snapshot_positional_variants.snap
@@ -1,26 +1,25 @@
 ---
-source: tests/snapshot_codegen.rs
-assertion_line: 71
+source: crates/floe-core/tests/snapshot_codegen.rs
 expression: output
 ---
-type Shape = { tag: "Circle"; value: number } | { tag: "Rect"; _0: number; _1: number } | { tag: "Point" };
+type Shape = { __tag: "Circle"; value: number } | { __tag: "Rect"; _0: number; _1: number } | { __tag: "Point" };
 
-const c = { tag: "Circle", value: 5 };
+const c = { __tag: "Circle", value: 5 };
 
-const r = { tag: "Rect", _0: 10, _1: 20 };
+const r = { __tag: "Rect", _0: 10, _1: 20 };
 
-const p = { tag: "Point" };
+const p = { __tag: "Point" };
 
 function describe(s: Shape): string {
-  return s.tag === "Circle" ? (() => { const radius = s.value; return `circle r=${radius}`; })() : s.tag === "Rect" ? (() => { const w = s._0; const h = s._1; return `rect ${w}x${h}`; })() : s.tag === "Point" ? "point" : (() => { throw new Error("non-exhaustive match"); })();
+  return s.__tag === "Circle" ? (() => { const radius = s.value; return `circle r=${radius}`; })() : s.__tag === "Rect" ? (() => { const w = s._0; const h = s._1; return `rect ${w}x${h}`; })() : s.__tag === "Point" ? "point" : (() => { throw new Error("non-exhaustive match"); })();
 }
 
 const _d = describe(c);
 
-type Result2 = { tag: "Ok2"; value: string } | { tag: "Err2"; code: number; message: string };
+type Result2 = { __tag: "Ok2"; value: string } | { __tag: "Err2"; code: number; message: string };
 
-const _ok = { tag: "Ok2", value: "hello" };
+const _ok = { __tag: "Ok2", value: "hello" };
 
-const _err = { tag: "Err2", code: 404, message: "not found" };
+const _err = { __tag: "Err2", code: 404, message: "not found" };
 
-const _msg = _ok.tag === "Ok2" ? (() => { const val = _ok.value; return val; })() : _ok.tag === "Err2" ? (() => { const code = _ok.code; const message = _ok.message; return `${code}: ${message}`; })() : (() => { throw new Error("non-exhaustive match"); })();
+const _msg = _ok.__tag === "Ok2" ? (() => { const val = _ok.value; return val; })() : _ok.__tag === "Err2" ? (() => { const code = _ok.code; const message = _ok.message; return `${code}: ${message}`; })() : (() => { throw new Error("non-exhaustive match"); })();

--- a/crates/floe-core/tests/snapshots/snapshot_codegen__snapshot_types.snap
+++ b/crates/floe-core/tests/snapshots/snapshot_codegen__snapshot_types.snap
@@ -1,10 +1,9 @@
 ---
-source: tests/snapshot_codegen.rs
-assertion_line: 65
+source: crates/floe-core/tests/snapshot_codegen.rs
 expression: output
 ---
 type User = { id: string; name: string; email: string };
 
-type Status = { tag: "Active" } | { tag: "Inactive"; reason: string } | { tag: "Suspended"; value: string } | { tag: "Error"; _0: number; _1: string };
+type Status = { __tag: "Active" } | { __tag: "Inactive"; reason: string } | { __tag: "Suspended"; value: string } | { __tag: "Error"; _0: number; _1: string };
 
-type UserId = { tag: "UserId"; value: string };
+type UserId = { __tag: "UserId"; value: string };

--- a/docs/design.md
+++ b/docs/design.md
@@ -78,8 +78,9 @@ All four of TypeScript's `?` uses (`?.`, `??`, `?:`, `? :`) are removed. `?` now
 | Closures | `(x) => x + 1` | `(x) => x + 1` |
 | Dot shorthand | `.name` in callback position | `(x) => x.name` |
 | Dot shorthand (predicate) | `.id != id` in callback position | `(x) => x.id != id` |
-| Qualified variant | `Type.Variant` for disambiguation | `{ tag: "Variant" }` (same as bare) |
-| Variant as function | `Validation` (bare, non-unit) | `(errors) => ({ tag: "Validation", errors })` |
+| Qualified variant | `Type.Variant` for disambiguation | `{ __tag: "Variant" }` (same as bare) |
+| Variant as function | `Validation` (bare, non-unit) | `(errors) => ({ __tag: "Validation", errors })` |
+| Tagged union discriminator | implicit — users write `match x { Home -> ... }` | `__tag` field (double-underscore is Floe's fingerprint — also used for for-block mangling like `User__display`; leaves the name `tag` free for user records) |
 | Generic functions | `fn identity<T>(x: T) -> T { x }` | `function identity<T>(x: T): T { return x; }` |
 | Default values | `fn f(x: number = 10)` | caller can omit, compiler fills in |
 | Structural equality | `==` on objects compares by value | deep equality check |
@@ -1654,12 +1655,12 @@ Emits clean, readable `.tsx`. Zero runtime imports.
 | `(x) => x + 1` | `(x) => x + 1` |
 | `.name` (in callback) | `(x) => x.name` |
 | `.id != id` (in callback) | `(x) => x.id != id` |
-| `Type.Variant` (qualified) | `{ tag: "Variant" }` (same as bare) |
+| `Type.Variant` (qualified) | `{ __tag: "Variant" }` (same as bare) |
 | `fn f(x: T) -> U { ... }` | `function f(x: T): U { ... }` |
 | `fn f<T>(x: T) -> T { ... }` | `function f<T>(x: T): T { ... }` |
 | untrusted npm call (e.g. `parseYaml(input)`) | `(() => { try { return { ok: true, value: parseYaml(input) }; } catch (_e) { return { ok: false, error: _e instanceof Error ? _e : new Error(String(_e)) }; } })()` |
-| `match x { A -> ..., B -> ... }` | `x.tag === "A" ? ... : x.tag === "B" ? ... : absurd(x)` |
-| `match x { A(v) when v > 0 -> ... }` | `x.tag === "A" ? (() => { const v = x.value; if (v > 0) { return ...; } ... })()` |
+| `match x { A -> ..., B -> ... }` | `x.__tag === "A" ? ... : x.__tag === "B" ? ... : absurd(x)` |
+| `match x { A(v) when v > 0 -> ... }` | `x.__tag === "A" ? (() => { const v = x.value; if (v > 0) { return ...; } ... })()` |
 | `match url { "/users/{id}" -> f(id) }` | `url.match(/^\/users\/([^/]+)$/) ? (() => { const _m = url.match(...); const id = _m![1]; return f(id); })() : ...` |
 | `fetchUser(id)?` | `const _r = fetchUser(id); if (!_r.ok) return _r; const val = _r.value;` |
 | `Ok(value)` | `{ ok: true, value }` |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -186,8 +186,8 @@ const c = Color.Red     // OK — qualified
 
 // Non-unit variants as functions (constructor-as-function):
 // A non-unit variant name used without args becomes an arrow function
-const toValidation = Validation  // (errors) => ({ tag: "Validation", errors })
-const toApi = SaveError.Api      // (message) => ({ tag: "Api", message })
+const toValidation = Validation  // (errors) => ({ __tag: "Validation", errors })
+const toApi = SaveError.Api      // (message) => ({ __tag: "Api", message })
 // Useful with mapErr:
 result |> Result.mapErr(Validation)  // instead of Result.mapErr(fn(e) Validation(e))
 ```
@@ -798,3 +798,4 @@ floe lsp                     # start language server (used by editors)
 13. **Implicit returns** — last expression in a block is the return value; no `return` keyword
 14. **Blank line before final expression** — `floe fmt` inserts a blank line before the last expression in multi-statement blocks (2+ statements) to visually separate the return value
 15. **Call argument rules** — positional must precede named; named may be in any order (reordered at compile time); every required param must be covered; no slot can be covered twice; defaulted params must be passed by name, not positionally
+16. **`__` is Floe's fingerprint in emitted TypeScript** — tagged-union discriminators compile to `__tag`, for-block methods mangle to `Type__method`. User records are free to use a plain `tag` field without colliding

--- a/docs/site/src/content/docs/docs/guide/type-driven-features.md
+++ b/docs/site/src/content/docs/docs/guide/type-driven-features.md
@@ -178,7 +178,7 @@ const testOrder = mock<Order>
 // {
 //   id: "mock-id-1",
 //   items: [{ productId: "mock-productId-2", quantity: 3 }],
-//   status: { tag: "Pending" }
+//   status: { __tag: "Pending" }
 // }
 ```
 

--- a/docs/site/src/content/docs/docs/reference/types.md
+++ b/docs/site/src/content/docs/docs/reference/types.md
@@ -132,9 +132,9 @@ Compiles to TypeScript discriminated union:
 
 ```typescript
 type Shape =
-  | { tag: "Circle"; value: number }
-  | { tag: "Rectangle"; width: number; height: number }
-  | { tag: "Point" };
+  | { __tag: "Circle"; value: number }
+  | { __tag: "Rectangle"; width: number; height: number }
+  | { __tag: "Point" };
 ```
 
 Positional: single field uses `value`, multiple use `_0`, `_1`. Named fields keep their names.

--- a/docs/site/src/pages/index.astro
+++ b/docs/site/src/pages/index.astro
@@ -514,20 +514,20 @@ type User = {
 };
 
 type Status =
-  | { tag: "Loading" }
-  | { tag: "Failed"; message: string }
-  | { tag: "Ready"; users: User[] };
+  | { __tag: "Loading" }
+  | { __tag: "Failed"; message: string }
+  | { __tag: "Ready"; users: User[] };
 
 export function Dashboard(): JSX.Element {
   const [status, setStatus] = useState<Status>(
-    { tag: "Loading" }
+    { __tag: "Loading" }
   );
 
-  if (status.tag === "Loading") {
+  if (status.__tag === "Loading") {
     return <Spinner />;
   }
 
-  if (status.tag === "Failed") {
+  if (status.__tag === "Failed") {
     return <Alert message={status.message} />;
   }
 


### PR DESCRIPTION
closes #1133

The tagged-union discriminator field was named \`tag\` — colliding with any user record that wants its own \`tag\` field (HTML attributes, git tag IDs, CodeMirror highlights, etc.). Renames to \`__tag\`, matching Floe's existing \`__\` prefix convention for for-block method mangling (\`User__display\`).

## Summary

- Flip \`TAG_FIELD\` in \`type_layout.rs\` from \`"tag"\` to \`"__tag"\`. Every codegen / exhaustiveness / dts path routes through this constant, so the single change propagates.
- Codegen snapshot tests (3 files) refreshed via \`cargo insta test\`.
- New regression test — \`user_record_tag_field_does_not_collide_with_union_discriminator\` — checks that \`type Button = { tag: string, ... }\` and \`type Route { | Home | Profile(...) }\` in the same file compile cleanly and don't cross-pollute.
- Docs: \`design.md\` adds a row for the discriminator + \`__\` fingerprint rule; \`llms.txt\` Key Rule #16 names the convention; site \`types.md\`, \`type-driven-features.md\`, and landing-page sample TS output updated to \`__tag\`.

## Breaking change

Yes — any raw-TS interop code that pattern-matches on the \`.tag\` field directly will break. Floe's own \`match\` syntax is unaffected (codegen emits the right accessor).

## Test plan

- [x] Full workspace tests pass
- [x] All codegen snapshots refreshed and accepted
- [x] New regression test passes
- [x] \`examples/todo-app\` and \`examples/store\` \`floe check\` + \`floe build\` clean
- [x] Generated TS output shows \`__tag\` instead of \`tag\` (verified in \`.floe/examples/.../types.ts\`)
- [x] 236/236 LSP pytest green
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)