### PR TITLE
fix: [#1135] enforce positional vs named variant fields

### DIFF
--- a/crates/floe-core/src/checker/match_check.rs
+++ b/crates/floe-core/src/checker/match_check.rs
@@ -79,9 +79,20 @@ impl Checker {
             }
             PatternKind::Variant { name, fields } => {
                 let mut handled = false;
-                if let Type::Union { variants, .. } = subject_ty
+                if let Type::Union {
+                    name: union_name,
+                    variants,
+                    ..
+                } = subject_ty
                     && let Some((_, field_types)) = variants.iter().find(|(n, _)| n == name)
                 {
+                    let declared_field_names = self.lookup_declared_field_names(union_name, name);
+                    self.check_variant_pattern_shape(
+                        name,
+                        fields,
+                        declared_field_names.as_deref(),
+                        pattern.span,
+                    );
                     if fields.len() != field_types.len() {
                         self.emit_error_with_help(
                             format!(
@@ -98,15 +109,17 @@ impl Checker {
                             ),
                         );
                     }
-                    for (i, pat) in fields.iter().enumerate() {
-                        let ty = field_types.get(i).unwrap_or(&Type::Unknown);
-                        self.check_pattern(pat, ty);
-                    }
+                    self.check_variant_pattern_fields(
+                        fields,
+                        field_types,
+                        declared_field_names.as_deref(),
+                    );
                     handled = true;
                 }
                 if subject_ty.is_option()
                     && name == crate::type_layout::VARIANT_SOME
-                    && let Some(pat) = fields.first()
+                    && let VariantPatternFields::Positional(pats) = fields
+                    && let Some(pat) = pats.first()
                     && let Some(inner) = subject_ty.option_inner()
                 {
                     self.check_pattern(pat, inner);
@@ -115,7 +128,7 @@ impl Checker {
                 // Fallback: when subject type is Unknown (e.g. from npm imports),
                 // still register bindings so they're available in the arm body
                 if !handled {
-                    for pat in fields {
+                    for pat in fields.patterns() {
                         self.check_pattern(pat, &Type::Unknown);
                     }
                 }
@@ -229,5 +242,107 @@ impl Checker {
                 }
             }
         }
+    }
+
+    /// Enforce that the pattern's field-list shape matches the variant's
+    /// declaration: positional patterns on `Variant(...)` variants, named
+    /// patterns on `Variant { ... }` variants. Reports a single diagnostic on
+    /// mismatch; field-level checking still runs so downstream bindings are
+    /// registered. `declared_names` is `Some` when the variant was found in
+    /// the type namespace; `None` for foreign unions where no shape check
+    /// applies.
+    fn check_variant_pattern_shape(
+        &mut self,
+        variant_name: &str,
+        fields: &VariantPatternFields,
+        declared_names: Option<&[Option<String>]>,
+        span: Span,
+    ) {
+        let Some(declared) = declared_names else {
+            return;
+        };
+        // Unit variants have no fields — shape is vacuous on either side.
+        if declared.is_empty() && fields.is_empty() {
+            return;
+        }
+        let declared_named = !declared.is_empty() && declared.iter().all(Option::is_some);
+        let pattern_named = matches!(fields, VariantPatternFields::Named(_));
+        if pattern_named == declared_named {
+            return;
+        }
+        let (msg, help) = if declared_named {
+            (
+                format!(
+                    "variant `{variant_name}` has named fields; pattern must use `{variant_name} {{ ... }}` shape"
+                ),
+                format!(
+                    "use `{variant_name} {{ field, ... }}` or `{variant_name} {{ field: pattern, ... }}`"
+                ),
+            )
+        } else {
+            (
+                format!(
+                    "variant `{variant_name}` has positional fields; pattern must use `{variant_name}(...)` shape"
+                ),
+                format!("use `{variant_name}(pattern, ...)` to destructure positionally"),
+            )
+        };
+        self.emit_error_with_help(
+            msg,
+            span,
+            ErrorCode::VariantPatternArity,
+            "wrong pattern shape",
+            help,
+        );
+    }
+
+    /// Recursively check nested patterns against their expected types. Named
+    /// patterns pair field-name to type via `declared_names`; positional
+    /// patterns pair by index.
+    fn check_variant_pattern_fields(
+        &mut self,
+        fields: &VariantPatternFields,
+        field_types: &[Type],
+        declared_names: Option<&[Option<String>]>,
+    ) {
+        match fields {
+            VariantPatternFields::Positional(pats) => {
+                for (i, pat) in pats.iter().enumerate() {
+                    let ty = field_types.get(i).unwrap_or(&Type::Unknown);
+                    self.check_pattern(pat, ty);
+                }
+            }
+            VariantPatternFields::Named(named) => {
+                for (name, pat) in named {
+                    let ty = declared_names
+                        .and_then(|names| {
+                            names
+                                .iter()
+                                .position(|n| n.as_deref() == Some(name.as_str()))
+                        })
+                        .and_then(|i| field_types.get(i))
+                        .unwrap_or(&Type::Unknown);
+                    self.check_pattern(pat, ty);
+                }
+            }
+        }
+    }
+
+    /// Look up the declared field names for a variant, keyed by its parent
+    /// union. `O(1)` in the number of types (direct HashMap lookup). Each
+    /// entry is `Some(name)` for a named field, `None` for a positional one —
+    /// callers derive the variant's shape from whether every entry is `Some`.
+    fn lookup_declared_field_names(
+        &self,
+        union_name: &str,
+        variant_name: &str,
+    ) -> Option<Vec<Option<String>>> {
+        use crate::parser::ast::TypeDef;
+        let info = self.env.lookup_type(union_name)?;
+        let TypeDef::Union(variants) = &info.def else {
+            return None;
+        };
+        let variant = variants.iter().find(|v| v.name == variant_name)?;
+        Some(variant.fields.iter().map(|f| f.name.clone()).collect())
     }
 }

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -2355,6 +2355,80 @@ fn variant_pattern_correct_arity() {
     );
 }
 
+// ── Variant pattern shape (positional vs named) ──────────────
+
+#[test]
+fn named_variant_rejects_positional_pattern() {
+    let source = r#"
+        type Shape { | Rectangle { width: number, height: number } }
+        const _r: Shape = Rectangle(width: 1, height: 2)
+        match _r {
+            Rectangle(w, h) -> w + h,
+        }
+    "#;
+    let diags = check(source);
+    assert!(
+        has_error_containing(&diags, "has named fields"),
+        "positional pattern on named variant should produce a shape mismatch error, got: {diags:?}"
+    );
+}
+
+#[test]
+fn positional_variant_rejects_named_pattern() {
+    let source = r#"
+        type Shape { | Circle(number) }
+        const _c: Shape = Circle(5)
+        match _c {
+            Circle { value: r } -> r,
+        }
+    "#;
+    let diags = check(source);
+    assert!(
+        has_error_containing(&diags, "has positional fields"),
+        "named pattern on positional variant should produce a shape mismatch error, got: {diags:?}"
+    );
+}
+
+#[test]
+fn named_variant_accepts_named_pattern() {
+    let source = r#"
+        type Shape { | Rectangle { width: number, height: number } }
+        const _r: Shape = Rectangle(width: 1, height: 2)
+        const _area = match _r {
+            Rectangle { width, height } -> width * height,
+        }
+    "#;
+    let diags = check(source);
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "named pattern on named variant should type-check cleanly: {errors:?}"
+    );
+}
+
+#[test]
+fn named_variant_accepts_named_pattern_with_rename() {
+    let source = r#"
+        type Shape { | Rectangle { width: number, height: number } }
+        const _r: Shape = Rectangle(width: 1, height: 2)
+        const _area = match _r {
+            Rectangle { width: w, height: h } -> w * h,
+        }
+    "#;
+    let diags = check(source);
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "named pattern with rename should type-check cleanly: {errors:?}"
+    );
+}
+
 // ── Literal pattern type checking ────────────────────────────
 
 #[test]

--- a/crates/floe-core/src/codegen/tests.rs
+++ b/crates/floe-core/src/codegen/tests.rs
@@ -2263,7 +2263,7 @@ fn user_record_tag_field_does_not_collide_with_union_discriminator() {
     let result = emit_typed(
         r#"
 type Button = { tag: string, label: string }
-type Route { | Home | Profile(id: string) }
+type Route { | Home | Profile { id: string } }
 
 const btn = Button(tag: "nav-button", label: "Home")
 const r = Home

--- a/crates/floe-core/src/codegen/typescript/match_emit.rs
+++ b/crates/floe-core/src/codegen/typescript/match_emit.rs
@@ -149,26 +149,31 @@ impl<'a> TypeScriptGenerator<'a> {
                     .variant_info
                     .get(name.as_str())
                     .map(|(_, names)| names.clone());
-                for (i, field_pat) in fields.iter().enumerate() {
-                    if !matches!(
+                let total = fields.len();
+                for (i, field_name, field_pat) in fields.entries() {
+                    if matches!(
                         field_pat.kind,
                         PatternKind::Wildcard | PatternKind::Binding(_)
                     ) {
-                        docs.push(pretty::str(" && "));
-                        let field_access = type_layout::variant_field_accessor_for(
+                        continue;
+                    }
+                    docs.push(pretty::str(" && "));
+                    let field_access = match field_name {
+                        Some(fname) => format!("{subj_str}.{fname}"),
+                        None => type_layout::variant_field_accessor_for(
                             &subject.ty,
                             name,
                             i,
-                            fields.len(),
+                            total,
                             field_names.as_deref(),
                             &subj_str,
-                        );
-                        let field_expr = TypedExpr::synthetic_typed(
-                            ExprKind::Identifier(field_access),
-                            subject.span,
-                        );
-                        docs.push(self.emit_pattern_condition(&field_expr, field_pat));
-                    }
+                        ),
+                    };
+                    let field_expr = TypedExpr::synthetic_typed(
+                        ExprKind::Identifier(field_access),
+                        subject.span,
+                    );
+                    docs.push(self.emit_pattern_condition(&field_expr, field_pat));
                 }
                 pretty::concat(docs)
             }
@@ -415,14 +420,18 @@ fn collect_bindings_inner(
         }
         PatternKind::Variant { name, fields } => {
             let field_names = variant_info.get(name.as_str()).map(|(_, names)| names);
-            for (i, field_pat) in fields.iter().enumerate() {
-                let field_access = type_layout::variant_field_accessor(
-                    name,
-                    i,
-                    fields.len(),
-                    field_names.map(|v| v.as_slice()),
-                    subject_str,
-                );
+            let total = fields.len();
+            for (i, field_name, field_pat) in fields.entries() {
+                let field_access = match field_name {
+                    Some(fname) => format!("{subject_str}.{fname}"),
+                    None => type_layout::variant_field_accessor(
+                        name,
+                        i,
+                        total,
+                        field_names.map(|v| v.as_slice()),
+                        subject_str,
+                    ),
+                };
                 collect_bindings_inner(&field_access, field_pat, variant_info, bindings);
             }
         }

--- a/crates/floe-core/src/cst/exprs.rs
+++ b/crates/floe-core/src/cst/exprs.rs
@@ -783,6 +783,15 @@ impl<'src> CstParser<'src> {
                         self.eat_trivia();
                         self.parse_comma_separated(Self::parse_pattern, TokenKind::RightParen);
                         self.expect(TokenKind::RightParen);
+                    } else if self.at(TokenKind::LeftBrace) {
+                        // Named-field variant pattern: `Rectangle { width, height: h }`
+                        self.bump(); // {
+                        self.eat_trivia();
+                        self.parse_comma_separated(
+                            Self::parse_named_variant_pattern_field,
+                            TokenKind::RightBrace,
+                        );
+                        self.expect(TokenKind::RightBrace);
                     }
                 } else {
                     self.bump();
@@ -810,6 +819,21 @@ impl<'src> CstParser<'src> {
             self.eat_trivia();
             self.parse_pattern();
         }
+    }
+
+    /// Parse a named-field entry inside a brace-form variant pattern:
+    /// `width` (shorthand binding) or `width: h` (rename) or `width: 0` (nested).
+    fn parse_named_variant_pattern_field(&mut self) {
+        self.builder
+            .start_node(SyntaxKind::VARIANT_FIELD_PATTERN.into());
+        self.expect_ident();
+        self.eat_trivia();
+        if self.at(TokenKind::Colon) {
+            self.bump();
+            self.eat_trivia();
+            self.parse_pattern();
+        }
+        self.builder.finish_node();
     }
 
     // ── Object Literal ───────────────────────────────────────────

--- a/crates/floe-core/src/cst/items.rs
+++ b/crates/floe-core/src/cst/items.rs
@@ -409,11 +409,12 @@ impl<'src> CstParser<'src> {
         if self.at(TokenKind::LeftBrace) {
             self.parse_type_body_in_braces();
         } else if self.at(TokenKind::LeftParen) {
-            // Newtype with paren syntax: `type UserId(string)`
+            // Newtype with paren syntax: `type UserId(string)`. Fields are
+            // positional — reject `type UserId(name: string)`.
             self.builder.start_node(SyntaxKind::TYPE_DEF_UNION.into());
             self.bump(); // (
             self.eat_trivia();
-            self.parse_comma_separated(Self::parse_variant_field, TokenKind::RightParen);
+            self.parse_comma_separated(Self::parse_positional_variant_field, TokenKind::RightParen);
             self.expect(TokenKind::RightParen);
             self.builder.finish_node();
         } else {
@@ -555,17 +556,22 @@ impl<'src> CstParser<'src> {
             self.expect_ident();
             self.eat_trivia();
 
-            // Variant fields: { named } or (positional)
+            // Variant fields: `{ name: Type, ... }` (named) or `(Type, ...)` (positional).
+            // Each bracket style accepts exactly one field form — mixing them is a
+            // parse error so there is a single canonical way to write each variant.
             if self.at(TokenKind::LeftBrace) {
                 self.bump(); // {
                 self.eat_trivia();
-                self.parse_comma_separated(Self::parse_variant_field, TokenKind::RightBrace);
+                self.parse_comma_separated(Self::parse_named_variant_field, TokenKind::RightBrace);
                 self.expect(TokenKind::RightBrace);
                 self.eat_trivia();
             } else if self.at(TokenKind::LeftParen) {
                 self.bump(); // (
                 self.eat_trivia();
-                self.parse_comma_separated(Self::parse_variant_field, TokenKind::RightParen);
+                self.parse_comma_separated(
+                    Self::parse_positional_variant_field,
+                    TokenKind::RightParen,
+                );
                 self.expect(TokenKind::RightParen);
                 self.eat_trivia();
             }
@@ -598,19 +604,46 @@ impl<'src> CstParser<'src> {
         self.builder.finish_node();
     }
 
-    fn parse_variant_field(&mut self) {
+    /// Parse a positional variant field: a type with no name. Used inside
+    /// `(...)` variant declarations. If a `name:` prefix is present the user
+    /// meant a named variant, so emit a targeted error but still consume the
+    /// tokens so downstream lowering stays valid.
+    fn parse_positional_variant_field(&mut self) {
         self.builder.start_node(SyntaxKind::VARIANT_FIELD.into());
 
-        // Check if this is a named field: `name: Type`
+        if self.is_ident() && self.peek_is(TokenKind::Colon) {
+            self.error(
+                "named fields are not allowed in `(...)` variants; \
+                 use `(Type)` for positional fields or `{ name: Type }` for named fields",
+            );
+            self.bump(); // name
+            self.eat_trivia();
+            self.bump(); // :
+            self.eat_trivia();
+        }
+        self.parse_type_expr();
+
+        self.builder.finish_node();
+    }
+
+    /// Parse a named variant field: `name: Type`. Used inside `{...}` variant
+    /// declarations. If the `name:` prefix is missing the user meant a
+    /// positional variant, so emit a targeted error.
+    fn parse_named_variant_field(&mut self) {
+        self.builder.start_node(SyntaxKind::VARIANT_FIELD.into());
+
         if self.is_ident() && self.peek_is(TokenKind::Colon) {
             self.bump(); // name
             self.eat_trivia();
             self.bump(); // :
             self.eat_trivia();
-            self.parse_type_expr();
         } else {
-            self.parse_type_expr();
+            self.error(
+                "`{...}` variants require named fields; \
+                 use `{ name: Type, ... }` or switch to `(Type, ...)` for positional fields",
+            );
         }
+        self.parse_type_expr();
 
         self.builder.finish_node();
     }

--- a/crates/floe-core/src/formatter/expr.rs
+++ b/crates/floe-core/src/formatter/expr.rs
@@ -405,7 +405,20 @@ impl Formatter<'_> {
                         let name = tok.text().to_string();
                         if name.starts_with(char::is_uppercase) {
                             let mut parts = vec![pretty::str(name)];
-                            if !sub_patterns.is_empty() {
+                            let named_fields: Vec<_> = node
+                                .children()
+                                .filter(|c| c.kind() == SyntaxKind::VARIANT_FIELD_PATTERN)
+                                .collect();
+                            if !named_fields.is_empty() {
+                                parts.push(pretty::str(" { "));
+                                for (i, field) in named_fields.iter().enumerate() {
+                                    if i > 0 {
+                                        parts.push(pretty::str(", "));
+                                    }
+                                    parts.push(self.fmt_variant_field_pattern(field));
+                                }
+                                parts.push(pretty::str(" }"));
+                            } else if !sub_patterns.is_empty() {
                                 parts.push(pretty::str("("));
                                 for (i, p) in sub_patterns.iter().enumerate() {
                                     if i > 0 {
@@ -491,6 +504,26 @@ impl Formatter<'_> {
             }
         }
         pretty::nil()
+    }
+
+    /// Format one field in a brace-form variant pattern: either shorthand
+    /// (`width`) or a rename/nested pattern (`width: pat`).
+    fn fmt_variant_field_pattern(&mut self, node: &SyntaxNode) -> Document {
+        let name = node
+            .children_with_tokens()
+            .filter_map(|t| t.into_token())
+            .find(|t| t.kind() == SyntaxKind::IDENT)
+            .map(|t| t.text().to_string())
+            .unwrap_or_default();
+        let nested = node.children().find(|c| c.kind() == SyntaxKind::PATTERN);
+        match nested {
+            Some(p) => pretty::concat(vec![
+                pretty::str(name),
+                pretty::str(": "),
+                self.fmt_pattern(&p),
+            ]),
+            None => pretty::str(name),
+        }
     }
 
     // ── Binary / Unary ──────────────────────────────────────────

--- a/crates/floe-core/src/lower/pattern.rs
+++ b/crates/floe-core/src/lower/pattern.rs
@@ -183,11 +183,24 @@ impl<'src> Lowerer<'src> {
                             } else {
                                 name
                             };
-                            let fields: Vec<Pattern> = node
+                            let fields = if node
                                 .children()
-                                .filter(|c| c.kind() == SyntaxKind::PATTERN)
-                                .filter_map(|c| self.lower_pattern(&c))
-                                .collect();
+                                .any(|c| c.kind() == SyntaxKind::VARIANT_FIELD_PATTERN)
+                            {
+                                VariantPatternFields::Named(
+                                    node.children()
+                                        .filter(|c| c.kind() == SyntaxKind::VARIANT_FIELD_PATTERN)
+                                        .filter_map(|c| self.lower_variant_field_pattern(&c))
+                                        .collect(),
+                                )
+                            } else {
+                                VariantPatternFields::Positional(
+                                    node.children()
+                                        .filter(|c| c.kind() == SyntaxKind::PATTERN)
+                                        .filter_map(|c| self.lower_pattern(&c))
+                                        .collect(),
+                                )
+                            };
                             return Some(Pattern {
                                 kind: PatternKind::Variant {
                                     name: variant_name,
@@ -274,6 +287,24 @@ impl<'src> Lowerer<'src> {
         }
 
         None
+    }
+
+    /// Lower a `VARIANT_FIELD_PATTERN` node: `field` (shorthand) or
+    /// `field: pattern`. Shorthand lowers to a binding pattern on the field name.
+    fn lower_variant_field_pattern(&mut self, node: &SyntaxNode) -> Option<(String, Pattern)> {
+        let span = self.node_span(node);
+        let name = self.collect_idents_direct(node).first()?.clone();
+
+        let nested = node
+            .children()
+            .find(|c| c.kind() == SyntaxKind::PATTERN)
+            .and_then(|c| self.lower_pattern(&c))
+            .unwrap_or_else(|| Pattern {
+                kind: PatternKind::Binding(name.clone()),
+                span,
+            });
+
+        Some((name, nested))
     }
 
     pub(super) fn lower_record_pattern_fields(

--- a/crates/floe-core/src/parser/ast.rs
+++ b/crates/floe-core/src/parser/ast.rs
@@ -293,7 +293,7 @@ pub struct TypeDecl<T = ()> {
 pub enum TypeDef<T = ()> {
     /// Record type: `{ field: Type, ...OtherType, ... }`
     Record(Vec<RecordEntry<T>>),
-    /// Union type: `| Variant1 | Variant2(field: Type)`
+    /// Union type: `| Unit | Positional(Type) | Named { field: Type }`
     Union(Vec<Variant<T>>),
     /// Type alias: `type X = SomeOtherType`
     Alias(TypeExpr<T>),
@@ -722,8 +722,13 @@ pub enum PatternKind {
         start: LiteralPattern,
         end: LiteralPattern,
     },
-    /// Variant/constructor pattern: `Ok(x)`, `Network(Timeout(ms))`
-    Variant { name: String, fields: Vec<Pattern> },
+    /// Variant/constructor pattern: `Ok(x)`, `Rectangle { width, height: h }`.
+    /// The field list is either positional (parens) or named (braces) — it
+    /// must match the shape of the variant's declaration.
+    Variant {
+        name: String,
+        fields: VariantPatternFields,
+    },
     /// Record destructuring pattern: `{ x, y }` or `{ ctrl: true }`
     Record { fields: Vec<(String, Pattern)> },
     /// String pattern with captures: `"/users/{id}"` or `"/users/{id}/posts"`
@@ -744,6 +749,100 @@ pub enum PatternKind {
         /// Optional rest binding: `..rest` captures the remaining tail
         rest: Option<String>,
     },
+}
+
+/// Field list shape for a variant pattern — mirrors the declaration.
+/// Parser + checker enforce that `Positional` patterns only match variants
+/// declared as `Variant(Type, ...)` and `Named` patterns only match variants
+/// declared as `Variant { field: Type, ... }`.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum VariantPatternFields {
+    /// `Ok(x)`, `Rect(w, h)` — positional field patterns.
+    Positional(Vec<Pattern>),
+    /// `Rectangle { width, height: h }` — named field patterns. Each entry is
+    /// `(field_name, nested_pattern)`. Shorthand like `{ width }` lowers to
+    /// `("width", PatternKind::Binding("width"))`.
+    Named(Vec<(String, Pattern)>),
+}
+
+impl VariantPatternFields {
+    /// Total number of fields in the pattern, regardless of shape.
+    pub fn len(&self) -> usize {
+        match self {
+            VariantPatternFields::Positional(pats) => pats.len(),
+            VariantPatternFields::Named(fields) => fields.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Iterate over the nested patterns without the field name.
+    pub fn patterns(&self) -> impl Iterator<Item = &Pattern> {
+        VariantPatternIter::Patterns(self.entries())
+    }
+
+    /// Iterate over `(index, Option<field_name>, pattern)` entries. `Some` name
+    /// is yielded for named-shape patterns, `None` for positional. Used by
+    /// codegen to pick the runtime field accessor.
+    pub fn entries(&self) -> VariantPatternEntries<'_> {
+        match self {
+            VariantPatternFields::Positional(pats) => VariantPatternEntries::Positional {
+                inner: pats.iter().enumerate(),
+            },
+            VariantPatternFields::Named(fields) => VariantPatternEntries::Named {
+                inner: fields.iter().enumerate(),
+            },
+        }
+    }
+
+    /// Human-readable name of the shape — for error messages.
+    pub fn shape_name(&self) -> &'static str {
+        match self {
+            VariantPatternFields::Positional(_) => "positional",
+            VariantPatternFields::Named(_) => "named",
+        }
+    }
+}
+
+/// Enum-based iterator over variant pattern fields. Avoids the heap
+/// allocation a `Box<dyn Iterator>` would incur in codegen / LSP hot paths.
+pub enum VariantPatternEntries<'a> {
+    Positional {
+        inner: std::iter::Enumerate<std::slice::Iter<'a, Pattern>>,
+    },
+    Named {
+        inner: std::iter::Enumerate<std::slice::Iter<'a, (String, Pattern)>>,
+    },
+}
+
+impl<'a> Iterator for VariantPatternEntries<'a> {
+    type Item = (usize, Option<&'a str>, &'a Pattern);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            VariantPatternEntries::Positional { inner } => inner.next().map(|(i, p)| (i, None, p)),
+            VariantPatternEntries::Named { inner } => inner
+                .next()
+                .map(|(i, (name, p))| (i, Some(name.as_str()), p)),
+        }
+    }
+}
+
+/// Bare-pattern iterator that drops the index and field name. Thin wrapper
+/// around `VariantPatternEntries` so callers that only care about the nested
+/// pattern don't need to destructure the tuple.
+enum VariantPatternIter<'a> {
+    Patterns(VariantPatternEntries<'a>),
+}
+
+impl<'a> Iterator for VariantPatternIter<'a> {
+    type Item = &'a Pattern;
+    fn next(&mut self) -> Option<Self::Item> {
+        let VariantPatternIter::Patterns(entries) = self;
+        entries.next().map(|(_, _, p)| p)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/crates/floe-core/src/parser/tests.rs
+++ b/crates/floe-core/src/parser/tests.rs
@@ -496,9 +496,10 @@ fn match_nested_variant() {
         ExprKind::Match { arms, .. } => match &arms[0].pattern.kind {
             PatternKind::Variant { name, fields } => {
                 assert_eq!(name, "Network");
-                assert_eq!(fields.len(), 1);
+                let pats: Vec<&Pattern> = fields.patterns().collect();
+                assert_eq!(pats.len(), 1);
                 assert!(
-                    matches!(&fields[0].kind, PatternKind::Variant { name, .. } if name == "Timeout")
+                    matches!(&pats[0].kind, PatternKind::Variant { name, .. } if name == "Timeout")
                 );
             }
             _ => panic!("expected variant pattern"),
@@ -524,8 +525,9 @@ fn match_record_destructure() {
     match expr {
         ExprKind::Match { arms, .. } => match &arms[0].pattern.kind {
             PatternKind::Variant { fields, .. } => {
-                assert_eq!(fields.len(), 2);
-                assert!(matches!(&fields[1].kind, PatternKind::Record { .. }));
+                let pats: Vec<&Pattern> = fields.patterns().collect();
+                assert_eq!(pats.len(), 2);
+                assert!(matches!(&pats[1].kind, PatternKind::Record { .. }));
             }
             _ => panic!("expected variant"),
         },
@@ -988,6 +990,79 @@ fn opaque_type() {
             assert_eq!(decl.name, "HashedPassword");
         }
         other => panic!("expected type decl, got {other:?}"),
+    }
+}
+
+#[test]
+fn variant_named_field_in_parens_is_error() {
+    let errs = parse("type Shape { | Circle(radius: number) }").unwrap_err();
+    assert!(
+        errs.iter().any(|e| e
+            .message
+            .contains("named fields are not allowed in `(...)` variants")),
+        "expected targeted error about named-in-parens, got: {errs:?}"
+    );
+}
+
+#[test]
+fn variant_positional_field_in_braces_is_error() {
+    let errs = parse("type Shape { | Rectangle { number, number } }").unwrap_err();
+    assert!(
+        errs.iter()
+            .any(|e| e.message.contains("`{...}` variants require named fields")),
+        "expected targeted error about positional-in-braces, got: {errs:?}"
+    );
+}
+
+#[test]
+fn newtype_paren_rejects_named_field() {
+    let errs = parse("type UserId(id: string)").unwrap_err();
+    assert!(
+        errs.iter().any(|e| e
+            .message
+            .contains("named fields are not allowed in `(...)` variants")),
+        "expected targeted error for named-in-parens newtype, got: {errs:?}"
+    );
+}
+
+#[test]
+fn named_variant_pattern_parses() {
+    let expr = first_expr("match r { Rect { width, height: h } -> width + h, _ -> 0 }");
+    match expr {
+        ExprKind::Match { arms, .. } => match &arms[0].pattern.kind {
+            PatternKind::Variant { name, fields } => {
+                assert_eq!(name, "Rect");
+                match fields {
+                    VariantPatternFields::Named(named) => {
+                        assert_eq!(named.len(), 2);
+                        assert_eq!(named[0].0, "width");
+                        assert!(
+                            matches!(&named[0].1.kind, PatternKind::Binding(n) if n == "width")
+                        );
+                        assert_eq!(named[1].0, "height");
+                        assert!(matches!(&named[1].1.kind, PatternKind::Binding(n) if n == "h"));
+                    }
+                    other => panic!("expected named fields, got {other:?}"),
+                }
+            }
+            other => panic!("expected variant pattern, got {other:?}"),
+        },
+        other => panic!("expected match, got {other:?}"),
+    }
+}
+
+#[test]
+fn positional_variant_pattern_parses() {
+    let expr = first_expr("match c { Circle(r) -> r, _ -> 0 }");
+    match expr {
+        ExprKind::Match { arms, .. } => match &arms[0].pattern.kind {
+            PatternKind::Variant { name, fields } => {
+                assert_eq!(name, "Circle");
+                assert!(matches!(fields, VariantPatternFields::Positional(_)));
+            }
+            other => panic!("expected variant pattern, got {other:?}"),
+        },
+        other => panic!("expected match, got {other:?}"),
     }
 }
 

--- a/crates/floe-core/src/syntax.rs
+++ b/crates/floe-core/src/syntax.rs
@@ -125,6 +125,10 @@ pub enum SyntaxKind {
     RECORD_SPREAD,
     VARIANT,
     VARIANT_FIELD,
+    /// Field pattern inside a brace-form variant pattern:
+    /// `Rectangle { width, height: h }` → one `VARIANT_FIELD_PATTERN` per
+    /// field, each wrapping an `IDENT` and an optional `COLON PATTERN`.
+    VARIANT_FIELD_PATTERN,
     TYPE_EXPR,
     TYPE_EXPR_FUNCTION,
     TYPE_EXPR_RECORD,

--- a/crates/floe-core/tests/fixtures/positional_variants.fl
+++ b/crates/floe-core/tests/fixtures/positional_variants.fl
@@ -1,4 +1,5 @@
 // Positional variant fields — parens syntax
+
 type Shape {
     | Circle(number)
     | Rect(number, number)
@@ -6,11 +7,15 @@ type Shape {
 }
 
 // Construction
+
 const c = Circle(5)
+
 const r = Rect(10, 20)
+
 const p = Point
 
 // Pattern matching
+
 fn describe(s: Shape) -> string {
     match s {
         Circle(radius) -> `circle r=${radius}`,
@@ -22,15 +27,24 @@ fn describe(s: Shape) -> string {
 const _d = describe(c)
 
 // Mixed: positional and named in same union
+
 type Result2 {
     | Ok2(string)
     | Err2 { code: number, message: string }
 }
 
 const _ok = Ok2("hello")
+
 const _err = Err2(code: 404, message: "not found")
 
 const _msg = match _ok {
     Ok2(val) -> val,
-    Err2(code, message) -> `${code}: ${message}`,
+    Err2 { code, message } -> `${code}: ${message}`,
+}
+
+// Named-variant patterns also support renaming: `field: newName`.
+
+const _msg2 = match _err {
+    Ok2(val) -> val,
+    Err2 { code: c, message: m } -> `${c}: ${m}`,
 }

--- a/crates/floe-core/tests/snapshots/snapshot_codegen__snapshot_positional_variants.snap
+++ b/crates/floe-core/tests/snapshots/snapshot_codegen__snapshot_positional_variants.snap
@@ -23,3 +23,5 @@ const _ok = { __tag: "Ok2", value: "hello" };
 const _err = { __tag: "Err2", code: 404, message: "not found" };
 
 const _msg = _ok.__tag === "Ok2" ? (() => { const val = _ok.value; return val; })() : _ok.__tag === "Err2" ? (() => { const code = _ok.code; const message = _ok.message; return `${code}: ${message}`; })() : (() => { throw new Error("non-exhaustive match"); })();
+
+const _msg2 = _err.__tag === "Ok2" ? (() => { const val = _err.value; return val; })() : _err.__tag === "Err2" ? (() => { const c = _err.code; const m = _err.message; return `${c}: ${m}`; })() : (() => { throw new Error("non-exhaustive match"); })();

--- a/crates/floe-lsp/src/completions.rs
+++ b/crates/floe-lsp/src/completions.rs
@@ -21,7 +21,7 @@ use super::completion::{
     dot_access_completions, identifier_before_dot, import_path_completions, is_in_comment,
     is_in_import_string, is_in_string_literal, is_pipe_context, resolve_piped_type,
 };
-use super::index::{SymbolIndex, symbol_kind_to_completion};
+use super::index::{SymbolIndex, VariantShapeHint, symbol_kind_to_completion};
 use super::stdlib_hover;
 use super::{BUILTINS, FloeLsp, KEYWORDS, position_to_offset, word_prefix_at_offset};
 
@@ -112,12 +112,12 @@ impl FloeLsp {
         if let Some(variants) = detect_match_context(&doc.content, offset, &doc.index) {
             let items: Vec<CompletionItem> = variants
                 .into_iter()
-                .filter(|v| prefix.is_empty() || v.starts_with(&prefix))
-                .map(|name| CompletionItem {
+                .filter(|(name, _)| prefix.is_empty() || name.starts_with(&prefix))
+                .map(|(name, shape)| CompletionItem {
                     label: name.clone(),
                     kind: Some(CompletionItemKind::ENUM_MEMBER),
                     detail: Some("match variant".to_string()),
-                    insert_text: Some(format!("{name} -> $0,")),
+                    insert_text: Some(match_arm_snippet(&name, shape.as_ref())),
                     insert_text_format: Some(InsertTextFormat::SNIPPET),
                     ..Default::default()
                 })
@@ -251,13 +251,14 @@ fn stdlib_module_prefix(source: &str, offset: usize, registry: &StdlibRegistry) 
     }
 }
 
-/// Detect if cursor is inside a `match expr { ... }` block.
-/// If so, look up the matched expression's type and return its variant names.
+/// Detect if cursor is inside a `match expr { ... }` block. Returns each
+/// variant name alongside its shape hint — callers use the hint to build
+/// the correct insert-snippet (`Variant`, `Variant(..)`, `Variant { .. }`).
 pub(super) fn detect_match_context(
     source: &str,
     offset: usize,
     index: &SymbolIndex,
-) -> Option<Vec<String>> {
+) -> Option<Vec<(String, Option<VariantShapeHint>)>> {
     let before = &source[..offset];
 
     // Find the innermost unclosed `match ... {` before the cursor
@@ -295,9 +296,36 @@ pub(super) fn detect_match_context(
     None
 }
 
+/// Build the match-arm insert snippet for a variant, keyed off its declared
+/// shape. Unknown shape falls back to bare `Name -> $0,`.
+pub(super) fn match_arm_snippet(name: &str, shape: Option<&VariantShapeHint>) -> String {
+    match shape {
+        Some(VariantShapeHint::Unit) | None => format!("{name} -> $0,"),
+        Some(VariantShapeHint::Positional(arity)) => {
+            let placeholders = (1..=*arity)
+                .map(|i| format!("${i}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{name}({placeholders}) -> $0,")
+        }
+        Some(VariantShapeHint::Named(fields)) => {
+            let entries = fields
+                .iter()
+                .enumerate()
+                .map(|(i, f)| format!("{f}: ${}", i + 1))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{name} {{ {entries} }} -> $0,")
+        }
+    }
+}
+
 /// Given a match expression text, try to find variant names for it.
 /// Looks up the expression as a type name in the symbol index.
-fn find_variants_for_expr(expr: &str, index: &SymbolIndex) -> Vec<String> {
+fn find_variants_for_expr(
+    expr: &str,
+    index: &SymbolIndex,
+) -> Vec<(String, Option<VariantShapeHint>)> {
     // The expr could be a variable name; look for a type with the same name
     // or look for a type whose variants are in the index
     let expr = expr.trim();
@@ -307,12 +335,12 @@ fn find_variants_for_expr(expr: &str, index: &SymbolIndex) -> Vec<String> {
     for sym in &type_syms {
         if sym.kind == SymbolKind::TYPE_PARAMETER {
             // Found a type — collect its variants from the index
-            let prefix = format!("{}.", expr);
-            let variants: Vec<String> = index
+            let type_prefix = format!("{}.", expr);
+            let variants: Vec<_> = index
                 .symbols
                 .iter()
-                .filter(|s| s.kind == SymbolKind::ENUM_MEMBER && s.detail.starts_with(&prefix))
-                .map(|s| s.name.clone())
+                .filter(|s| s.kind == SymbolKind::ENUM_MEMBER && s.detail.starts_with(&type_prefix))
+                .map(|s| (s.name.clone(), s.variant_shape.clone()))
                 .collect();
             if !variants.is_empty() {
                 return variants;
@@ -322,11 +350,11 @@ fn find_variants_for_expr(expr: &str, index: &SymbolIndex) -> Vec<String> {
 
     // Strategy 2: the expr might be a variable — look for all ENUM_MEMBER symbols
     // This is a best-effort fallback
-    let all_variants: Vec<String> = index
+    let all_variants: Vec<_> = index
         .symbols
         .iter()
         .filter(|s| s.kind == SymbolKind::ENUM_MEMBER)
-        .map(|s| s.name.clone())
+        .map(|s| (s.name.clone(), s.variant_shape.clone()))
         .collect();
 
     // Only return if there are some variants to suggest

--- a/crates/floe-lsp/src/index.rs
+++ b/crates/floe-lsp/src/index.rs
@@ -44,6 +44,22 @@ pub(super) struct Symbol {
     pub(super) first_param_type: Option<Arc<Type>>,
     /// For properties: the parent type name (e.g., "User" for User.name)
     pub(super) owner_type: Option<String>,
+    /// For `ENUM_MEMBER` variants: shape of the declared field list. Drives
+    /// match-arm completion to insert the right snippet — `Variant`, `Variant(..)`,
+    /// or `Variant { .. }` — instead of always plain `Variant`.
+    pub(super) variant_shape: Option<VariantShapeHint>,
+}
+
+/// Summary of a variant declaration's field list, used by LSP completion.
+#[derive(Debug, Clone)]
+pub(super) enum VariantShapeHint {
+    /// Unit variant: no fields — `Variant`.
+    Unit,
+    /// Positional fields: `Variant(Type1, Type2)` — suggests `Variant($1, $2)`.
+    Positional(usize),
+    /// Named fields: `Variant { f1: Type1, f2: Type2 }` — suggests
+    /// `Variant { f1, f2 }`.
+    Named(Vec<String>),
 }
 
 /// Index of all symbols in a document.
@@ -115,6 +131,7 @@ fn collect_items(items: &[TypedItem], symbols: &mut Vec<Symbol>) {
                         detail: format!("import {{ {} }} from \"{}\"", spec.name, decl.source),
                         first_param_type: None,
                         owner_type: None,
+                        variant_shape: None,
                     });
                 }
             }
@@ -152,6 +169,7 @@ fn collect_items(items: &[TypedItem], symbols: &mut Vec<Symbol>) {
                     detail: format!("{vis}const {name}{type_ann}"),
                     first_param_type: None,
                     owner_type: None,
+                    variant_shape: None,
                 });
 
                 // Also index destructured names
@@ -167,6 +185,7 @@ fn collect_items(items: &[TypedItem], symbols: &mut Vec<Symbol>) {
                                 detail: format!("const {{ {n} }}"),
                                 first_param_type: None,
                                 owner_type: None,
+                                variant_shape: None,
                             });
                         }
                     }
@@ -182,6 +201,7 @@ fn collect_items(items: &[TypedItem], symbols: &mut Vec<Symbol>) {
                                 detail: format!("const {{ {n} }}"),
                                 first_param_type: None,
                                 owner_type: None,
+                                variant_shape: None,
                             });
                         }
                     }
@@ -230,6 +250,7 @@ fn collect_items(items: &[TypedItem], symbols: &mut Vec<Symbol>) {
                     ),
                     first_param_type: None,
                     owner_type: None,
+                    variant_shape: None,
                 });
 
                 for param in &decl.params {
@@ -319,6 +340,7 @@ fn collect_items(items: &[TypedItem], symbols: &mut Vec<Symbol>) {
                     detail: format!("{vis}{opaque}type {}{type_params}{body}", decl.name),
                     first_param_type: None,
                     owner_type: None,
+                    variant_shape: None,
                 });
 
                 // Index record fields
@@ -338,6 +360,7 @@ fn collect_items(items: &[TypedItem], symbols: &mut Vec<Symbol>) {
                                 ),
                                 first_param_type: None,
                                 owner_type: Some(decl.name.clone()),
+                                variant_shape: None,
                             });
                         }
                     }
@@ -355,6 +378,7 @@ fn collect_items(items: &[TypedItem], symbols: &mut Vec<Symbol>) {
                             detail: format!("{}.{}", decl.name, variant.name),
                             first_param_type: None,
                             owner_type: None,
+                            variant_shape: Some(variant_shape_from_decl(&variant.fields)),
                         });
                     }
                 }
@@ -382,6 +406,7 @@ fn collect_items(items: &[TypedItem], symbols: &mut Vec<Symbol>) {
                                 detail: format!("self: {type_str}"),
                                 first_param_type: None,
                                 owner_type: None,
+                                variant_shape: None,
                             });
                         } else {
                             push_param_symbol(param, symbols);
@@ -402,6 +427,7 @@ fn collect_items(items: &[TypedItem], symbols: &mut Vec<Symbol>) {
                     detail: format!("{vis}trait {}", decl.name),
                     first_param_type: None,
                     owner_type: None,
+                    variant_shape: None,
                 });
 
                 // Index trait methods
@@ -437,6 +463,7 @@ fn collect_items(items: &[TypedItem], symbols: &mut Vec<Symbol>) {
                         ),
                         first_param_type: None,
                         owner_type: None,
+                        variant_shape: None,
                     });
 
                     // Recurse into default method bodies
@@ -534,6 +561,7 @@ fn collect_pattern_bindings(pattern: &floe_core::parser::ast::Pattern, symbols: 
                 detail: format!("(pattern) {ty}"),
                 first_param_type: None,
                 owner_type: None,
+                variant_shape: None,
             });
         }
         PatternKind::Binding(name) if name != "_" => {
@@ -546,10 +574,11 @@ fn collect_pattern_bindings(pattern: &floe_core::parser::ast::Pattern, symbols: 
                 detail: format!("binding {name}"),
                 first_param_type: None,
                 owner_type: None,
+                variant_shape: None,
             });
         }
         PatternKind::Variant { fields, .. } => {
-            for field in fields {
+            for field in fields.patterns() {
                 collect_pattern_bindings(field, symbols);
             }
         }
@@ -572,6 +601,7 @@ fn collect_pattern_bindings(pattern: &floe_core::parser::ast::Pattern, symbols: 
                     detail: format!("binding {rest_name}"),
                     first_param_type: None,
                     owner_type: None,
+                    variant_shape: None,
                 });
             }
         }
@@ -629,6 +659,7 @@ fn push_param_symbol(param: &TypedParam, symbols: &mut Vec<Symbol>) {
         detail: format!("parameter {}{type_ann}", param.name),
         first_param_type: None,
         owner_type: None,
+        variant_shape: None,
     });
 }
 
@@ -769,6 +800,7 @@ fn for_block_function_symbol<T>(
         ),
         first_param_type,
         owner_type: None,
+        variant_shape: None,
     }
 }
 
@@ -815,5 +847,21 @@ fn enrich_symbol(
         && let Type::Function { params, .. } = ty.as_ref()
     {
         sym.first_param_type = params.first().cloned().map(Arc::new);
+    }
+}
+
+/// Summarize a variant's declared fields into a shape hint. Empty field list
+/// is a unit variant; all-named means a brace-form variant; otherwise
+/// positional. The parser rejects mixed forms, so we don't have to handle
+/// that case here.
+fn variant_shape_from_decl<T>(fields: &[VariantField<T>]) -> VariantShapeHint {
+    if fields.is_empty() {
+        return VariantShapeHint::Unit;
+    }
+    let names: Vec<String> = fields.iter().filter_map(|f| f.name.clone()).collect();
+    if names.len() == fields.len() {
+        VariantShapeHint::Named(names)
+    } else {
+        VariantShapeHint::Positional(fields.len())
     }
 }

--- a/crates/floe-lsp/src/tests.rs
+++ b/crates/floe-lsp/src/tests.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use super::completion::*;
 use super::completions::{
     detect_match_context, is_in_jsx_tag, jsx_attribute_completions, lambda_event_completions,
+    match_arm_snippet,
 };
 use super::goto_def::import_path_at_offset;
 use super::index::*;
@@ -700,7 +701,7 @@ fn match_context_detects_variants() {
     let offset = editor_source.len();
     let variants = detect_match_context(editor_source, offset, &index);
     assert!(variants.is_some(), "should detect match context");
-    let names = variants.unwrap();
+    let names: Vec<_> = variants.unwrap().into_iter().map(|(n, _)| n).collect();
     assert!(names.contains(&"Red".to_string()));
     assert!(names.contains(&"Green".to_string()));
     assert!(names.contains(&"Blue".to_string()));
@@ -717,6 +718,38 @@ fn match_context_not_detected_outside_match() {
     assert!(
         variants.is_none(),
         "should not detect match context outside match block"
+    );
+}
+
+#[test]
+fn match_context_emits_shape_aware_snippets() {
+    let source = r#"
+type Shape {
+    | Unit
+    | Circle(number)
+    | Rect(number, number)
+    | Rectangle { width: number, height: number }
+}
+"#;
+    let (index, _) = build_index_and_types(source);
+    let editor_source = format!("{source}match s {{\n    ");
+    let offset = editor_source.len();
+    let variants: Vec<_> = detect_match_context(&editor_source, offset, &index)
+        .expect("match context")
+        .into_iter()
+        .collect();
+
+    let by_name = |name: &str| {
+        let (n, shape) = variants.iter().find(|(n, _)| n == name).expect(name);
+        match_arm_snippet(n, shape.as_ref())
+    };
+
+    assert_eq!(by_name("Unit"), "Unit -> $0,");
+    assert_eq!(by_name("Circle"), "Circle($1) -> $0,");
+    assert_eq!(by_name("Rect"), "Rect($1, $2) -> $0,");
+    assert_eq!(
+        by_name("Rectangle"),
+        "Rectangle { width: $1, height: $2 } -> $0,"
     );
 }
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -68,7 +68,7 @@ All four of TypeScript's `?` uses (`?.`, `??`, `?:`, `? :`) are removed. `?` now
 | `?` operator | `fetchUser(id)?` | early return on Err/None |
 | Newtypes | `type UserId(string)` | `string` at runtime (single-variant wrapper) |
 | Opaque types | `opaque type HashedPw(string)` | `string`, but only the defining module can create/read |
-| Tagged unions | `type Route { \| Home \| Profile(string) }` | discriminated union (positional or named fields) |
+| Tagged unions | `type Route { \| Home \| Profile(string) \| Settings { tab: string } }` | discriminated union. `(Type, ...)` variants are positional; `{ name: Type, ... }` variants are named. Mixing the two forms in one variant is a parse error. |
 | String literal unions | `type Method = "GET" \| "POST" \| "PUT"` | `"GET" \| "POST" \| "PUT"` (pass-through for npm interop) |
 | Nested unions | `type ApiError { \| Network(NetworkError) \| NotFound }` | nested discriminated union (compiler generates tags) |
 | Multi-depth match | `Network(Timeout(ms)) -> ...` | nested if/else with tag checks |
@@ -617,42 +617,44 @@ type AppError {
 Match at any depth in one expression. Mix shallow and deep arms freely.
 
 ```floe
-// Level 1 — broad categories
+// Level 1 — broad categories. Named variants still need to use `{ ... }` even
+// when destructuring is unneeded; fields bind to wildcards.
 match error {
-  Network(_)        -> "Connection problem"
-  Validation(_)     -> "Invalid input"
-  Auth(_)           -> "Access denied"
-  NotFound          -> "Not found"
-  ServerError(_, _) -> "Server broke"
+  Network(_)                          -> "Connection problem"
+  Validation(_)                       -> "Invalid input"
+  Auth(_)                             -> "Access denied"
+  NotFound                            -> "Not found"
+  ServerError { status: _, body: _ }  -> "Server broke"
 }
 
-// Level 2 — drill into sub-variants
+// Level 2 — drill into sub-variants. Pattern shape follows the declaration:
+// `Network(NetworkError)` is positional; `Timeout { ms: number }` is named.
 match error {
-  Network(Timeout(ms))         -> `Timed out after ${ms}ms`
-  Network(DnsFailure(host))    -> `Can't resolve ${host}`
-  Network(ConnectionRefused(_)) -> "Server not running"
-  Auth(TokenExpired(_))        -> "Session expired, please log in again"
-  Auth(_)                      -> "Access denied"
-  Validation(e)                -> describeValidation(e)
-  NotFound                     -> "Not found"
-  ServerError(s, _)            -> `Server error ${s}`
+  Network(Timeout { ms })         -> `Timed out after ${ms}ms`
+  Network(DnsFailure { host })    -> `Can't resolve ${host}`
+  Network(ConnectionRefused(_))   -> "Server not running"
+  Auth(TokenExpired(_))           -> "Session expired, please log in again"
+  Auth(_)                         -> "Access denied"
+  Validation(e)                   -> describeValidation(e)
+  NotFound                        -> "Not found"
+  ServerError { status, body }    -> `Server error ${status}: ${body}`
 }
 
 // Level 3+ — deep nested matching
 match appError {
-  User(Http(Network(Timeout(ms)))) ->
+  User(Http(Network(Timeout { ms }))) ->
     `User fetch timed out after ${ms}ms`
 
-  User(Http(Decode(MissingField(f)))) ->
+  User(Http(Decode(MissingField { name: f }))) ->
     `API response missing field: ${f}`
 
-  Payment(InsufficientFunds(needed, have)) ->
-    `Need $${needed} but only have $${have}`
+  Payment(InsufficientFunds { needed, available }) ->
+    `Need $${needed} but only have $${available}`
 
-  Payment(CardDeclined(reason)) ->
+  Payment(CardDeclined { reason }) ->
     `Card declined: ${reason}`
 
-  Auth(TokenExpired(_)) ->
+  Auth(TokenExpired { expiredAt: _ }) ->
     refreshToken()
 
   _ -> showGenericError(appError)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -82,6 +82,8 @@ type UpdateUser {
 
 // Union type (discriminated)
 // Positional fields use ( ), named fields use { }
+// Variant fields: `(Type, ...)` is positional-only (no field names);
+// `{ name: Type, ... }` is named-only. Mixing the two forms is a parse error.
 type Route {
     | Home
     | Profile(string)
@@ -243,11 +245,14 @@ const data = input |>? JSON.parse                // pipe parse, unwrap Result
 ## Match Expressions
 
 ```floe
-// Match on union types (exhaustive)
+// Variant pattern shape must match declaration:
+//   `Variant(...)` variants → `Variant(pat, ...)` patterns
+//   `Variant { ... }` variants → `Variant { field, ... }` or `{ field: pat }` patterns
+// Mixing is a compile error.
 match route {
     Home -> <HomePage />,
-    Profile(id) -> <ProfilePage id={id} />,
-    Settings(tab) -> <SettingsPage tab={tab} />,
+    Profile(id) -> <ProfilePage id={id} />,        // Profile(string) — positional
+    Settings { tab } -> <SettingsPage tab={tab} />, // Settings { tab: string } — named
     NotFound -> <NotFoundPage />,
 }
 

--- a/docs/site/src/content/docs/docs/guide/pattern-matching.md
+++ b/docs/site/src/content/docs/docs/guide/pattern-matching.md
@@ -36,11 +36,35 @@ match findItem(id) {
 
 ## Union Types
 
+A variant's field shape — `(...)` for positional, `{ ... }` for named — is part of its contract. Pattern matching must use the same shape.
+
+### Named-field variants
+
 ```floe
 type Shape {
   | Circle { radius: number }
   | Rectangle { width: number, height: number }
   | Triangle { base: number, height: number }
+}
+
+fn area(shape: Shape) -> number {
+  match shape {
+    Circle { radius } -> 3.14159 * radius * radius,
+    Rectangle { width, height } -> width * height,
+    Triangle { base, height: h } -> 0.5 * base * h,
+  }
+}
+```
+
+Inside a named pattern, `{ width }` is shorthand for `{ width: width }`. Use `{ width: w }` to rebind under a different name.
+
+### Positional-field variants
+
+```floe
+type Shape {
+  | Circle(number)
+  | Rectangle(number, number)
+  | Triangle(number, number)
 }
 
 fn area(shape: Shape) -> number {
@@ -52,7 +76,9 @@ fn area(shape: Shape) -> number {
 }
 ```
 
-Adding a new variant to `Shape` without updating the `match` is a compile error.
+Pick the shape based on whether the fields carry meaningful names. Using the wrong pattern shape — `Circle { radius: r }` on a positional variant, or `Rectangle(w, h)` on a named variant — is a compile error.
+
+Adding a new variant to `Shape` without updating the `match` is also a compile error.
 
 ## Range Patterns
 

--- a/editors/neovim/queries/floe/highlights.scm
+++ b/editors/neovim/queries/floe/highlights.scm
@@ -94,8 +94,14 @@
 (variant
   name: (type_identifier) @constructor)
 
+(variant_field
+  name: (identifier) @property)
+
 (variant_pattern
   name: (type_identifier) @constructor)
+
+(variant_field_pattern
+  name: (identifier) @property)
 
 (variant_expression
   variant: (type_identifier) @constructor)

--- a/editors/tree-sitter-floe/grammar.js
+++ b/editors/tree-sitter-floe/grammar.js
@@ -189,14 +189,19 @@ module.exports = grammar({
       prec.right(1, seq(
         field("name", $.type_identifier),
         optional(choice(
+          // Named-field variants: `{ field: Type, ... }`
           seq("{", commaSep1($.variant_field), "}"),
+          // Positional variants: `(Type, ...)` — no field names
           seq("(", commaSep1($._type_expression), ")"),
         )),
       )),
 
+    // Named field inside a brace-form variant. The name is required — the
+    // Floe parser rejects type-only fields inside `{ ... }` variants.
     variant_field: ($) =>
       seq(
-        optional(seq(field("name", $.identifier), ":")),
+        field("name", $.identifier),
+        ":",
         field("type", $._type_expression),
       ),
 
@@ -464,7 +469,18 @@ module.exports = grammar({
     variant_pattern: ($) =>
       seq(
         field("name", $.type_identifier),
-        optional(seq("(", commaSep1($._pattern), ")")),
+        optional(choice(
+          // Positional: `Variant(pat, ...)`
+          seq("(", commaSep1($._pattern), ")"),
+          // Named: `Variant { field, field: pat, ... }`
+          seq("{", commaSep1($.variant_field_pattern), "}"),
+        )),
+      ),
+
+    variant_field_pattern: ($) =>
+      seq(
+        field("name", $.identifier),
+        optional(seq(":", field("pattern", $._pattern))),
       ),
 
     literal_pattern: ($) =>

--- a/editors/tree-sitter-floe/queries/highlights.scm
+++ b/editors/tree-sitter-floe/queries/highlights.scm
@@ -94,8 +94,14 @@
 (variant
   name: (type_identifier) @constructor)
 
+(variant_field
+  name: (identifier) @property)
+
 (variant_pattern
   name: (type_identifier) @constructor)
+
+(variant_field_pattern
+  name: (identifier) @property)
 
 (variant_expression
   variant: (type_identifier) @constructor)

--- a/examples/store/src/errors.fl
+++ b/examples/store/src/errors.fl
@@ -5,16 +5,16 @@ import { ApiError, for Display } from "./types"
 export for ApiError: Display {
     fn display(self) -> string {
         self |> match {
-            Network(Timeout(ms)) -> `Request timed out after ${ms}ms`,
-            Network(DnsFailure(host)) -> `Cannot resolve ${host}`,
+            Network(Timeout { ms }) -> `Request timed out after ${ms}ms`,
+            Network(DnsFailure { host }) -> `Cannot resolve ${host}`,
             Network(ConnectionRefused) -> "Server is not responding",
-            NotFound(id) -> `Product #${id} not found`,
-            BadResponse(status, _) -> status |> match {
+            NotFound { id } -> `Product #${id} not found`,
+            BadResponse { status, body: _ } -> status |> match {
                 400..499 -> `Client error (${status})`,
                 500..599 -> `Server error (${status})`,
                 s -> `Unexpected status ${s}`,
             },
-            ParseError(msg) -> `Invalid response: ${msg}`,
+            ParseError { message } -> `Invalid response: ${message}`,
         }
     }
 }
@@ -23,7 +23,7 @@ for ApiError {
     export fn isRetryable(self) -> boolean {
         self |> match {
             Network(_) -> true,
-            BadResponse(status, _) -> status |> match {
+            BadResponse { status, body: _ } -> status |> match {
                 429 -> true,
                 500..599 -> true,
                 _ -> false,

--- a/examples/store/src/pages/cart.fl
+++ b/examples/store/src/pages/cart.fl
@@ -93,9 +93,9 @@ fn OrderSummary(
         >
             {props.orderStatus |> match {
                 Pending -> "Checkout",
-                Confirmed(OrderId(n)) -> `Order #${n} confirmed!`,
-                Shipped(tracking) -> `Shipped: ${tracking}`,
-                Failed(reason) -> `Failed: ${reason}`,
+                Confirmed { orderId: OrderId(n) } -> `Order #${n} confirmed!`,
+                Shipped { tracking } -> `Shipped: ${tracking}`,
+                Failed { reason } -> `Failed: ${reason}`,
             }}
         </button>
     </div>

--- a/examples/store/src/product.fl
+++ b/examples/store/src/product.fl
@@ -120,9 +120,9 @@ export fn matchesPrice(product: Product, range: PriceRange) -> boolean {
         p when range == Under(25) -> p < 25,
         p -> match range {
             Any -> true,
-            Under(max) -> p < max,
-            Between(min, max) -> p >= min && p < max,
-            Over(min) -> p >= min,
+            Under { max } -> p < max,
+            Between { min, max } -> p >= min && p < max,
+            Over { min } -> p >= min,
         },
     }
 }

--- a/examples/todo-app/src/todo.fl
+++ b/examples/todo-app/src/todo.fl
@@ -50,7 +50,7 @@ for Array<Todo> {
 
 fn toResult(v: Validation) -> Result<string, string> {
     match v {
-        Valid(text) -> Ok(text),
+        Valid { text } -> Ok(text),
         TooShort -> Err("Text too short"),
         TooLong -> Err("Text too long"),
         Empty -> Err("Text is empty"),

--- a/tests/lsp/fixtures.py
+++ b/tests/lsp/fixtures.py
@@ -31,7 +31,7 @@ fn describeColor(c: Color) -> string {
     match c {
         Red -> "red",
         Green -> "green",
-        Blue(hex) -> `blue: ${hex}`,
+        Blue { hex } -> `blue: ${hex}`,
     }
 }
 """
@@ -110,7 +110,7 @@ type Product {
 
 type Status {
     | Active
-    | Inactive(reason: string)
+    | Inactive { reason: string }
 }
 
 type HttpMethod = "GET" | "POST" | "PUT" | "DELETE"
@@ -151,8 +151,8 @@ const (name, age) = getPair()
 
 HOVER_MATCH_BINDING = """\
 type Shape {
-    | Circle(radius: number)
-    | Rect(width: number, height: number)
+    | Circle(number)
+    | Rect(number, number)
 }
 
 fn area(s: Shape) -> number {
@@ -221,8 +221,8 @@ type Inner {
 
 fn describe(o: Outer) -> string {
     match o {
-        A(inner) -> match inner {
-            X(val) -> `x: ${val}`,
+        A { inner } -> match inner {
+            X { val } -> `x: ${val}`,
             Y -> "y",
         },
         B -> "b",
@@ -755,14 +755,14 @@ type NetworkError {
 }
 
 type ApiError {
-    | Network { NetworkError }
+    | Network(NetworkError)
     | NotFound
 }
 
 fn describe(e: ApiError) -> string {
     match e {
-        Network(Timeout(ms)) -> `timeout: ${ms}`,
-        Network(DnsFailure(host)) -> `dns: ${host}`,
+        Network(Timeout { ms }) -> `timeout: ${ms}`,
+        Network(DnsFailure { host }) -> `dns: ${host}`,
         NotFound -> "not found",
     }
 }
@@ -782,7 +782,7 @@ fn describe(c: Color) -> string {
     match c {
         Red -> "red",
         Green -> "green",
-        Blue(hex) -> `blue: ${hex}`,
+        Blue { hex } -> `blue: ${hex}`,
     }
 }
 """


### PR DESCRIPTION
closes #1135

Variant fields split into two shapes that must not mix:

- `Variant(Type, ...)` is positional; patterns are `Variant(pat, ...)`.
- `Variant { field: Type, ... }` is named; patterns are `Variant { field, ... }` or `Variant { field: pat, ... }`.

The parser rejects named fields in `(...)` and type-only fields in `{...}` at parse time with a targeted error. The checker rejects shape mismatches between a pattern and its declared variant at match-check time. LSP match-arm completion now inserts the correct snippet for each shape.

## Summary of changes

**Declaration side (parser):**
- Split `parse_variant_field` into `parse_positional_variant_field` + `parse_named_variant_field` in `cst/items.rs`. Each emits a targeted error when the wrong form is used.
- Applies to union variants (`| Foo(T)` / `| Foo { f: T }`) and to the paren newtype form (`type UserId(string)`).

**Pattern side:**
- New `VARIANT_FIELD_PATTERN` syntax kind + CST parser branch for `Variant { field, field: pat }` in `cst/exprs.rs`.
- `PatternKind::Variant` now carries `fields: VariantPatternFields` (`Positional` / `Named`) instead of `Vec<Pattern>`. Helpers: `len`, `is_empty`, `patterns()`, `entries()`, `shape_name()`.
- Lowerer, checker, codegen, formatter, and LSP all branch on shape.
- Checker looks up the declared variant via the union's type name in `O(1)` and errors on shape mismatch (`check_variant_pattern_shape`) before recursing into field patterns.

**LSP:**
- `Symbol.variant_shape: Option<VariantShapeHint>` so completion knows each variant's declared shape.
- `match_arm_snippet` produces `Unit -> \$0,`, `Circle(\$1) -> \$0,`, or `Rectangle { width: \$1, height: \$2 } -> \$0,` based on declaration.

**Docs + grammars:**
- `docs/design.md`, `docs/llms.txt`, and `docs/site/docs/guide/pattern-matching.md` spell out the rule and the two forms.
- `editors/tree-sitter-floe/grammar.js` + `queries/highlights.scm` + neovim mirror add `variant_field_pattern` and a `variant_field` name highlight.

**Migrations:**
- `examples/store/src/pages/cart.fl` — `Confirmed`/`Shipped`/`Failed` match arms switched to brace form.
- `crates/floe-core/tests/fixtures/positional_variants.fl` + snapshot.
- `tests/lsp/fixtures.py` — 7 pattern migrations (Blue, A/X, Network chain, etc.).

## Test plan

- [x] `cargo test --workspace` — 1436 lib + 98 CST + 33 codegen snapshot + 29 error snapshot + 99 LSP = all pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `python3 -m pytest tests/lsp/ --floe-bin=./target/debug/floe` — 236 passed
- [x] `floe fmt --check` / `floe check` / `floe build` on both example apps
- [x] End-to-end CLI test: both `Circle(radius: number)` (named-in-parens) and `Rectangle { number, number }` (positional-in-braces) produce targeted errors with correct spans.
- [x] End-to-end CLI test: both pattern shape mismatches error with `E039`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)