### PR TITLE
feat: require import { for Trait } and support block-level export for (#1090, #1089)

### DIFF
--- a/crates/floe-core/src/checker/error_codes.rs
+++ b/crates/floe-core/src/checker/error_codes.rs
@@ -140,6 +140,8 @@ pub enum ErrorCode {
     TraitUsedAsType,
     /// For-block method called via dot syntax — must use pipe syntax.
     DotCallOnForBlockMethod,
+    /// Trait imported without the `for` prefix — must be `import { for Trait }`.
+    TraitImportWithoutFor,
 }
 
 impl ErrorCode {
@@ -202,6 +204,7 @@ impl ErrorCode {
             Self::NotCallable => "E047",
             Self::TraitUsedAsType => "E049",
             Self::DotCallOnForBlockMethod => "E050",
+            Self::TraitImportWithoutFor => "E053",
         }
     }
 }

--- a/crates/floe-core/src/checker/imports.rs
+++ b/crates/floe-core/src/checker/imports.rs
@@ -64,6 +64,26 @@ impl Checker {
             // the resulting type.
             let spec_untrusted = is_npm && !decl.trusted && !spec.trusted;
 
+            // Traits are behaviour, not data — importing them as plain
+            // specifiers silently let them resolve as types. Short-circuit
+            // before `lookup_resolved_symbol` so the user gets one targeted
+            // diagnostic instead of cascading "type-used-as-value" errors.
+            if let Some(ref resolved) = resolved
+                && resolved.trait_decls.iter().any(|t| t.name == spec.name)
+            {
+                self.emit_error_with_help(
+                    format!(
+                        "trait `{}` must be imported with `import {{ for {} }}`",
+                        spec.name, spec.name
+                    ),
+                    spec.span,
+                    ErrorCode::TraitImportWithoutFor,
+                    "traits require the `for` prefix",
+                    format!("change to `for {}`", spec.name),
+                );
+                continue;
+            }
+
             // Try to find the actual type from resolved imports
             let ty = if let Some(ref resolved) = resolved {
                 match self.lookup_resolved_symbol(&spec.name, resolved) {

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -2866,20 +2866,13 @@ for User: Greet {
     assert!(has_error_containing(&diags, "has `self`"));
 }
 
-// ── Bug: Cross-file trait resolution ────────────────────────
-// Traits imported from another file should be recognized by the checker
+// ── Traits imported from another file (cross-file + #1090) ────
 
-#[test]
-fn cross_file_trait_resolution() {
+fn resolved_module_with_display_trait() -> ResolvedImports {
     use crate::lexer::span::Span;
     use crate::parser::ast::*;
-    use crate::resolve::ResolvedImports;
-    use std::collections::HashMap;
 
     let dummy_span = Span::new(0, 0, 0, 0);
-
-    // Simulate a resolved import that exports a trait `Display`
-    let mut imports = HashMap::new();
     let mut resolved = ResolvedImports::default();
     resolved.trait_decls.push(TraitDecl {
         exported: true,
@@ -2906,7 +2899,6 @@ fn cross_file_trait_resolution() {
         }],
         span: dummy_span,
     });
-    // Also need to export the type
     resolved.type_decls.push(TypeDecl {
         exported: true,
         opaque: false,
@@ -2927,7 +2919,15 @@ fn cross_file_trait_resolution() {
         }))]),
         deriving: vec![],
     });
-    imports.insert("./types".to_string(), resolved);
+    resolved
+}
+
+#[test]
+fn trait_imported_without_for_errors() {
+    use std::collections::HashMap;
+
+    let mut imports = HashMap::new();
+    imports.insert("./types".to_string(), resolved_module_with_display_trait());
 
     let source = r#"
 import { User, Display } from "./types"
@@ -2944,8 +2944,45 @@ for User: Display {
         .expect("parse should succeed");
     let diags = Checker::with_imports(imports).check(&program);
     assert!(
-        !has_error_containing(&diags, "unknown trait"),
-        "imported trait Display should be recognized, but got errors: {:?}",
+        has_error(&diags, ErrorCode::TraitImportWithoutFor),
+        "expected TraitImportWithoutFor, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    assert!(has_error_containing(
+        &diags,
+        "trait `Display` must be imported with `import { for Display }`"
+    ));
+}
+
+#[test]
+fn trait_imported_with_for_accepted() {
+    use std::collections::HashMap;
+
+    let mut imports = HashMap::new();
+    imports.insert("./types".to_string(), resolved_module_with_display_trait());
+
+    let source = r#"
+import { User, for Display } from "./types"
+
+for User: Display {
+    fn display(self) -> string {
+        self.name
+    }
+}
+"#;
+
+    let program = Parser::new(source)
+        .parse_program()
+        .expect("parse should succeed");
+    let diags = Checker::with_imports(imports).check(&program);
+    assert!(
+        !has_error(&diags, ErrorCode::TraitImportWithoutFor),
+        "should not error on trait imported via `for`: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::UnknownTrait),
+        "trait should be registered after `for` import: {:?}",
         diags.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }

--- a/crates/floe-core/src/parser/tests.rs
+++ b/crates/floe-core/src/parser/tests.rs
@@ -1330,6 +1330,68 @@ fn for_block_error_non_fn() {
     assert!(result.is_err());
 }
 
+// ── Block-level export on for-blocks (#1089) ─────────────────
+
+#[test]
+fn export_for_block_marks_all_methods_exported() {
+    let input = r#"
+type User { name: string }
+export for User {
+    fn display(self) -> string { self.name }
+    fn shout(self) -> string { self.name }
+}
+"#;
+    let program = parse_ok(input);
+    match &program.items[1].kind {
+        ItemKind::ForBlock(block) => {
+            assert_eq!(block.functions.len(), 2);
+            assert!(
+                block.functions.iter().all(|f| f.exported),
+                "all methods in `export for` block should be exported",
+            );
+        }
+        other => panic!("expected ForBlock, got {other:?}"),
+    }
+}
+
+#[test]
+fn export_for_trait_impl_marks_all_methods_exported() {
+    let input = r#"
+type User { name: string }
+trait Display { fn display(self) -> string }
+export for User: Display {
+    fn display(self) -> string { self.name }
+}
+"#;
+    let program = parse_ok(input);
+    match &program.items[2].kind {
+        ItemKind::ForBlock(block) => {
+            assert_eq!(block.trait_name.as_deref(), Some("Display"));
+            assert!(block.functions.iter().all(|f| f.exported));
+        }
+        other => panic!("expected ForBlock, got {other:?}"),
+    }
+}
+
+#[test]
+fn per_method_export_still_works_on_for_block() {
+    let input = r#"
+type User { name: string }
+for User {
+    export fn display(self) -> string { self.name }
+    fn helper(self) -> string { self.name }
+}
+"#;
+    let program = parse_ok(input);
+    match &program.items[1].kind {
+        ItemKind::ForBlock(block) => {
+            assert!(block.functions[0].exported);
+            assert!(!block.functions[1].exported);
+        }
+        other => panic!("expected ForBlock, got {other:?}"),
+    }
+}
+
 // (Inline for-declaration tests removed — only block form is supported)
 
 // ── Import { for Type } ────────────────────────────────────

--- a/crates/floe-core/src/resolve.rs
+++ b/crates/floe-core/src/resolve.rs
@@ -1041,6 +1041,26 @@ mod tests {
         assert_eq!(resolved.for_blocks[0].functions.len(), 1);
     }
 
+    #[test]
+    fn block_level_export_for_exports_all_methods() {
+        // `export for X { ... }` should export every method in the block,
+        // matching per-method `export fn` behavior.
+        let (_dir, base) = setup_files(&[
+            ("main.fl", ""),
+            (
+                "ext.fl",
+                "export for User {\n    fn greet(self) -> string { self.name }\n    fn shout(self) -> string { self.name }\n}",
+            ),
+        ]);
+        let main_path = base.join("main.fl");
+        let program = parse_program("import { for User } from \"./ext\"");
+        let result = resolve_imports(&main_path, &program, &TsconfigPaths::default());
+        let resolved = result.get("./ext").unwrap();
+        assert_eq!(resolved.for_blocks.len(), 1);
+        assert_eq!(resolved.for_blocks[0].functions.len(), 2);
+        assert!(resolved.for_blocks[0].functions.iter().all(|f| f.exported));
+    }
+
     // ── Missing files handled gracefully ──────────────────────────
 
     #[test]

--- a/docs/design.md
+++ b/docs/design.md
@@ -970,6 +970,15 @@ For generic types, use the base type only — no type params in imports. `import
 
 Same-file rule unchanged: importing a type still auto-imports its for-block functions from that file.
 
+The `for` prefix maps to the two kinds of behaviour in the language:
+
+| Syntax | Meaning |
+|---|---|
+| `import { User }` | Data: type, const, or function |
+| `import { for X }` | Behaviour: for-block methods OR a trait contract |
+
+Traits are behaviour, not data, so `import { SnippetRepository }` on a trait is a compile error (E053) — the compiler suggests `import { for SnippetRepository }` instead.
+
 For block rules:
 
 1. `self` is the explicit first parameter — type inferred from the `for` block
@@ -979,6 +988,25 @@ For block rules:
 5. Cross-file `for` blocks use `import { for Type }` syntax
 6. Compiles to standalone functions with `self` explicitly typed
 7. Only block syntax is supported (`for Type { ... }`)
+
+### Exporting For-Block Methods
+
+Methods in a `for` block can be exported individually or as a whole block:
+
+```floe
+// Per-method export — useful when only some methods are public
+for User {
+  export fn display(self) -> string { self.name }
+  fn internalHelper(self) -> string { self.name }
+}
+
+// Block-level export — the natural shape for trait impls
+export for User: Display {
+  fn display(self) -> string { self.name }
+}
+```
+
+`export for X { ... }` is equivalent to prefixing every method inside with `export`. For trait implementations, all methods are part of the contract so the block-level form is preferred.
 
 ### Traits — Type-Directed Behavioral Contracts
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -516,10 +516,18 @@ const data = fetchData()         // Result<T, Error> — auto-wrapped (untrusted
 // Use ? to unwrap untrusted results
 const parsed = fetchData()?      // unwraps or returns Err early
 
-// Importing for-block extensions
+// Importing for-block extensions and traits
 import { for User } from "./user-helpers"
 import { Todo, Filter, for Array, for string } from "./todo"
+
+// Traits are behaviour — require the `for` prefix just like for-blocks
+import { User, for Display } from "./types"      // OK
+// import { User, Display } from "./types"       // ERROR E053 — use `for Display`
 ```
+
+Rule of thumb:
+- `import { Name }` — data (type / const / function)
+- `import { for Name }` — behaviour (for-block methods OR trait contract)
 
 ## Callback Flattening (use)
 
@@ -591,6 +599,12 @@ for string {
 // Usage in pipes — self is first argument
 todos |> filterBy(Filter.Active)
 "hello" |> validate
+
+// Block-level export — exports every method in the block
+export for User {
+    fn display(self) -> string { self.name }
+    fn shout(self) -> string { self.name |> String.toUpperCase }
+}
 ```
 
 ## Traits
@@ -611,6 +625,14 @@ trait Eq {
 
 // Implement a trait
 for User: Display {
+    fn display(self) -> string {
+        `${self.name} (${self.age})`
+    }
+}
+
+// `export for` exports every method in the block at once — the natural
+// shape for trait impls where all methods are part of the contract
+export for User: Display {
     fn display(self) -> string {
         `${self.name} (${self.age})`
     }

--- a/docs/site/src/content/docs/docs/guide/for-blocks.md
+++ b/docs/site/src/content/docs/docs/guide/for-blocks.md
@@ -72,7 +72,17 @@ import { Todo, Filter, for Array, for string } from "./todo"
 
 `import { for Type }` brings all exported for-block functions for that type from the imported file. For generic types, use the base type only (no type params) -- `import { for Array }` brings all `for Array<T>` extensions.
 
-Importing a type still auto-imports its for-block functions from the same file. The `import { for Type }` syntax is for cross-file for-blocks.
+The same `for` prefix is required for [traits](/docs/guide/traits/). A trait is behaviour, not data, so it must be imported like a for-block rather than like a type:
+
+```floe
+// ❌ error -- traits require the `for` prefix
+import { SnippetRepository } from "./repositories"
+
+// ✅ correct
+import { for SnippetRepository } from "./repositories"
+```
+
+Importing a type still auto-imports its for-block functions from the same file. The `import { for Type }` syntax is for cross-file for-blocks and trait contracts.
 
 ## Real-World Example
 
@@ -132,6 +142,18 @@ for User {
   }
 }
 ```
+
+Prefix the whole block with `export` to export every method at once. This is the natural shape for trait implementations, where all methods are part of the contract:
+
+```floe
+export for User: Display {
+  fn display(self) -> string {
+    `${self.name} (${self.age})`
+  }
+}
+```
+
+Per-method `export` is useful for plain `for` blocks where only some methods should be public. Block-level `export` keeps trait implementations tidy.
 
 ## Rules
 

--- a/docs/site/src/content/docs/docs/guide/traits.md
+++ b/docs/site/src/content/docs/docs/guide/traits.md
@@ -50,6 +50,34 @@ for User: Eq {
 }
 ```
 
+## Exporting and Importing
+
+Traits and their implementations sit on either side of the `export`/`import` rule for *behaviour*:
+
+```floe
+// Define and export a trait
+export trait Display {
+  fn display(self) -> string
+}
+
+// Export every method in a trait impl at once
+export for User: Display {
+  fn display(self) -> string { self.name }
+}
+```
+
+Import traits with the `for` prefix -- the same syntax used to pull in cross-file for-block methods:
+
+```floe
+import { User, for Display } from "./types"
+
+for User: Display {
+  fn display(self) -> string { self.name }
+}
+```
+
+Writing `import { Display }` for a trait is an error -- the compiler asks you to add the `for` prefix.
+
 ## Multiple Traits
 
 A type can implement multiple traits:

--- a/examples/store/src/errors.fl
+++ b/examples/store/src/errors.fl
@@ -1,9 +1,9 @@
-import { ApiError, Display } from "./types"
+import { ApiError, for Display } from "./types"
 
 // ── Multi-depth match on nested error unions ───────────
 
-for ApiError: Display {
-    export fn display(self) -> string {
+export for ApiError: Display {
+    fn display(self) -> string {
         self |> match {
             Network(Timeout(ms)) -> `Request timed out after ${ms}ms`,
             Network(DnsFailure(host)) -> `Cannot resolve ${host}`,

--- a/examples/store/src/product.fl
+++ b/examples/store/src/product.fl
@@ -1,15 +1,15 @@
-import { Product, ProductId, CartItem, SortOrder, PriceRange, Display, Discountable } from "./types"
+import { Product, ProductId, CartItem, SortOrder, PriceRange, for Display, for Discountable } from "./types"
 
 // ── Trait implementations ──────────────────────────────
 
-for Product: Display {
-    export fn display(self) -> string {
+export for Product: Display {
+    fn display(self) -> string {
         `${self.title} - $${self.price}`
     }
 }
 
-for Product: Discountable {
-    export fn effectivePrice(self) -> number {
+export for Product: Discountable {
+    fn effectivePrice(self) -> number {
         self.price * (1 - self.discountPercentage / 100)
     }
 }

--- a/examples/todo-app/src/todo.fl
+++ b/examples/todo-app/src/todo.fl
@@ -1,4 +1,4 @@
-import { Todo, Filter, Validation, Display } from "./types"
+import { Todo, Filter, Validation, for Display } from "./types"
 
 for string {
     export fn validate(self) -> Validation {
@@ -14,8 +14,8 @@ for string {
     }
 }
 
-for Todo: Display {
-    export fn display(self) -> string {
+export for Todo: Display {
+    fn display(self) -> string {
         match self.done {
             true -> `[x] ${self.text}`,
             false -> `[ ] ${self.text}`,


### PR DESCRIPTION
closes #1090
closes #1089

## Summary

Two related cleanups to the trait / for-block import-export surface.

- **#1090** — traits are behaviour, not data, so plain \`import { Trait }\` is now an error (E053). The compiler asks for \`import { for Trait }\`, matching the existing syntax for cross-file for-block methods.
- **#1089** — \`export for X { ... }\` now exports every method in the block at once, matching how traits use block-level \`export\`. The parser/lowerer already threaded item-level \`export\` through to each method; this PR locks the behaviour in with tests and docs.

The two sit on either side of the same rule:

| Syntax | Meaning |
|---|---|
| \`import { User }\` | Data: type, const, or function |
| \`import { for X }\` | Behaviour: for-block methods OR a trait contract |

## Changes

- \`ErrorCode::TraitImportWithoutFor\` (E053)
- \`check_import\` short-circuits when a specifier names a trait, emitting the targeted diagnostic before generic symbol resolution would turn it into a cascading "type-used-as-value" error
- Parser tests covering block-level \`export for\` on plain for-blocks and trait impls, plus a regression test for per-method \`export fn\`
- Resolver test confirming \`export for X { ... }\` exports every method
- Checker tests for both directions of the trait-import rule
- Example apps (\`store\`, \`todo-app\`) switched to the new syntax (\`for Display\`, \`export for\`)
- \`docs/design.md\`, \`docs/llms.txt\`, and the site guides updated

## Test plan

- [x] \`cargo test --workspace\` — 1432 + 33 + 29 + 98 passing
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all\` — clean
- [x] \`floe fmt / check / build\` on both example apps — clean
- [x] \`python3 -m pytest tests/lsp/\` — 236 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)