### PR TITLE
fix: [#1175] accept inline object-type literals as type arguments

### DIFF
--- a/crates/floe-core/src/cst.rs
+++ b/crates/floe-core/src/cst.rs
@@ -212,11 +212,23 @@ impl<'src> CstParser<'src> {
     /// Looks ahead for balanced `<>` followed by `(`.
     fn is_generic_call(&self) -> bool {
         let mut depth = 0;
+        let mut brace_depth = 0;
         let mut i = self.pos; // at `<`
         while i < self.tokens.len() {
             match &self.tokens[i].kind {
-                TokenKind::LessThan => depth += 1,
-                TokenKind::GreaterThan => {
+                // Inline object-type literals (e.g. `foo<{ k: T }>()`) are valid
+                // type arguments. Track brace nesting so `<` / `>` inside braces
+                // (nested generics like `foo<{ k: Map<K, V> }>()`) don't shift
+                // the outer angle counter.
+                TokenKind::LeftBrace => brace_depth += 1,
+                TokenKind::RightBrace => {
+                    if brace_depth == 0 {
+                        return false;
+                    }
+                    brace_depth -= 1;
+                }
+                TokenKind::LessThan if brace_depth == 0 => depth += 1,
+                TokenKind::GreaterThan if brace_depth == 0 => {
                     depth -= 1;
                     if depth == 0 {
                         // Check if the next non-trivia token is `(`
@@ -228,11 +240,8 @@ impl<'src> CstParser<'src> {
                             && self.tokens[i].kind == TokenKind::LeftParen;
                     }
                 }
-                // These tokens can't appear in type arguments
-                TokenKind::LeftBrace
-                | TokenKind::RightBrace
-                | TokenKind::Semicolon
-                | TokenKind::Equal => return false,
+                // Outside of braces, these tokens end any plausible type-arg list.
+                TokenKind::Semicolon | TokenKind::Equal if brace_depth == 0 => return false,
                 _ => {}
             }
             i += 1;

--- a/crates/floe-core/src/parser/tests.rs
+++ b/crates/floe-core/src/parser/tests.rs
@@ -1327,6 +1327,72 @@ fn generic_type() {
     }
 }
 
+// ── Generic Call: object-type literal as type argument ──────
+
+#[test]
+fn generic_call_with_object_type_literal() {
+    // Regression for #1175: `foo<{ field: T }>()` was parsed as comparison
+    // (`foo < { field: T } > ()`) because `is_generic_call` bailed on any `{`.
+    let expr = first_expr("foo<{ bindings: Env }>()");
+    match expr {
+        ExprKind::Call {
+            type_args, args, ..
+        } => {
+            assert_eq!(type_args.len(), 1);
+            assert!(
+                matches!(type_args[0].kind, TypeExprKind::Record { .. }),
+                "expected record type arg, got {:?}",
+                type_args[0].kind,
+            );
+            assert!(args.is_empty());
+        }
+        other => panic!("expected Call, got {other:?}"),
+    }
+}
+
+#[test]
+fn generic_call_with_nested_object_type_literal() {
+    let expr = first_expr("foo<{ outer: { inner: number } }>()");
+    assert!(matches!(expr, ExprKind::Call { .. }));
+}
+
+#[test]
+fn generic_call_with_multiple_type_args_including_object() {
+    let expr = first_expr(r#"foo<string, { k: number }>()"#);
+    match expr {
+        ExprKind::Call { type_args, .. } => {
+            assert_eq!(type_args.len(), 2);
+            assert!(matches!(type_args[1].kind, TypeExprKind::Record { .. }));
+        }
+        other => panic!("expected Call, got {other:?}"),
+    }
+}
+
+#[test]
+fn generic_call_with_named_type_arg_still_works() {
+    let expr = first_expr("foo<Env>()");
+    match expr {
+        ExprKind::Call { type_args, .. } => {
+            assert_eq!(type_args.len(), 1);
+            assert!(matches!(type_args[0].kind, TypeExprKind::Named { .. }));
+        }
+        other => panic!("expected Call, got {other:?}"),
+    }
+}
+
+#[test]
+fn comparison_followed_by_block_is_not_generic_call() {
+    // `f < x > { ... }` is not a generic call — no `(` after the `>`.
+    // The `{` after `>` disambiguates.
+    let input = r#"
+fn check() -> boolean {
+    const r = f < x
+    r
+}
+"#;
+    parse_ok(input);
+}
+
 // ── Full program ─────────────────────────────────────────────
 
 #[test]

--- a/crates/floe-core/src/parser/tests.rs
+++ b/crates/floe-core/src/parser/tests.rs
@@ -1331,8 +1331,6 @@ fn generic_type() {
 
 #[test]
 fn generic_call_with_object_type_literal() {
-    // Regression for #1175: `foo<{ field: T }>()` was parsed as comparison
-    // (`foo < { field: T } > ()`) because `is_generic_call` bailed on any `{`.
     let expr = first_expr("foo<{ bindings: Env }>()");
     match expr {
         ExprKind::Call {
@@ -1369,7 +1367,7 @@ fn generic_call_with_multiple_type_args_including_object() {
 }
 
 #[test]
-fn generic_call_with_named_type_arg_still_works() {
+fn generic_call_with_named_type_arg() {
     let expr = first_expr("foo<Env>()");
     match expr {
         ExprKind::Call { type_args, .. } => {


### PR DESCRIPTION
closes #1175

## Summary

`is_generic_call` at `crates/floe-core/src/cst.rs` returned `false` the moment it saw `LeftBrace` inside the angle brackets, so `foo<{ bindings: Env }>()` was parsed as `foo < { bindings: Env } > ()` — a chain of comparisons. That routed the object literal through the value-expression parser and the checker flagged the inner `Env` identifier with `E046: \`Env\` is a type, not a value`.

Track brace depth separately from angle depth. Inside a balanced `{ ... }`:
- `<` / `>` no longer affect the outer angle counter — nested generics (e.g. `foo<{ k: Map<K, V> }>()`) stay balanced
- `;` / `=` no longer bail — record-field defaults don't prematurely disqualify

An unmatched `}` still fails the heuristic. The final `>` at angle-depth zero still requires `(` to follow, so `f < x > { ... }` (comparison + block) remains a comparison.

## Test plan

- [x] `cargo test -p floe-core --lib` — all 1453 tests pass (4 new parser tests + 1 regression test)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] New tests:
  - `generic_call_with_object_type_literal` — the E046 repro
  - `generic_call_with_nested_object_type_literal` — `{ outer: { inner: T } }`
  - `generic_call_with_multiple_type_args_including_object` — mixed named and object args
  - `generic_call_with_named_type_arg_still_works` — regression for plain `foo<Env>()`
  - `comparison_followed_by_block_is_not_generic_call` — `f < x` without `()` must stay a comparison
- [x] End-to-end: `foo<{ bindings: Env }>()` checks and compiles clean
- [x] Example apps (todo-app, store) still pass `floe fmt` + `check` + `build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)