### PR TITLE
fix: [#1168] stop silently unwrapping Result when piped into stdlib

### DIFF
--- a/crates/floe-core/src/checker/expr.rs
+++ b/crates/floe-core/src/checker/expr.rs
@@ -389,12 +389,16 @@ impl Checker {
     }
 
     fn is_type_untrusted(&self, ty: &Type) -> bool {
-        let name = match ty {
-            Type::Foreign { name: n, .. } | Type::Named(n) => n,
-            _ => return false,
-        };
-        let base = name.split(['<', '.']).next().unwrap_or(name);
-        self.untrusted_imports.contains(base)
+        match ty {
+            Type::Foreign {
+                untrusted: true, ..
+            } => true,
+            Type::Foreign { name, .. } | Type::Named(name) => {
+                let base = name.split(['<', '.']).next().unwrap_or(name);
+                self.untrusted_imports.contains(base)
+            }
+            _ => false,
+        }
     }
 
     /// Peek at an object expression's type from the env without running check_expr.
@@ -1983,10 +1987,7 @@ impl Checker {
         // binds T → Todo).
         if let Some(first_param) = inst_params.first() {
             let unified = unify::unify(first_param, left_ty).is_ok();
-            if !unified
-                && !self.types_compatible(&first_param.resolved(), left_ty)
-                && !self.is_untrusted_result_mismatch(&first_param.resolved(), left_ty)
-            {
+            if !unified && !self.types_compatible(&first_param.resolved(), left_ty) {
                 let resolved_first = first_param.resolved();
                 let (msg, label) = self.type_mismatch_detail(&resolved_first, left_ty);
                 self.emit_error(
@@ -2482,8 +2483,8 @@ impl Checker {
         {
             return ty.clone();
         }
-        if let Type::Foreign { name, .. } = obj_ty {
-            return Type::foreign(format!("{name}.{field}"));
+        if let Type::Foreign { name, untrusted } = obj_ty {
+            return Type::foreign_with_trust(format!("{name}.{field}"), *untrusted);
         }
         Type::Unknown
     }
@@ -2836,15 +2837,6 @@ impl Checker {
             }
         }
         resolved
-    }
-
-    /// Returns true when the mismatch is caused by an untrusted Result that already
-    /// has an error at the const binding — downstream errors should be suppressed.
-    pub(super) fn is_untrusted_result_mismatch(&self, expected: &Type, found: &Type) -> bool {
-        found.is_result()
-            && found
-                .result_ok()
-                .is_some_and(|ok_ty| self.types_unifiable(expected, ok_ty))
     }
 
     /// Returns extra diagnostic detail when there is a specific explanation for the mismatch.

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -7944,3 +7944,52 @@ trait Repo {
         diags.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn pipe_into_stdlib_method_does_not_silently_unwrap_result() {
+    // #1168: piping `Result<T, E>` into a stdlib method expecting `T` must
+    // error — the caller is responsible for unwrapping with `?` or `match`.
+    let diags = check(
+        r#"
+fn arr() -> Result<Array<number>, Error> { Ok([1, 2, 3]) }
+export fn main() -> string {
+    const r = arr() |> Array.at(0)
+    const x: string = r
+    x
+}
+"#,
+    );
+    assert!(
+        has_error(&diags, ErrorCode::TypeMismatch),
+        "piping Result<Array<T>, E> into Array.at should error, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.message.contains("Result") && d.message.contains("Array.at")),
+        "error should flag the Result argument to Array.at, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn pipe_unwrap_then_stdlib_preserves_element_type() {
+    // Once the Result is unwrapped via `?`, the pipe should bind the
+    // element type correctly: Array<number> |> Array.at(0) → Option<number>.
+    let diags = check(
+        r#"
+fn arr() -> Result<Array<number>, Error> { Ok([1, 2, 3]) }
+export fn main() -> Result<Option<number>, Error> {
+    const a = arr()?
+    const r = a |> Array.at(0)
+    Ok(r)
+}
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::TypeMismatch),
+        "unwrapped Array<number> |> Array.at(0) should type-check, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}

--- a/crates/floe-core/src/checker/types.rs
+++ b/crates/floe-core/src/checker/types.rs
@@ -126,6 +126,14 @@ impl Type {
         }
     }
 
+    /// Construct a foreign type preserving a dynamic trust flag.
+    pub fn foreign_with_trust(name: impl Into<String>, untrusted: bool) -> Type {
+        Type::Foreign {
+            name: name.into(),
+            untrusted,
+        }
+    }
+
     /// True if this resolves to any foreign type (trusted or untrusted).
     pub fn is_foreign(&self) -> bool {
         matches!(self.resolved(), Type::Foreign { .. })


### PR DESCRIPTION
closes #1168

## Summary

- Removes the `is_untrusted_result_mismatch` suppression in the pipe checker that let `Result<T, E> |> stdlib.method(T)` silently strip the `Result`. Piping a `Result` into a method expecting its `Ok` type now errors and forces `?` or `match`.
- The suppression also broke generic inference — the pipe returned `Option<?T>` instead of binding `T` to the Array element. Both are fixed by the same change.
- Tightens untrusted-flag handling in the same module so a future Result-wrap propagation fix (see follow-up below) lands on correct foundations: `is_type_untrusted` now honors the `Foreign { untrusted: true }` flag, and `resolve_member_type_silent` preserves the flag when qualifying the member name.

## What this does NOT fix

Issue #1168 Q3 — the `Result` wrap failing to fire for drizzle chains routed through a TypeScript type alias like `Database = ReturnType<typeof createDb>` — is a separate bug in the interop layer (untrusted-ness is lost at the `.d.ts` boundary). Should be filed as a follow-up.

## Test plan

- [x] `cargo test --workspace` — all 1429 floe-core + 33 LSP tests pass
- [x] New tests: `pipe_into_stdlib_method_does_not_silently_unwrap_result` and `pipe_unwrap_then_stdlib_preserves_element_type`
- [x] `cargo fmt --check` + `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `floe check` clean on `examples/todo-app/src/` and `examples/store/src/` with tsgo installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)