### PR TITLE
fix: [#1194] expose Router.fetch so `export default app` works under Workers

### DIFF
--- a/integrations/hono/src/index.test.ts
+++ b/integrations/hono/src/index.test.ts
@@ -12,6 +12,13 @@ describe("@floeorg/hono shim", () => {
     assert.equal(typeof r.__inner.fetch, "function");
   });
 
+  it("router() exposes fetch at the top level so it works as a Workers default export", async () => {
+    const app = get(router<TestEnv>(), "/ping", () => new Response("pong"));
+    assert.equal(typeof app.fetch, "function");
+    const res = await app.fetch(new Request("http://local/ping"), { greeting: "unused" });
+    assert.equal(await res.text(), "pong");
+  });
+
   it("get + post register routes and handle() dispatches by method and path", async () => {
     const app = post(
       get(router<TestEnv>(), "/hello", (c) => new Response(c.env.greeting)),

--- a/integrations/hono/src/index.ts
+++ b/integrations/hono/src/index.ts
@@ -8,9 +8,14 @@ type Env = Record<string, unknown>;
  * the pipe operator. The underlying Hono instance is stored on a
  * double-underscore field to signal "compiler fingerprint — do not
  * reach into this directly".
+ *
+ * `fetch` is exposed at the top level so the router value satisfies
+ * runtimes like Cloudflare Workers directly — `export default app`
+ * works without a wrapping `{ fetch: ... }` adapter.
  */
 export type Router<E extends Env = Env> = {
   readonly __inner: Hono<{ Bindings: E }>;
+  fetch: Hono<{ Bindings: E }>["fetch"];
 };
 
 export type Handler<E extends Env = Env> = (
@@ -18,7 +23,8 @@ export type Handler<E extends Env = Env> = (
 ) => Response | Promise<Response>;
 
 export function router<E extends Env = Env>(): Router<E> {
-  return { __inner: new Hono<{ Bindings: E }>() };
+  const inner = new Hono<{ Bindings: E }>();
+  return { __inner: inner, fetch: inner.fetch.bind(inner) };
 }
 
 export function get<E extends Env>(


### PR DESCRIPTION
closes #1194

## Summary

`@floeorg/hono`'s `Router<E>` wrapped the Hono instance at `__inner` and didn't surface `fetch` at the top level. Cloudflare Workers (and any runtime that dispatches through `default.fetch`) rejected `export default app` with "Handler does not export a fetch() function", forcing every user of the shim to write a 6-line adapter:

```ts
import { handle } from "@floeorg/hono";
import { app } from "./presentation/routes";
export default {
  fetch(req, env) { return handle(app, req, env); },
};
```

After this patch:

```ts
export { app as default } from "./presentation/routes";
```

## Change

Bind the inner Hono instance's `fetch` onto the returned Router value at construction time:

```ts
export type Router<E extends Env = Env> = {
  readonly __inner: Hono<{ Bindings: E }>;
  fetch: Hono<{ Bindings: E }>["fetch"];
};

export function router<E extends Env = Env>(): Router<E> {
  const inner = new Hono<{ Bindings: E }>();
  return { __inner: inner, fetch: inner.fetch.bind(inner) };
}
```

`handle(router, request, env)` stays exported for manual dispatch.

## Test plan

- [x] New test: `router() exposes fetch at the top level so it works as a Workers default export` — calls `app.fetch(request, env)` directly
- [x] All 7 existing shim tests still pass
- [x] Tests run green: `pnpm --filter @floeorg/hono test`
- [x] Build green: `pnpm --filter @floeorg/hono build`

## Follow-up

After this lands and ships to npm, the Workers-facing glue in yeet and similar apps shrinks to one line — closes the last adapter-code gap for "Floe-native Workers app".

🤖 Generated with [Claude Code](https://claude.com/claude-code)