### PR TITLE
feat: [#1179] ship @floeorg/hono shim and fix pipe resolution precedence

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -28,6 +28,11 @@
         },
         {
           "type": "json",
+          "path": "integrations/hono/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "editors/vscode/package.json",
           "jsonpath": "$.version"
         }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,12 @@ jobs:
           pnpm build
           npx npm@latest publish --access public --provenance
 
+      - name: Build and publish Hono shim
+        working-directory: integrations/hono
+        run: |
+          pnpm build
+          npx npm@latest publish --access public --provenance
+
   publish-extension:
     name: Publish VS Code Extension
     needs: release

--- a/crates/floe-core/src/codegen/tests.rs
+++ b/crates/floe-core/src/codegen/tests.rs
@@ -347,6 +347,47 @@ fn pipe_chained() {
     assert_eq!(emit("a |> f |> g"), "g(f(a));");
 }
 
+#[test]
+fn pipe_local_fn_shadows_stdlib_template() {
+    // A locally defined `map` must win over the Array.map stdlib template.
+    // Imports feed the same `local_names` set, so this also covers trusted
+    // imports — the unit test avoids the npm resolver round-trip.
+    let src = r#"
+fn map(arr: Array<number>, f: (number) -> number) -> Array<number> { arr }
+const _items = [1, 2, 3] |> map((x) => x + 1)
+"#;
+    let out = emit_typed(src);
+    assert!(
+        out.contains("map([1, 2, 3]"),
+        "expected local `map` call, got:\n{out}"
+    );
+    assert!(
+        !out.contains("[1, 2, 3].map"),
+        "local `map` should not be routed through Array.map template:\n{out}"
+    );
+}
+
+#[test]
+fn pipe_local_fn_named_get_shadows_record_get() {
+    // `get` is one of the stdlib names most likely to collide with
+    // imports (Record.get / Map.get / Http.get). A local definition must
+    // still win.
+    let src = r#"
+type Router { path: string }
+fn get(r: Router, path: string) -> Router { Router(path: path) }
+const _r = Router(path: "/") |> get("/hello")
+"#;
+    let out = emit_typed(src);
+    assert!(
+        out.contains("get({"),
+        "expected local `get` call, got:\n{out}"
+    );
+    assert!(
+        !out.contains(".has("),
+        "local `get` should not be routed through Record.get template:\n{out}"
+    );
+}
+
 // ── Pipe into Match ─────────────────────────────────────────
 
 #[test]

--- a/crates/floe-core/src/codegen/typescript/pipes.rs
+++ b/crates/floe-core/src/codegen/typescript/pipes.rs
@@ -96,9 +96,11 @@ impl<'a> TypeScriptGenerator<'a> {
         extra_args: &[TypedArg],
     ) -> Option<String> {
         if let ExprKind::Identifier(name) = &callee.kind {
-            if self.ctx.local_names.contains(name.as_str())
-                && self.ctx.stdlib.lookup_by_name(name).is_empty()
-            {
+            // Local definitions and imports (trusted or otherwise) shadow
+            // stdlib pipe templates. Without this, `import trusted { get }`
+            // still routes `x |> get(...)` through `Record.get` / `Map.get`
+            // codegen instead of calling the imported function.
+            if self.ctx.local_names.contains(name.as_str()) {
                 return None;
             }
 

--- a/crates/floe-core/tests/snapshots/snapshot_codegen__snapshot_partial_application.snap
+++ b/crates/floe-core/tests/snapshots/snapshot_codegen__snapshot_partial_application.snap
@@ -1,5 +1,6 @@
 ---
-source: tests/snapshot_codegen.rs
+source: crates/floe-core/tests/snapshot_codegen.rs
+assertion_line: 115
 expression: output
 ---
 function add(a: number, b: number): number {
@@ -16,4 +17,4 @@ function map(arr: Array<number>, f: (_p0: number) => number): Array<number> {
 
 const _addTen = (_x) => add(10, _x);
 
-const _items = [1, 2, 3].map((_x) => multiply(_x, 2));
+const _items = map([1, 2, 3], (_x) => multiply(_x, 2));

--- a/examples/hono-api/package.json
+++ b/examples/hono-api/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "floe-hono-api",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check": "floe check src/"
+  },
+  "dependencies": {
+    "@floeorg/hono": "workspace:*",
+    "hono": "^4.12.10"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.2"
+  }
+}

--- a/examples/hono-api/src/main.fl
+++ b/examples/hono-api/src/main.fl
@@ -1,0 +1,23 @@
+import trusted { router, get, post, handle, Router } from "@floeorg/hono"
+
+type Env {
+    greeting: string,
+}
+
+fn hello(_c: unknown) -> Response {
+    Response("hello")
+}
+
+fn echo(_c: unknown) -> Response {
+    Response("echo")
+}
+
+export fn build() -> Router<Env> {
+    router<Env>()
+        |> get("/hello", hello)
+        |> post("/echo", echo)
+}
+
+export fn serve(request: Request, env: Env) -> unknown {
+    handle(build(), request, env)
+}

--- a/examples/hono-api/tsconfig.json
+++ b/examples/hono-api/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "lib": ["ES2022", "WebWorker"],
+    "types": []
+  },
+  "include": ["src/**/*.ts", "src/**/*.fl"]
+}

--- a/integrations/hono/package.json
+++ b/integrations/hono/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@floeorg/hono",
+  "version": "0.4.7",
+  "description": "Immutable router API for Hono, consumable from Floe via pipe operators",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "node --test --experimental-strip-types src/*.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "floe",
+    "hono",
+    "router",
+    "immutable"
+  ],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/floeorg/floe.git",
+    "directory": "integrations/hono"
+  },
+  "homepage": "https://github.com/floeorg/floe",
+  "peerDependencies": {
+    "hono": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.2",
+    "hono": "^4.12.10",
+    "typescript": "^6.0.2"
+  }
+}

--- a/integrations/hono/src/index.test.ts
+++ b/integrations/hono/src/index.test.ts
@@ -1,0 +1,83 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { router, get, post, put, patch, del, handle, type Handler } from "./index.ts";
+
+type TestEnv = { readonly greeting: string };
+
+describe("@floeorg/hono shim", () => {
+  it("router() returns a fresh Router wrapping a Hono instance", () => {
+    const r = router<TestEnv>();
+    assert.ok(r.__inner);
+    assert.equal(typeof r.__inner.fetch, "function");
+  });
+
+  it("get + post register routes and handle() dispatches by method and path", async () => {
+    const app = post(
+      get(router<TestEnv>(), "/hello", (c) => new Response(c.env.greeting)),
+      "/echo",
+      async (c) => new Response(await c.req.text()),
+    );
+
+    const helloRes = await handle(
+      app,
+      new Request("http://local/hello"),
+      { greeting: "world" },
+    );
+    assert.equal(helloRes.status, 200);
+    assert.equal(await helloRes.text(), "world");
+
+    const echoRes = await handle(
+      app,
+      new Request("http://local/echo", { method: "POST", body: "ping" }),
+      { greeting: "unused" },
+    );
+    assert.equal(await echoRes.text(), "ping");
+  });
+
+  it("unknown routes yield a 404", async () => {
+    const app = get(router<TestEnv>(), "/hello", () => new Response("ok"));
+    const res = await handle(
+      app,
+      new Request("http://local/missing"),
+      { greeting: "unused" },
+    );
+    assert.equal(res.status, 404);
+  });
+
+  it("each helper returns the same Router identity so chaining is lossless", () => {
+    const r = router<TestEnv>();
+    const noop: Handler<TestEnv> = () => new Response();
+    assert.equal(get(r, "/", noop), r);
+    assert.equal(post(r, "/", noop), r);
+    assert.equal(put(r, "/", noop), r);
+    assert.equal(patch(r, "/", noop), r);
+    assert.equal(del(r, "/", noop), r);
+  });
+
+  it("put / patch / del dispatch correctly", async () => {
+    const app = del(
+      patch(
+        put(router<TestEnv>(), "/u", () => new Response("u")),
+        "/p",
+        () => new Response("p"),
+      ),
+      "/d",
+      () => new Response("d"),
+    );
+
+    const u = await handle(app, new Request("http://local/u", { method: "PUT" }), { greeting: "" });
+    const p = await handle(app, new Request("http://local/p", { method: "PATCH" }), { greeting: "" });
+    const d = await handle(app, new Request("http://local/d", { method: "DELETE" }), { greeting: "" });
+
+    assert.equal(await u.text(), "u");
+    assert.equal(await p.text(), "p");
+    assert.equal(await d.text(), "d");
+  });
+
+  it("routes see the env object passed to handle()", async () => {
+    const app = get(router<TestEnv>(), "/env", (c) => new Response(c.env.greeting));
+    const res = await handle(app, new Request("http://local/env"), { greeting: "hey" });
+    assert.equal(await res.text(), "hey");
+  });
+});

--- a/integrations/hono/src/index.ts
+++ b/integrations/hono/src/index.ts
@@ -1,0 +1,77 @@
+import { Hono, type Context } from "hono";
+
+type Env = Record<string, unknown>;
+
+/**
+ * An immutable-looking handle around a Hono instance. Every routing
+ * helper below returns a `Router<E>` so Floe code can chain them with
+ * the pipe operator. The underlying Hono instance is stored on a
+ * double-underscore field to signal "compiler fingerprint — do not
+ * reach into this directly".
+ */
+export type Router<E extends Env = Env> = {
+  readonly __inner: Hono<{ Bindings: E }>;
+};
+
+export type Handler<E extends Env = Env> = (
+  c: Context<{ Bindings: E }>,
+) => Response | Promise<Response>;
+
+export function router<E extends Env = Env>(): Router<E> {
+  return { __inner: new Hono<{ Bindings: E }>() };
+}
+
+export function get<E extends Env>(
+  r: Router<E>,
+  path: string,
+  handler: Handler<E>,
+): Router<E> {
+  r.__inner.get(path, handler);
+  return r;
+}
+
+export function post<E extends Env>(
+  r: Router<E>,
+  path: string,
+  handler: Handler<E>,
+): Router<E> {
+  r.__inner.post(path, handler);
+  return r;
+}
+
+export function put<E extends Env>(
+  r: Router<E>,
+  path: string,
+  handler: Handler<E>,
+): Router<E> {
+  r.__inner.put(path, handler);
+  return r;
+}
+
+export function patch<E extends Env>(
+  r: Router<E>,
+  path: string,
+  handler: Handler<E>,
+): Router<E> {
+  r.__inner.patch(path, handler);
+  return r;
+}
+
+// `delete` is reserved in JS/TS identifier position, so this function is
+// named `del`. Floe users write `del(router, "/x", handler)`.
+export function del<E extends Env>(
+  r: Router<E>,
+  path: string,
+  handler: Handler<E>,
+): Router<E> {
+  r.__inner.delete(path, handler);
+  return r;
+}
+
+export function handle<E extends Env>(
+  r: Router<E>,
+  request: Request,
+  env: E,
+): Response | Promise<Response> {
+  return r.__inner.fetch(request, env);
+}

--- a/integrations/hono/tsconfig.json
+++ b/integrations/hono/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "types": ["node"],
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,19 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
 
+  examples/hono-api:
+    dependencies:
+      '@floeorg/hono':
+        specifier: workspace:*
+        version: link:../../integrations/hono
+      hono:
+        specifier: ^4.12.10
+        version: 4.12.14
+    devDependencies:
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+
   examples/store:
     dependencies:
       '@tanstack/react-query':
@@ -185,6 +198,18 @@ importers:
       '@types/node':
         specifier: ^25.5.2
         version: 25.5.2
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+
+  integrations/hono:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.2
+        version: 25.5.2
+      hono:
+        specifier: ^4.12.10
+        version: 4.12.14
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -1686,6 +1711,10 @@ packages:
 
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
+    engines: {node: '>=16.9.0'}
 
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
@@ -4197,6 +4226,8 @@ snapshots:
       hast-util-parse-selector: 4.0.0
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
+
+  hono@4.12.14: {}
 
   html-escaper@3.0.3: {}
 


### PR DESCRIPTION
closes #1179

## Summary

Adds `@floeorg/hono`, a thin TypeScript shim that wraps Hono behind an immutable-looking, pipe-friendly API — Floe code can write `router() |> get(...) |> post(...)` with no compiler changes to support builder-style mutation. The shim keeps Hono's mutation sealed inside TypeScript where Floe's immutability rules don't reach.

While wiring up an end-to-end Floe example, pipe codegen was silently routing identifiers through stdlib templates — `router |> get("/x", h)` emitted `router.has("/x") ? router.get("/x") : undefined` (the `Record.get` template) instead of calling the imported `get(router, "/x", h)`. The guard in `try_emit_bare_stdlib_pipe` only bailed when the name was local AND no stdlib function existed with the same name, so locally defined or trusted-imported names were silently shadowed by stdlib templates. Now any name in `local_names` (which the collector populates from both declarations and imports) wins; stdlib templates only apply when the name is unshadowed.

## Shape of the shim

```floe
import trusted { router, get, post, handle, Router } from "@floeorg/hono"

type Env { greeting: string }

export fn build() -> Router<Env> {
    router<Env>()
        |> get("/hello", hello)
        |> post("/echo", echo)
}

export fn serve(request: Request, env: Env) -> unknown {
    handle(build(), request, env)
}
```

Compiles to:

```ts
export function build(): Router<Env> {
  return post(get(router(), "/hello", hello), "/echo", echo);
}
export function serve(request: Request, env: Env): unknown {
  return handle(build(), request, env);
}
```

## Included

- `integrations/hono/` — new npm package (`@floeorg/hono`), TypeScript source, 6 `node:test` unit tests (router creation, method + path dispatch, 404 fallthrough, identity chaining, PUT/PATCH/DELETE, env passthrough)
- `examples/hono-api/` — Floe example app that imports the shim and defines a small router
- `.github/release-please-config.json` + `.github/workflows/release.yml` — version + publish automation
- Codegen fix in `crates/floe-core/src/codegen/typescript/pipes.rs`
- Two codegen unit tests pinning the shadowing behavior (local `map` vs Array.map; local `get` vs Record.get)
- Snapshot `snapshot_partial_application` updated — reflects the corrected behavior where a locally defined `map` now pipes to itself

## Test plan

- [x] `cargo test --workspace` — 1455 Rust tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] `pnpm --filter @floeorg/hono test` — 6 shim tests pass
- [x] `pnpm --filter @floeorg/hono build` produces `dist/`
- [x] `floe check examples/hono-api/src/` passes
- [x] `floe build examples/hono-api/src/` emits expected TS
- [x] `floe check/build examples/todo-app/src/` — unchanged, still passes
- [x] `floe check/build examples/store/src/` — unchanged, still passes
- [x] Manual codegen inspection of `examples/hono-api/src/main.fl` — pipe now routes to imported `get`/`post`, not stdlib templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)