### PR TITLE
test: [#1050] cover the `|>?` pipe-unwrap operator

### DIFF
--- a/crates/floe-core/src/codegen/tests.rs
+++ b/crates/floe-core/src/codegen/tests.rs
@@ -2256,6 +2256,39 @@ export fn describe(r: Result<number, string>) -> string {
 }
 
 #[test]
+fn pipe_unwrap_emits_early_return_on_none() {
+    // `x |>? f` pipes into `f`, then early-returns on `None`/`Err` the
+    // same way `(x |> f)?` does — identical runtime semantics.
+    let result = emit_typed(
+        r#"
+fn half(n: number) -> Option<number> {
+    match n % 2 {
+        0 -> Some(n / 2),
+        _ -> None,
+    }
+}
+
+fn run() -> Option<number> {
+    const x = 10 |>? half
+    Some(x + 1)
+}
+"#,
+    );
+    assert!(
+        result.contains("half("),
+        "pipe target should be called, got:\n{result}"
+    );
+    assert!(
+        result.contains("return") && result.contains(".ok"),
+        "pipe-unwrap should emit an early-return check, got:\n{result}"
+    );
+    assert!(
+        result.contains("x + 1"),
+        "body after the unwrap should use the unwrapped value, got:\n{result}"
+    );
+}
+
+#[test]
 fn untrusted_call_detection_reads_callee_type() {
     // A call to an untrusted foreign fn must emit the try/catch boundary
     // wrapper — driven by `callee.ty.is_untrusted_foreign()`, not by a

--- a/crates/floe-core/src/parser/tests.rs
+++ b/crates/floe-core/src/parser/tests.rs
@@ -222,6 +222,22 @@ fn pipe_chain_then_unwrap() {
     }
 }
 
+#[test]
+fn pipe_unwrap_operator_parses_as_unwrap_of_pipe() {
+    // `x |>? f` is sugar for `(x |> f)?`: pipe into f, then unwrap.
+    let expr = first_expr("x |>? f");
+    match &expr {
+        ExprKind::Unwrap(inner) => {
+            assert!(
+                matches!(inner.kind, ExprKind::Pipe { .. }),
+                "expected Unwrap(Pipe), got Unwrap({:?})",
+                inner.kind
+            );
+        }
+        _ => panic!("expected Unwrap, got {expr:?}"),
+    }
+}
+
 // ── Function Calls ───────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
closes #1050

When I went to implement \`|>?\` I found the feature was already wired up end-to-end on the Gleam-architecture epic branches — lexer, parser, CST→AST lowering, formatter, codegen, tree-sitter / tmLanguage / Neovim grammars, and docs (\`design.md\`, \`llms.txt\`, \`docs/site/.../operators.md\`) all mention and handle it. What was missing was explicit regression tests.

## Summary

- \`parser::tests::pipe_unwrap_operator_parses_as_unwrap_of_pipe\` — \`x |>? f\` parses as \`ExprKind::Unwrap(ExprKind::Pipe { .. })\`
- \`codegen::tests::pipe_unwrap_emits_early_return_on_none\` — emitted TS calls the pipe target, checks \`.ok\`, and returns early on \`None\`/\`Err\`

## Verified end-to-end

\`\`\`floe
fn half(n: number) -> Option<number> { ... }
fn run() -> Option<number> {
    const x = 10 |>? half    // equivalent to `(10 |> half)?`
    Some(x + 1)
}
\`\`\`
Type-checks, formats cleanly (operator preserved as \`|>?\`), and emits the expected early-return.

## Gates

- 1418 core, 33 formatter, 29 test-helpers, 98 LSP unit, 236 LSP pytest
- Both example apps (\`floe check\`) clean
- Clippy with \`-D warnings\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)