### PR TITLE
fix: [#1169] reject dot-access on trait methods via generic bound

### DIFF
--- a/crates/floe-core/src/checker/expr.rs
+++ b/crates/floe-core/src/checker/expr.rs
@@ -2611,6 +2611,24 @@ impl Checker {
             return Type::Error;
         }
 
+        // Trait methods reached through a type-parameter bound also require pipe
+        // syntax — otherwise `r.create(x)` slips through when `r: R` and `R: Repo`
+        // because the receiver's type is a bare `Type::Named("R")` that
+        // `resolve_for_block_method` doesn't recognise.
+        if let Type::Named(type_param) = obj_ty
+            && let Some(bounds) = self.env.get_type_param_bounds(type_param.as_str()).cloned()
+            && let Some(trait_name) = self.trait_defining_method_in_bounds(field, &bounds)
+        {
+            self.emit_error_with_help(
+                format!("cannot call trait method `{field}` with dot syntax"),
+                span,
+                ErrorCode::DotCallOnForBlockMethod,
+                format!("`{field}` comes from trait `{trait_name}` and requires pipe syntax"),
+                format!("use `|> {field}(...)` instead of `.{field}(...)`"),
+            );
+            return Type::Error;
+        }
+
         // Foreign types: try to resolve to Record via DTS before allowing blind access
         if let Type::Foreign { name, .. } = obj_ty {
             let concrete = self.resolve_type_to_concrete(obj_ty);

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -5889,6 +5889,51 @@ const _g: string = u |> greet
     );
 }
 
+#[test]
+fn dot_call_on_trait_method_via_generic_bound_errors() {
+    // #1169: A trait method reached through a trait-bounded type parameter
+    // must still be called via pipe syntax. Previously dot-access slipped
+    // through because the receiver's type (`Type::Named("R")`) wasn't
+    // recognised by `resolve_for_block_method` and the member access fell
+    // through to the foreign/unknown branch.
+    let diags = check(
+        r#"
+trait Repo {
+    fn create(self, value: string) -> string
+}
+
+fn use_repo<R: Repo>(r: R, v: string) -> string {
+    r.create(v)
+}
+"#,
+    );
+    assert!(
+        has_error(&diags, ErrorCode::DotCallOnForBlockMethod),
+        "dot-call on trait method via generic bound should error; got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn pipe_call_on_trait_method_via_generic_bound_allowed() {
+    let diags = check(
+        r#"
+trait Repo {
+    fn create(self, value: string) -> string
+}
+
+fn use_repo<R: Repo>(r: R, v: string) -> string {
+    r |> create(v)
+}
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::DotCallOnForBlockMethod),
+        "pipe syntax for trait method via generic bound should not error; got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
 // ── JSX member expressions ──────────────────────────────────
 
 #[test]

--- a/crates/floe-core/src/checker/traits.rs
+++ b/crates/floe-core/src/checker/traits.rs
@@ -286,6 +286,24 @@ impl Checker {
             .insert((type_name.to_string(), trait_name.to_string()));
     }
 
+    /// Return the name of the first trait in `bounds` that defines a method
+    /// called `method_name`. Used to diagnose dot-access on trait methods
+    /// reached through a type-parameter bound, which must use pipe syntax.
+    pub(crate) fn trait_defining_method_in_bounds(
+        &self,
+        method_name: &str,
+        bounds: &[String],
+    ) -> Option<String> {
+        for bound_trait in bounds {
+            if let Some(methods) = self.traits.trait_defs.get(bound_trait.as_str())
+                && methods.iter().any(|m| m.name == method_name)
+            {
+                return Some(bound_trait.clone());
+            }
+        }
+        None
+    }
+
     /// Look up a trait method by name across a list of trait bounds.
     /// Returns the method as a `Type::Function` if found.
     pub(crate) fn resolve_trait_method(


### PR DESCRIPTION
## Summary

- Fixes #1169: dot-access on a for-block/trait method slipped through the checker when the receiver was a trait-bounded type parameter (`<R: Repo>`, then `r: R`). The existing `DotCallOnForBlockMethod` guard only recognised `Type::Named(concrete)` / `Type::Foreign` receivers, so a bare `Type::Named("R")` was never matched and the access fell through to the foreign-namespace branch.
- Adds a second guard in `resolve_member_type` that checks the receiver's trait bounds and rejects the dot-access when any bound-trait defines the field. Reuses the same error code with a trait-flavoured label.
- Adds `trait_defining_method_in_bounds` helper to `checker/traits.rs`.

## Test plan

- [x] New checker test: `dot_call_on_trait_method_via_generic_bound_errors` (was failing before the fix, green now)
- [x] New checker test: `pipe_call_on_trait_method_via_generic_bound_allowed` (positive case still compiles)
- [x] Existing for-block dot-call tests still pass
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` green
- [x] `floe fmt --check` / `check` / `build` on `examples/todo-app` and `examples/store` green
- [x] `pytest tests/lsp/` — 236 passed

closes #1169

🤖 Generated with [Claude Code](https://claude.com/claude-code)