### PR TITLE
fix: [#1174] allow PascalCase field names in record type declarations

### DIFF
--- a/crates/floe-core/src/cst/items.rs
+++ b/crates/floe-core/src/cst/items.rs
@@ -464,25 +464,27 @@ impl<'src> CstParser<'src> {
                 self.parse_record_fields();
                 self.builder.finish_node();
             }
+            Some(TokenKind::Identifier(_))
+                if self.peek_inside_brace_second() == Some(TokenKind::Colon) =>
+            {
+                // Record field: `name: Type`, regardless of case. PascalCase
+                // field names are common in TS interop (Hono's `Bindings`,
+                // React props forwarded by name, etc.).
+                self.builder.start_node(SyntaxKind::TYPE_DEF_RECORD.into());
+                self.parse_record_fields();
+                self.builder.finish_node();
+            }
             Some(TokenKind::Identifier(name)) if name.starts_with(char::is_lowercase) => {
-                // Peek further: if followed by `:`, it's a record field.
-                // Otherwise it's a newtype (e.g. `type OrderId { number }`)
-                if self.peek_inside_brace_second() == Some(TokenKind::Colon) {
-                    self.builder.start_node(SyntaxKind::TYPE_DEF_RECORD.into());
-                    self.parse_record_fields();
-                    self.builder.finish_node();
-                } else {
-                    // Newtype wrapping a lowercase type like `number`, `string`, `boolean`
-                    self.builder.start_node(SyntaxKind::TYPE_DEF_UNION.into());
-                    self.bump(); // {
-                    self.eat_trivia();
-                    self.builder.start_node(SyntaxKind::VARIANT_FIELD.into());
-                    self.parse_type_expr();
-                    self.builder.finish_node();
-                    self.eat_trivia();
-                    self.expect(TokenKind::RightBrace);
-                    self.builder.finish_node();
-                }
+                // Newtype wrapping a lowercase type like `number`, `string`, `boolean`
+                self.builder.start_node(SyntaxKind::TYPE_DEF_UNION.into());
+                self.bump(); // {
+                self.eat_trivia();
+                self.builder.start_node(SyntaxKind::VARIANT_FIELD.into());
+                self.parse_type_expr();
+                self.builder.finish_node();
+                self.eat_trivia();
+                self.expect(TokenKind::RightBrace);
+                self.builder.finish_node();
             }
             Some(TokenKind::RightBrace) => {
                 // Empty record: `type Foo {}`

--- a/crates/floe-core/src/parser/tests.rs
+++ b/crates/floe-core/src/parser/tests.rs
@@ -885,6 +885,55 @@ fn type_record() {
 }
 
 #[test]
+fn type_record_pascal_case_fields() {
+    match first_item("type HonoEnv { Bindings: Env, Variables: Vars }") {
+        ItemKind::TypeDecl(decl) => {
+            assert_eq!(decl.name, "HonoEnv");
+            match decl.def {
+                TypeDef::Record(ref entries) => {
+                    assert_eq!(entries.len(), 2);
+                    assert_eq!(entries[0].as_field().unwrap().name, "Bindings");
+                    assert_eq!(entries[1].as_field().unwrap().name, "Variables");
+                }
+                ref other => panic!("expected record, got {other:?}"),
+            }
+        }
+        other => panic!("expected type decl, got {other:?}"),
+    }
+}
+
+#[test]
+fn type_record_mixed_case_fields() {
+    match first_item("type X { DB: string, fooBar: number, BAZ: boolean }") {
+        ItemKind::TypeDecl(decl) => match decl.def {
+            TypeDef::Record(ref entries) => {
+                assert_eq!(entries.len(), 3);
+                assert_eq!(entries[0].as_field().unwrap().name, "DB");
+                assert_eq!(entries[1].as_field().unwrap().name, "fooBar");
+                assert_eq!(entries[2].as_field().unwrap().name, "BAZ");
+            }
+            ref other => panic!("expected record, got {other:?}"),
+        },
+        other => panic!("expected type decl, got {other:?}"),
+    }
+}
+
+#[test]
+fn type_newtype_with_pascal_wrapper_still_works() {
+    // `type Foo { Bar }` (no colon) remains a newtype wrapping `Bar`.
+    match first_item("type OrderId { Number }") {
+        ItemKind::TypeDecl(decl) => {
+            assert_eq!(decl.name, "OrderId");
+            assert!(
+                !matches!(decl.def, TypeDef::Record(_)),
+                "should not be a record (no colon after field)",
+            );
+        }
+        other => panic!("expected type decl, got {other:?}"),
+    }
+}
+
+#[test]
 fn type_record_with_spread() {
     match first_item("type B { ...A, extra: string }") {
         ItemKind::TypeDecl(decl) => {


### PR DESCRIPTION
closes #1174

## Summary

The type-body disambiguator at `crates/floe-core/src/cst/items.rs` only recognized records when the first field name started with a lowercase letter. PascalCase keys common in TS interop — Hono's `Bindings` / `Variables`, React prop tables, anything bridged from a JS library that uses capitalized object keys — fell through to the newtype-wrapper arm and produced a confusing `expected RightBrace, found Some(Colon)` parse error.

Fix: treat any `Identifier` followed by `:` as a record field. The lowercase-without-colon path that enables newtype wrappers like `type OrderId { number }` is preserved.

## Test plan

- [x] `cargo test -p floe-core --lib` (all 1448 tests pass)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] New parser tests: `type_record_pascal_case_fields`, `type_record_mixed_case_fields`, `type_newtype_with_pascal_wrapper_still_works`
- [x] End-to-end: `type Bindings { DB: string }` + `Bindings(DB: "d1")` checks and compiles to idiomatic TypeScript
- [x] Example apps (todo-app, store) still pass `floe fmt` + `check` + `build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)