### PR TITLE
feat: [#1177] recognize TS built-in utility types in bridge aliases

### DIFF
--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -5741,108 +5741,67 @@ fn string_literal_union_always_errors() {
 
 // ── TypeScript utility types ─────────────────────────────────
 
+fn assert_utility_type_accepted(src: &str) {
+    let diags = check(src);
+    assert!(
+        !has_error(&diags, ErrorCode::BridgeTypeWithoutImport)
+            && !has_error(&diags, ErrorCode::UndefinedName),
+        "utility-type alias rejected: {diags:?}"
+    );
+}
+
 #[test]
 fn bridge_alias_with_return_type_and_typeof_local_is_ok() {
-    let diags = check(
-        r#"
-fn createDb(id: string) -> string { id }
-type Database = ReturnType<typeof createDb>
-"#,
-    );
-    assert!(
-        !has_error(&diags, ErrorCode::BridgeTypeWithoutImport),
-        "ReturnType<typeof localFn> should be accepted as a valid bridge: {diags:?}"
-    );
-    assert!(
-        !has_error(&diags, ErrorCode::UndefinedName),
-        "ReturnType should be recognized as a TS utility type: {diags:?}"
+    assert_utility_type_accepted(
+        "fn createDb(id: string) -> string { id }
+type Database = ReturnType<typeof createDb>",
     );
 }
 
 #[test]
 fn bridge_alias_with_parameters_is_ok() {
-    let diags = check(
-        r#"
-fn createDb(id: string) -> string { id }
-type DbArgs = Parameters<typeof createDb>
-"#,
-    );
-    assert!(
-        !has_error(&diags, ErrorCode::BridgeTypeWithoutImport),
-        "Parameters<typeof localFn> should be accepted: {diags:?}"
-    );
-    assert!(
-        !has_error(&diags, ErrorCode::UndefinedName),
-        "Parameters should be recognized: {diags:?}"
+    assert_utility_type_accepted(
+        "fn createDb(id: string) -> string { id }
+type DbArgs = Parameters<typeof createDb>",
     );
 }
 
 #[test]
 fn bridge_alias_with_partial_over_local_record_is_ok() {
-    let diags = check(
-        r#"
-type User { name: string, email: string, age: number }
-type PartialUser = Partial<User>
-"#,
-    );
-    assert!(
-        !has_error(&diags, ErrorCode::BridgeTypeWithoutImport),
-        "Partial<LocalType> should be accepted: {diags:?}"
-    );
-    assert!(
-        !has_error(&diags, ErrorCode::UndefinedName),
-        "Partial should be recognized: {diags:?}"
+    assert_utility_type_accepted(
+        "type User { name: string, email: string, age: number }
+type PartialUser = Partial<User>",
     );
 }
 
 #[test]
 fn bridge_alias_with_readonly_and_non_nullable_is_ok() {
-    let diags = check(
-        r#"
-type User { name: string }
+    assert_utility_type_accepted(
+        "type User { name: string }
 type ReadOnlyUser = Readonly<User>
-type NonNullableUser = NonNullable<User>
-"#,
-    );
-    assert!(
-        !has_error(&diags, ErrorCode::BridgeTypeWithoutImport),
-        "Readonly / NonNullable should be accepted: {diags:?}"
-    );
-    assert!(
-        !has_error(&diags, ErrorCode::UndefinedName),
-        "Readonly and NonNullable should be recognized: {diags:?}"
+type NonNullableUser = NonNullable<User>",
     );
 }
 
 #[test]
 fn bare_typeof_local_still_errors() {
-    // Standalone `typeof` on a local still errors — utility types are
-    // the interop pattern, not identity aliases.
     let diags = check(
-        r#"
-fn createDb(id: string) -> string { id }
-type Identity = typeof createDb
-"#,
+        "fn createDb(id: string) -> string { id }
+type Identity = typeof createDb",
     );
     assert!(
         has_error(&diags, ErrorCode::BridgeTypeWithoutImport),
-        "bare `typeof localFn` should still be a bridge error: {diags:?}"
+        "{diags:?}"
     );
 }
 
 #[test]
 fn unknown_utility_like_name_still_errors() {
-    // Only names in the allowlist pass through; typos still error.
     let diags = check(
-        r#"
-type User { name: string }
-type Wat = MyCustomUtility<User>
-"#,
+        "type User { name: string }
+type Wat = MyCustomUtility<User>",
     );
-    assert!(
-        has_error(&diags, ErrorCode::UndefinedName),
-        "unknown names should still error as undefined: {diags:?}"
-    );
+    assert!(has_error(&diags, ErrorCode::UndefinedName), "{diags:?}");
 }
 
 // ── Intersection restriction ─────────────────────────────────

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -5739,6 +5739,112 @@ fn string_literal_union_always_errors() {
     );
 }
 
+// ── TypeScript utility types ─────────────────────────────────
+
+#[test]
+fn bridge_alias_with_return_type_and_typeof_local_is_ok() {
+    let diags = check(
+        r#"
+fn createDb(id: string) -> string { id }
+type Database = ReturnType<typeof createDb>
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::BridgeTypeWithoutImport),
+        "ReturnType<typeof localFn> should be accepted as a valid bridge: {diags:?}"
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::UndefinedName),
+        "ReturnType should be recognized as a TS utility type: {diags:?}"
+    );
+}
+
+#[test]
+fn bridge_alias_with_parameters_is_ok() {
+    let diags = check(
+        r#"
+fn createDb(id: string) -> string { id }
+type DbArgs = Parameters<typeof createDb>
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::BridgeTypeWithoutImport),
+        "Parameters<typeof localFn> should be accepted: {diags:?}"
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::UndefinedName),
+        "Parameters should be recognized: {diags:?}"
+    );
+}
+
+#[test]
+fn bridge_alias_with_partial_over_local_record_is_ok() {
+    let diags = check(
+        r#"
+type User { name: string, email: string, age: number }
+type PartialUser = Partial<User>
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::BridgeTypeWithoutImport),
+        "Partial<LocalType> should be accepted: {diags:?}"
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::UndefinedName),
+        "Partial should be recognized: {diags:?}"
+    );
+}
+
+#[test]
+fn bridge_alias_with_readonly_and_non_nullable_is_ok() {
+    let diags = check(
+        r#"
+type User { name: string }
+type ReadOnlyUser = Readonly<User>
+type NonNullableUser = NonNullable<User>
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::BridgeTypeWithoutImport),
+        "Readonly / NonNullable should be accepted: {diags:?}"
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::UndefinedName),
+        "Readonly and NonNullable should be recognized: {diags:?}"
+    );
+}
+
+#[test]
+fn bare_typeof_local_still_errors() {
+    // Standalone `typeof` on a local still errors — utility types are
+    // the interop pattern, not identity aliases.
+    let diags = check(
+        r#"
+fn createDb(id: string) -> string { id }
+type Identity = typeof createDb
+"#,
+    );
+    assert!(
+        has_error(&diags, ErrorCode::BridgeTypeWithoutImport),
+        "bare `typeof localFn` should still be a bridge error: {diags:?}"
+    );
+}
+
+#[test]
+fn unknown_utility_like_name_still_errors() {
+    // Only names in the allowlist pass through; typos still error.
+    let diags = check(
+        r#"
+type User { name: string }
+type Wat = MyCustomUtility<User>
+"#,
+    );
+    assert!(
+        has_error(&diags, ErrorCode::UndefinedName),
+        "unknown names should still error as undefined: {diags:?}"
+    );
+}
+
 // ── Intersection restriction ─────────────────────────────────
 
 #[test]

--- a/crates/floe-core/src/checker/type_registration.rs
+++ b/crates/floe-core/src/checker/type_registration.rs
@@ -200,6 +200,9 @@ impl Checker {
                 if self.is_dts_export_name(name) {
                     return true;
                 }
+                if crate::type_layout::is_ts_utility_type(name) {
+                    return true;
+                }
                 if let Some(ty) = self.env.lookup(name)
                     && matches!(ty, Type::Foreign { .. })
                 {

--- a/crates/floe-core/src/checker/type_resolve.rs
+++ b/crates/floe-core/src/checker/type_resolve.rs
@@ -221,6 +221,15 @@ impl Checker {
                     // Accept ambient type names from TypeScript lib definitions
                     // (e.g., Date, RegExp, URL, HTMLElement) as valid type annotations.
                     Type::Named(name.to_string())
+                } else if type_layout::is_ts_utility_type(name) {
+                    // TS built-in utility types (ReturnType, Parameters, Partial, ...)
+                    // have no Floe runtime representation. Resolve the type args so
+                    // inner references are marked used, then pass through as a Named
+                    // type. Codegen emits `Name<Args...>` unchanged and TS resolves it.
+                    for arg in type_args {
+                        self.resolve_type(arg);
+                    }
+                    Type::Named(name.to_string())
                 } else {
                     self.emit_error_with_help(
                         format!("unknown type `{name}`"),

--- a/crates/floe-core/src/checker/type_resolve.rs
+++ b/crates/floe-core/src/checker/type_resolve.rs
@@ -222,10 +222,8 @@ impl Checker {
                     // (e.g., Date, RegExp, URL, HTMLElement) as valid type annotations.
                     Type::Named(name.to_string())
                 } else if type_layout::is_ts_utility_type(name) {
-                    // TS built-in utility types (ReturnType, Parameters, Partial, ...)
-                    // have no Floe runtime representation. Resolve the type args so
-                    // inner references are marked used, then pass through as a Named
-                    // type. Codegen emits `Name<Args...>` unchanged and TS resolves it.
+                    // Resolve args so inner references are marked used; TS resolves
+                    // the utility-type semantics at its own compile time.
                     for arg in type_args {
                         self.resolve_type(arg);
                     }

--- a/crates/floe-core/src/type_layout.rs
+++ b/crates/floe-core/src/type_layout.rs
@@ -39,6 +39,38 @@ pub const TYPE_MAP: &str = "Map";
 pub const TYPE_SET: &str = "Set";
 pub const TYPE_JSX_ELEMENT: &str = "JSX.Element";
 
+/// TypeScript built-in utility types that Floe passes through to TS unchanged.
+/// These have no runtime representation in Floe — they're type-level operations
+/// that TS handles at compile time. Used by bridge (`= type`) aliases so
+/// `type Database = ReturnType<typeof createDb>` is accepted without needing
+/// to import `ReturnType` from anywhere.
+pub const TS_UTILITY_TYPES: &[&str] = &[
+    "ReturnType",
+    "Parameters",
+    "ConstructorParameters",
+    "Awaited",
+    "Partial",
+    "Required",
+    "Readonly",
+    "Pick",
+    "Omit",
+    "NonNullable",
+    "Record",
+    "Extract",
+    "Exclude",
+    "InstanceType",
+    "ThisParameterType",
+    "OmitThisParameter",
+    "Uppercase",
+    "Lowercase",
+    "Capitalize",
+    "Uncapitalize",
+];
+
+pub fn is_ts_utility_type(name: &str) -> bool {
+    TS_UTILITY_TYPES.contains(&name)
+}
+
 /// Returns true if the name is a built-in type (not user-defined or npm).
 /// When adding new built-in types, add a `TYPE_*` constant above and
 /// include it in this match.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -160,6 +160,21 @@ type Props {
 }
 // Compiles to: type Props = VariantProps<typeof variants> & { className: string };
 
+// TS built-in utility types (usable in bridge `= type` aliases, no import needed)
+// Recognized: ReturnType, Parameters, ConstructorParameters, Awaited,
+//             Partial, Required, Readonly, Pick, Omit, NonNullable,
+//             Record, Extract, Exclude, InstanceType,
+//             Uppercase, Lowercase, Capitalize, Uncapitalize
+fn createDb(id: string) -> string { id }
+type Database = ReturnType<typeof createDb>
+type DbArgs = Parameters<typeof createDb>
+
+type User { name: string, email: string }
+type PartialUser = Partial<User>
+type ReadOnlyUser = Readonly<User>
+// These pass through to TS unchanged. Standalone `type X = typeof value`
+// (without a utility-type wrapper) still errors — use ReturnType/Parameters/etc.
+
 // Tuples
 const point: (number, number) = (10, 20)
 const (x, y) = point


### PR DESCRIPTION
closes #1177

## Summary

The checker rejected `type Database = ReturnType<typeof createDb>` with `unknown type \`ReturnType\`` because the type resolver only knew Floe-native and dts-imported names. The same alias also failed the "bridge-type without import" gate because no foreign reference was detected.

Adds a small allowlist of recognized TypeScript built-in utility types that the checker passes through to codegen unchanged:

- `ReturnType`, `Parameters`, `ConstructorParameters`, `Awaited`
- `Partial`, `Required`, `Readonly`, `Pick`, `Omit`, `NonNullable`, `Record`
- `Extract`, `Exclude`, `InstanceType`, `ThisParameterType`, `OmitThisParameter`
- `Uppercase`, `Lowercase`, `Capitalize`, `Uncapitalize`

Three tiny surgical changes:

1. `type_layout`: new `TS_UTILITY_TYPES` constant + `is_ts_utility_type` helper
2. `type_resolve::resolve_named_type`: when the unknown-name fallthrough would error, first check the utility-type allowlist; if it matches, resolve the type args (to mark inner references used) and return `Type::Named(name)`
3. `type_registration::type_expr_references_foreign`: utility types count as referencing foreign, so `type X = Partial<User>` is a valid bridge alias even when `User` is a Floe-native record

Bare `type X = typeof localFn` still errors — identity aliases aren't the interop pattern we want to encourage. Only utility-type wrappers unlock the bridge.

## Output

```floe
fn createDb(id: string) -> string { id }
type Database = ReturnType<typeof createDb>
type DbArgs = Parameters<typeof createDb>

type User { name: string, email: string, age: number }
type PartialUser = Partial<User>
type ReadOnlyUser = Readonly<User>
```

compiles to:

```ts
function createDb(id: string): string { return id; }
type Database = ReturnType<typeof createDb>;
type DbArgs = Parameters<typeof createDb>;
type User = { name: string; email: string; age: number };
type PartialUser = Partial<User>;
type ReadOnlyUser = Readonly<User>;
```

## Test plan

- [x] `cargo test --workspace` — 1462 Rust tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] New tests in `crates/floe-core/src/checker/tests.rs`:
  - `bridge_alias_with_return_type_and_typeof_local_is_ok`
  - `bridge_alias_with_parameters_is_ok`
  - `bridge_alias_with_partial_over_local_record_is_ok`
  - `bridge_alias_with_readonly_and_non_nullable_is_ok`
  - `bare_typeof_local_still_errors` (pins the negative case)
  - `unknown_utility_like_name_still_errors` (pins that typos still fail)
- [x] Existing `typeof_local_binding_is_bridge_error` and related tests still pass
- [x] `floe check/build examples/todo-app/` + `examples/store/` — unchanged, both pass
- [x] `docs/llms.txt` updated with the allowlist and a usage example

## Known limitations (separate follow-ups)

- `Pick<User, "name" | "email">` — string-literal unions as type arguments don't parse yet. String-literal type args like `ComponentProps<"div">` work; unions of them don't. Orthogonal parser change.
- Using the bridge type as a concrete value's type (`fn f(d: Database) -> string { d }`) still triggers strict unification against the unresolved alias — also an existing compat gap, orthogonal to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)