### PR TITLE
feat: [#1192] ship @floeorg/esbuild-plugin

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -33,6 +33,11 @@
         },
         {
           "type": "json",
+          "path": "integrations/esbuild-plugin/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": "editors/vscode/package.json",
           "jsonpath": "$.version"
         }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,12 @@ jobs:
           pnpm build
           npx npm@latest publish --access public --provenance
 
+      - name: Build and publish esbuild plugin
+        working-directory: integrations/esbuild-plugin
+        run: |
+          pnpm build
+          npx npm@latest publish --access public --provenance
+
   publish-extension:
     name: Publish VS Code Extension
     needs: release

--- a/integrations/esbuild-plugin/package.json
+++ b/integrations/esbuild-plugin/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@floeorg/esbuild-plugin",
+  "version": "0.4.7",
+  "description": "esbuild plugin for Floe - resolves and compiles .fl imports for wrangler, Bun, tsup, and raw esbuild",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "node --test --experimental-strip-types src/*.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "floe",
+    "esbuild",
+    "esbuild-plugin",
+    "wrangler",
+    "bun",
+    "tsup"
+  ],
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/floeorg/floe.git",
+    "directory": "integrations/esbuild-plugin"
+  },
+  "homepage": "https://github.com/floeorg/floe",
+  "peerDependencies": {
+    "esbuild": ">=0.17.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.2",
+    "esbuild": "^0.27.3",
+    "typescript": "^6.0.2"
+  }
+}

--- a/integrations/esbuild-plugin/src/index.test.ts
+++ b/integrations/esbuild-plugin/src/index.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+import floe from "./index.ts";
+
+describe("@floeorg/esbuild-plugin", () => {
+  let projectDir: string;
+
+  before(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "floe-esbuild-test-"));
+    mkdirSync(join(projectDir, "src", "nested"), { recursive: true });
+    writeFileSync(join(projectDir, "package.json"), `{"name":"test","type":"module"}`);
+    writeFileSync(
+      join(projectDir, "src", "app.ts"),
+      `import { hello } from "./nested/helper";\nexport const out = hello("world");\n`,
+    );
+    writeFileSync(
+      join(projectDir, "src", "nested", "helper.fl"),
+      `export fn hello(name: string) -> string {\n    \`Hello, \${name}!\`\n}\n`,
+    );
+    execFileSync("floe", ["build", "src/"], { cwd: projectDir, stdio: "pipe" });
+  });
+
+  after(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it("resolves extensionless imports to .fl and bundles the compiled TS", async () => {
+    const outfile = join(projectDir, "out.js");
+    const result = await build({
+      entryPoints: [join(projectDir, "src", "app.ts")],
+      bundle: true,
+      format: "esm",
+      outfile,
+      plugins: [floe()],
+      absWorkingDir: projectDir,
+      logLevel: "silent",
+    });
+    assert.equal(result.errors.length, 0);
+
+    const bundle = readFileSync(outfile, "utf8");
+    assert.match(bundle, /Hello, \$\{name\}/);
+    assert.match(bundle, /hello\("world"\)/);
+  });
+
+  it("respects user-written .ts siblings over .fl", async () => {
+    mkdirSync(join(projectDir, "src", "ts-wins"), { recursive: true });
+    writeFileSync(
+      join(projectDir, "src", "ts-wins", "shared.ts"),
+      `export const kind = "ts";\n`,
+    );
+    writeFileSync(
+      join(projectDir, "src", "ts-wins", "shared.fl"),
+      `export const _kind: string = "fl"\n`,
+    );
+    writeFileSync(
+      join(projectDir, "src", "entry.ts"),
+      `import { kind } from "./ts-wins/shared";\nexport const out = kind;\n`,
+    );
+    execFileSync("floe", ["build", "src/"], { cwd: projectDir, stdio: "pipe" });
+
+    const outfile = join(projectDir, "out2.js");
+    await build({
+      entryPoints: [join(projectDir, "src", "entry.ts")],
+      bundle: true,
+      format: "esm",
+      outfile,
+      plugins: [floe()],
+      absWorkingDir: projectDir,
+      logLevel: "silent",
+    });
+
+    const bundle = readFileSync(outfile, "utf8");
+    assert.match(bundle, /kind = "ts"/);
+    assert.doesNotMatch(bundle, /_kind = "fl"/);
+  });
+
+});

--- a/integrations/esbuild-plugin/src/index.ts
+++ b/integrations/esbuild-plugin/src/index.ts
@@ -1,0 +1,146 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import type { Plugin } from "esbuild";
+
+export interface FloeOptions {
+  /** Path to the `floe` binary. Defaults to `"floe"`. */
+  compiler?: string;
+}
+
+/**
+ * esbuild plugin for Floe.
+ *
+ * Resolves extensionless relative imports to `.fl` sources and serves the
+ * compiled TypeScript from the project's `.floe/` mirror when it exists,
+ * falling back to an on-demand `floe build` invocation otherwise.
+ *
+ * Works under wrangler, Bun's bundler, tsup, electron-forge, and raw esbuild —
+ * any bundler that accepts an esbuild plugin.
+ *
+ * @example
+ * ```ts
+ * import floe from "@floeorg/esbuild-plugin";
+ * import { build } from "esbuild";
+ *
+ * await build({
+ *   entryPoints: ["src/app.ts"],
+ *   bundle: true,
+ *   plugins: [floe()],
+ * });
+ * ```
+ */
+export default function floe(options: FloeOptions = {}): Plugin {
+  const compiler = options.compiler ?? "floe";
+
+  return {
+    name: "floe",
+    setup(build) {
+      build.onResolve({ filter: /^\.\.?\// }, (args) => {
+        const basePath = resolve(args.resolveDir, args.path);
+
+        // If the import explicitly references a .fl file, take it.
+        if (basePath.endsWith(".fl") && existsSync(basePath)) {
+          return { path: basePath };
+        }
+
+        // For extensionless imports, prefer `.fl` when nothing with a
+        // conventional extension exists at the target — Floe-native
+        // modules don't have `.ts` siblings in `src/`.
+        if (!basePath.endsWith(".fl")) {
+          for (const ext of [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]) {
+            if (existsSync(basePath + ext)) return;
+          }
+          const flPath = basePath + ".fl";
+          if (existsSync(flPath)) {
+            return { path: flPath };
+          }
+        }
+
+        return;
+      });
+
+      build.onLoad({ filter: /\.fl$/ }, (args) => {
+        const cached = readCachedOutput(args.path);
+        if (cached !== null) {
+          return { contents: cached, loader: "ts", resolveDir: dirname(args.path) };
+        }
+
+        try {
+          const compiled = compileFloe(compiler, args.path);
+          return { contents: compiled, loader: "ts", resolveDir: dirname(args.path) };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return {
+            errors: [
+              {
+                text: `Floe compilation failed for ${args.path}`,
+                detail: message,
+              },
+            ],
+          };
+        }
+      });
+    },
+  };
+}
+
+/**
+ * Read pre-compiled `.ts`/`.tsx` output from the `.floe/` mirror if it's
+ * fresher than the source `.fl`. Returns null if the mirror is missing,
+ * stale, or the project root can't be located.
+ */
+function readCachedOutput(flFile: string): string | null {
+  const projectRoot = findProjectRoot(flFile);
+  if (!projectRoot) return null;
+
+  let sourceMtime: number;
+  try {
+    sourceMtime = statSync(flFile).mtimeMs;
+  } catch {
+    return null;
+  }
+
+  const rel = relative(projectRoot, flFile);
+  const floeDir = join(projectRoot, ".floe");
+
+  for (const ext of ["tsx", "ts"]) {
+    const outPath = join(floeDir, rel).replace(/\.fl$/, `.${ext}`);
+    try {
+      if (statSync(outPath).mtimeMs >= sourceMtime) {
+        return readFileSync(outPath, "utf-8");
+      }
+    } catch {
+      // try next extension
+    }
+  }
+
+  return null;
+}
+
+/** Walk up from `start` looking for a directory that contains `package.json`. */
+function findProjectRoot(start: string): string | null {
+  let dir = isAbsolute(start) ? dirname(start) : resolve(start);
+  while (true) {
+    if (existsSync(join(dir, "package.json"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+function compileFloe(compiler: string, filename: string): string {
+  try {
+    return execFileSync(compiler, ["build", "--emit-stdout", filename], {
+      encoding: "utf-8",
+      timeout: 30_000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  } catch (error) {
+    if (error && typeof error === "object" && "stderr" in error) {
+      const stderr = (error as { stderr: string | Buffer }).stderr;
+      throw new Error(String(stderr));
+    }
+    throw error;
+  }
+}

--- a/integrations/esbuild-plugin/src/index.ts
+++ b/integrations/esbuild-plugin/src/index.ts
@@ -8,6 +8,9 @@ export interface FloeOptions {
   compiler?: string;
 }
 
+const JS_TS_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"] as const;
+const COMPILED_EXTENSIONS = ["tsx", "ts"] as const;
+
 /**
  * esbuild plugin for Floe.
  *
@@ -36,39 +39,45 @@ export default function floe(options: FloeOptions = {}): Plugin {
   return {
     name: "floe",
     setup(build) {
+      const rootCache = new Map<string, string | null>();
+      const findRoot = (flFile: string): string | null => {
+        const key = dirname(flFile);
+        const cached = rootCache.get(key);
+        if (cached !== undefined) return cached;
+        const found = findProjectRoot(flFile);
+        rootCache.set(key, found);
+        return found;
+      };
+
       build.onResolve({ filter: /^\.\.?\// }, (args) => {
         const basePath = resolve(args.resolveDir, args.path);
 
-        // If the import explicitly references a .fl file, take it.
         if (basePath.endsWith(".fl") && existsSync(basePath)) {
           return { path: basePath };
         }
 
-        // For extensionless imports, prefer `.fl` when nothing with a
-        // conventional extension exists at the target — Floe-native
-        // modules don't have `.ts` siblings in `src/`.
+        // Floe-native modules don't have `.ts` siblings — prefer `.fl` only
+        // when no conventional extension matches, so mixed projects with
+        // handwritten `.ts` keep working.
         if (!basePath.endsWith(".fl")) {
-          for (const ext of [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]) {
+          for (const ext of JS_TS_EXTENSIONS) {
             if (existsSync(basePath + ext)) return;
           }
           const flPath = basePath + ".fl";
-          if (existsSync(flPath)) {
-            return { path: flPath };
-          }
+          if (existsSync(flPath)) return { path: flPath };
         }
-
-        return;
       });
 
       build.onLoad({ filter: /\.fl$/ }, (args) => {
-        const cached = readCachedOutput(args.path);
+        const resolveDir = dirname(args.path);
+        const projectRoot = findRoot(args.path);
+        const cached = projectRoot ? readCachedOutput(args.path, projectRoot) : null;
         if (cached !== null) {
-          return { contents: cached, loader: "ts", resolveDir: dirname(args.path) };
+          return { contents: cached, loader: "ts", resolveDir };
         }
 
         try {
-          const compiled = compileFloe(compiler, args.path);
-          return { contents: compiled, loader: "ts", resolveDir: dirname(args.path) };
+          return { contents: compileFloe(compiler, args.path), loader: "ts", resolveDir };
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           return {
@@ -87,13 +96,10 @@ export default function floe(options: FloeOptions = {}): Plugin {
 
 /**
  * Read pre-compiled `.ts`/`.tsx` output from the `.floe/` mirror if it's
- * fresher than the source `.fl`. Returns null if the mirror is missing,
- * stale, or the project root can't be located.
+ * fresher than the source `.fl`. Returns null if the mirror is missing
+ * or stale.
  */
-function readCachedOutput(flFile: string): string | null {
-  const projectRoot = findProjectRoot(flFile);
-  if (!projectRoot) return null;
-
+function readCachedOutput(flFile: string, projectRoot: string): string | null {
   let sourceMtime: number;
   try {
     sourceMtime = statSync(flFile).mtimeMs;
@@ -104,7 +110,7 @@ function readCachedOutput(flFile: string): string | null {
   const rel = relative(projectRoot, flFile);
   const floeDir = join(projectRoot, ".floe");
 
-  for (const ext of ["tsx", "ts"]) {
+  for (const ext of COMPILED_EXTENSIONS) {
     const outPath = join(floeDir, rel).replace(/\.fl$/, `.${ext}`);
     try {
       if (statSync(outPath).mtimeMs >= sourceMtime) {
@@ -118,7 +124,6 @@ function readCachedOutput(flFile: string): string | null {
   return null;
 }
 
-/** Walk up from `start` looking for a directory that contains `package.json`. */
 function findProjectRoot(start: string): string | null {
   let dir = isAbsolute(start) ? dirname(start) : resolve(start);
   while (true) {

--- a/integrations/esbuild-plugin/tsconfig.json
+++ b/integrations/esbuild-plugin/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "types": ["node"],
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,16 +26,6 @@ importers:
         specifier: ^0.8.0
         version: 0.8.0(@astrojs/starlight@0.38.2(astro@6.1.7(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(typescript@5.9.3)))(astro@6.1.7(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(typescript@5.9.3))
 
-  editors/tree-sitter-floe:
-    dependencies:
-      nan:
-        specifier: ^2.18.0
-        version: 2.26.2
-    devDependencies:
-      tree-sitter-cli:
-        specifier: ^0.26.8
-        version: 0.26.8
-
   editors/vscode:
     dependencies:
       vscode-languageclient:
@@ -208,6 +198,18 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+
+  integrations/esbuild-plugin:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.2
+        version: 25.6.0
+      esbuild:
+        specifier: ^0.27.3
+        version: 0.27.7
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -2070,9 +2072,6 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nan@2.26.2:
-    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
-
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2395,11 +2394,6 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
-
-  tree-sitter-cli@0.26.8:
-    resolution: {integrity: sha512-teQFMF5V/g8aIdakZ0M/eZoedCM3MuBt1JuDOICLloA2hy7QfeOInb99U6wiML4qXcBHWREwf0U1TWzw7p67YA==}
-    engines: {node: '>=12.0.0'}
-    hasBin: true
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -4839,8 +4833,6 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nan@2.26.2: {}
-
   nanoid@3.3.11: {}
 
   neotraverse@0.6.18: {}
@@ -5337,8 +5329,6 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
-
-  tree-sitter-cli@0.26.8: {}
 
   trim-lines@3.0.1: {}
 


### PR DESCRIPTION
closes #1192

## Summary

New first-party npm package: `@floeorg/esbuild-plugin`. Resolves extensionless relative imports to `.fl` sources and serves the compiled TypeScript from the project's `.floe/` mirror (with on-demand compile as fallback).

Because wrangler, Bun's bundler, tsup, and electron-forge all consume esbuild plugins via the same `Plugin` API, one package covers the whole non-Vite ecosystem in a single dep.

## Why this matters

Before: a yeet-style Workers project with `src/app.ts` importing `./presentation/routes` (where `routes.fl` exists) failed to bundle — wrangler's esbuild couldn't resolve the extensionless import because `rootDirs` is a tsc-only feature. Users had to reach into `.floe/src/...` from their entry file, leaking a build artifact path into source code.

After: users plug `@floeorg/esbuild-plugin` into their esbuild/tsup/Bun/custom-wrangler-build setup and `./presentation/routes` resolves cleanly through to the Floe-emitted TypeScript.

## Shape

```ts
import floe from "@floeorg/esbuild-plugin";
import { build } from "esbuild";

await build({
  entryPoints: ["src/app.ts"],
  bundle: true,
  plugins: [floe()],
});
```

Mirrors `@floeorg/vite-plugin`'s pattern: cache-first read from `.floe/`, shell out to `floe build --emit-stdout` when the cache is cold, defer to user-written `.ts` siblings when they exist (so mixed `.fl` + `.ts` projects don't get handwritten `.ts` shadowed).

## Included

- `integrations/esbuild-plugin/` — package source + `node:test` unit tests
- Release-please + workflow entries so `@floeorg/esbuild-plugin` versions with the rest of the monorepo
- Tests:
  - Resolves extensionless imports to `.fl` and bundles the compiled TS
  - User-written `.ts` siblings take precedence over `.fl` (mixed-project support)

## Test plan

- [x] `pnpm --filter @floeorg/esbuild-plugin build` — builds clean
- [x] `pnpm --filter @floeorg/esbuild-plugin test` — 2 tests pass
- [x] Manual end-to-end against a yeet-style Workers project:
  - `node scripts/build.mjs` (esbuild + plugin) — bundle succeeds, `231kb` output includes Floe-compiled content
  - `src/app.ts` can `import from "./presentation/routes"` with no reach-in path

## Follow-up notes

- Subsumes #1007 (bun plugin) — Bun's bundler uses esbuild's plugin API so `@floeorg/esbuild-plugin` covers it.
- Wrangler doesn't accept arbitrary esbuild plugins in its config, so users wire this via a custom build script + `no_bundle`. A thinner `@floeorg/workers` convenience package could wrap this pattern (separate issue, not filed).
- `floe build --emit-stdout` currently exits 0 on compile errors (emits placeholder TS with `/* type error */`) rather than propagating via exit code. Bundler error surfacing would improve if the CLI exits non-zero on errors — file as a follow-up if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)