### PR TITLE
fix: [#1198] cover trailing newlines in LSP format TextEdit range

### DIFF
--- a/crates/floe-lsp/src/handlers.rs
+++ b/crates/floe-lsp/src/handlers.rs
@@ -209,15 +209,25 @@ impl LanguageServer for FloeLsp {
             return Ok(None);
         }
 
-        let last_line = doc.content.lines().count().saturating_sub(1) as u32;
-        let last_char = doc.content.lines().last().map_or(0, |l| l.len()) as u32;
-
         Ok(Some(vec![TextEdit {
             range: Range {
                 start: Position::new(0, 0),
-                end: Position::new(last_line, last_char),
+                end: end_position(&doc.content),
             },
             new_text: formatted,
         }]))
     }
+}
+
+/// Position pointing at the end of `content`, covering any trailing newline.
+///
+/// `str::lines()` discards the empty segment after a final `\n`, so ranges
+/// built from it stop one newline short and leave stray trailing blank lines
+/// behind. This counts `\n`s directly and measures the tail in UTF-16 code
+/// units, as required by the LSP spec.
+pub(crate) fn end_position(content: &str) -> Position {
+    let line = content.bytes().filter(|&b| b == b'\n').count() as u32;
+    let last_line_start = content.rfind('\n').map_or(0, |i| i + 1);
+    let character = content[last_line_start..].encode_utf16().count() as u32;
+    Position::new(line, character)
 }

--- a/crates/floe-lsp/src/tests.rs
+++ b/crates/floe-lsp/src/tests.rs
@@ -6,6 +6,7 @@ use super::completions::{
     match_arm_snippet,
 };
 use super::goto_def::import_path_at_offset;
+use super::handlers::end_position;
 use super::index::*;
 use super::*;
 
@@ -1092,4 +1093,41 @@ const u = User(name: "a", age: 1)
         labels.contains(&"age"),
         "should suggest 'age', got: {labels:?}"
     );
+}
+
+// ── Formatting range helper ──────────────────────────────────────
+
+#[test]
+fn end_position_no_trailing_newline() {
+    let pos = end_position("const x = 1");
+    assert_eq!(pos, Position::new(0, 11));
+}
+
+#[test]
+fn end_position_single_trailing_newline() {
+    let pos = end_position("const x = 1\n");
+    assert_eq!(pos, Position::new(1, 0));
+}
+
+#[test]
+fn end_position_multiple_trailing_newlines_covers_all() {
+    // The previous implementation using `str::lines()` returned (2, 0) here,
+    // leaving the final "\n" outside the edit range — which caused the
+    // formatter to leave two trailing newlines after applying the TextEdit.
+    let pos = end_position("const x = 1\n\n\n");
+    assert_eq!(pos, Position::new(3, 0));
+}
+
+#[test]
+fn end_position_multiline_no_trailing_newline() {
+    let pos = end_position("const a = 1\nconst b = 2");
+    assert_eq!(pos, Position::new(1, 11));
+}
+
+#[test]
+fn end_position_utf16_surrogate_pair_on_last_line() {
+    // "𝕊" (U+1D54A) is encoded as two UTF-16 code units — LSP character
+    // offsets must count code units, not chars.
+    let pos = end_position("const s = \"𝕊\"");
+    assert_eq!(pos, Position::new(0, 14));
 }


### PR DESCRIPTION
## Summary

- Formatting via LSP left 2 trailing newlines when a file had 2+ blank trailing lines with no whitespace. Only files whose trailing lines contained indentation formatted correctly.
- The in-memory `floe_core::formatter::format` function is fine; the bug was in `crates/floe-lsp/src/handlers.rs`, which built the replacement range from `str::lines()`. `str::lines()` drops the empty segment after a final `\n`, so the range stopped short and the final `\n` was outside the edit — the client then re-appended it after the formatted text.
- Replaced the range computation with an `end_position()` helper that counts `\n`s directly and measures the tail in UTF-16 code units per the LSP spec.

closes #1198

## Test plan

- [x] `cargo test -p floe-lsp` — 104 passing, including 5 new `end_position_*` tests
- [x] `cargo clippy -p floe-lsp --all-targets -- -D warnings`
- [x] `cargo fmt`
- [ ] Manual: edit a `.fl` file with 3 trailing newlines in VS Code, run Format Document, verify file ends with exactly one `\n`

🤖 Generated with [Claude Code](https://claude.com/claude-code)