### PR TITLE
fix: [#1197] resolve overloaded method return types via __chain_call_ probes

### DIFF
--- a/crates/floe-core/src/checker/expr.rs
+++ b/crates/floe-core/src/checker/expr.rs
@@ -943,6 +943,17 @@ impl Checker {
             .collect();
         self.ctx.lambda_param_hints.clear();
 
+        // A `__chain_call_{key}` probe means tsgo already resolved this call
+        // site's overload and produced a concrete return type. Skip Floe-side
+        // arg validation (same as the Foreign-member branch below): the probe
+        // captures `.field(null! as any)`, so arg-vs-param checks would be
+        // against `any` anyway.
+        if let ExprKind::Member { object, field } = &callee.kind
+            && let Some(ty) = self.lookup_chain_call_probe(object, field)
+        {
+            return ty;
+        }
+
         // Handle piped value insertion
         if let Some(piped_ty) = piped_ty {
             if has_placeholder {
@@ -2454,39 +2465,49 @@ impl Checker {
         }
     }
 
-    /// Look up an awaited chain probe for a chain call expression.
-    /// e.g. for `db.insert(t).values({...}).returning()`, tries probes
-    /// `__chain_await_db$insert$values$returning` and (type-rooted)
-    /// `__chain_await_Database$insert$values$returning`.
-    /// Also handles the `?` unwrap form `chain()?` by peeling through Unwrap.
+    /// Look up a chain probe for a Member `object.field`, trying the
+    /// variable-rooted key first (e.g. `db$insert$values`) and then the
+    /// type-rooted key (e.g. `Database$insert$values`). `prefix` selects the
+    /// probe family: `"__chain_call_"` for overload-resolved call results,
+    /// `"__chain_await_"` for awaited chain results.
+    fn lookup_prefixed_chain_probe(
+        &mut self,
+        prefix: &str,
+        object: &Expr,
+        field: &str,
+    ) -> Option<Type> {
+        let chain_key = extract_chain_key(object, field)?;
+        if let Some(ty) = self.lookup_dts_probe(&format!("{prefix}{chain_key}")) {
+            return Some(ty);
+        }
+        let type_key = self.chain_key_by_root_type(object, field)?;
+        self.lookup_dts_probe(&format!("{prefix}{type_key}"))
+    }
+
+    /// Look up the call-result chain probe for a Member chain callee
+    /// (e.g. `c.req.param("code")` → `__chain_call_Context$req$param`).
+    /// tsgo has already resolved the correct overload, so the probe type
+    /// is the concrete return value.
+    fn lookup_chain_call_probe(&mut self, object: &Expr, field: &str) -> Option<Type> {
+        self.lookup_prefixed_chain_probe("__chain_call_", object, field)
+    }
+
+    /// Look up the awaited chain probe for a chain call expression
+    /// (e.g. `db.insert(t).values({...}).returning()` →
+    /// `__chain_await_Database$insert$values$returning`). Peels through the
+    /// `?` unwrap form `chain()?` to reach the underlying call.
     fn lookup_awaited_chain_probe(&mut self, left: &Expr) -> Option<Type> {
-        // Peel through Unwrap (e.g. `chain()?`) to reach the underlying call
         let expr = match &left.kind {
             ExprKind::Unwrap(inner) => inner.as_ref(),
             _ => left,
         };
-        let callee = match &expr.kind {
-            ExprKind::Call { callee, .. } => callee,
-            _ => return None,
+        let ExprKind::Call { callee, .. } = &expr.kind else {
+            return None;
         };
-        let (object, field) = match &callee.kind {
-            ExprKind::Member { object, field } => (object, field),
-            _ => return None,
+        let ExprKind::Member { object, field } = &callee.kind else {
+            return None;
         };
-        let chain_key = extract_chain_key(object, field)?;
-        // Try variable-name key first
-        let probe_name = format!("__chain_await_{chain_key}");
-        if let Some(ty) = self.lookup_dts_probe(&probe_name) {
-            return Some(ty);
-        }
-        // Try type-name key (parameter/field typed as npm/bridge type)
-        if let Some(type_key) = self.chain_key_by_root_type(object, field) {
-            let probe_name = format!("__chain_await_{type_key}");
-            if let Some(ty) = self.lookup_dts_probe(&probe_name) {
-                return Some(ty);
-            }
-        }
-        None
+        self.lookup_prefixed_chain_probe("__chain_await_", object, field)
     }
 
     /// Resolve a member type without emitting diagnostics (for probe key lookups).

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -7352,6 +7352,68 @@ fn example() -> () {
 }
 
 #[test]
+fn chain_call_probe_resolves_overloaded_method_return_type() {
+    // When a chainable method has overloaded signatures (e.g. Hono's
+    // `HonoRequest.param`), the raw `__chain_{key}` probe exposes every
+    // overload as an object with multiple call signatures — and Floe's DTS
+    // parser keeps only the first, picking the wrong one. A separate
+    // `__chain_call_{key}` probe captures the CALL RESULT with `null! as any`
+    // as the argument, letting tsgo pick the matching overload, and the
+    // checker prefers it in `check_call`.
+    use crate::interop::{DtsExport, TsType};
+    use std::collections::HashMap;
+
+    let program = crate::parser::Parser::new(
+        r#"
+import trusted { Context } from "hono"
+
+fn needsString(s: string) -> string { s }
+
+export fn handler(c: Context<unknown>) -> string {
+    match c.req.param("code") {
+        None -> "missing",
+        Some(v) -> needsString(v),
+    }
+}
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+
+    // Simulate tsgo emitting a `__chain_call_Context$req$param` probe that
+    // captures the result of calling `.param(null! as any)` — tsgo picks
+    // overload 2 (`(key: string): string | undefined`) and Floe wraps the
+    // resulting `string | undefined` to `Option<string>` at the boundary.
+    let context_export = DtsExport {
+        name: "Context".to_string(),
+        ts_type: TsType::Any,
+    };
+    let chain_call_probe = DtsExport {
+        name: "__chain_call_Context$req$param".to_string(),
+        ts_type: TsType::Union(vec![
+            TsType::Primitive("string".to_string()),
+            TsType::Undefined,
+        ]),
+    };
+
+    let mut dts_imports = HashMap::new();
+    dts_imports.insert("hono".to_string(), vec![context_export, chain_call_probe]);
+
+    let checker = Checker::with_all_imports(HashMap::new(), dts_imports);
+    let (diags, _, _, _) = checker.check_with_types(&program);
+
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "overloaded chain call should resolve via __chain_call_ probe, got: {:?}",
+        errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn chain_probe_resolves_for_fl_bridge_type_param() {
     // When a function parameter is typed as a Floe bridge type alias (e.g. db: Database
     // where `type Database = DrizzleType`), chain probes keyed by type name should resolve

--- a/crates/floe-core/src/interop/tsgo.rs
+++ b/crates/floe-core/src/interop/tsgo.rs
@@ -1229,5 +1229,40 @@ fn Component() {
             "inlined probe should preserve type arguments, got:\n{probe}"
         );
     }
+
+    #[test]
+    fn generate_probe_property_getter_then_method_call() {
+        // A chain with a property getter (`.req`) followed by a method call
+        // (`.param(...)`) must emit `.req` bare and `.param(null! as any)` as
+        // a call so tsgo picks the right overload.
+        let source = r#"import trusted { Context } from "hono"
+
+export fn handler(c: Context<unknown>) -> string {
+    match c.req.param("code") {
+        None -> "missing",
+        Some(v) -> v,
+    }
 }
-// temporary debug
+"#;
+        let program = Parser::new(source).parse_program().unwrap();
+        let probe = generate_probe(&program, &HashMap::new(), &HashMap::new());
+
+        assert!(
+            probe.contains("declare const __chain_base_Context: Context;"),
+            "probe should declare a Context chain base, got:\n{probe}"
+        );
+        // `.req` is a property, NOT a method call — it must NOT get `(null! as any)`
+        assert!(
+            !probe.contains(".req(null! as any)"),
+            "property getter `.req` must not be invoked as a method, got:\n{probe}"
+        );
+        // The terminal `.param(...)` must be probed as a call so tsgo picks
+        // the overload matching a string-typed key argument.
+        assert!(
+            probe.contains(
+                "__chain_call_Context$req$param = __chain_base_Context.req.param(null! as any);"
+            ),
+            "expected __chain_call_ probe with .req.param(null! as any), got:\n{probe}"
+        );
+    }
+}

--- a/crates/floe-core/src/interop/tsgo/probe_gen.rs
+++ b/crates/floe-core/src/interop/tsgo/probe_gen.rs
@@ -734,6 +734,10 @@ pub(super) fn generate_probe(
     let mut chain_step_args: HashMap<String, String> = HashMap::new();
     // Track which chain steps are zero-arg calls (e.g. .select()) for full-chain probes
     let mut chain_step_zero_args: HashSet<String> = HashSet::new();
+    // Chain step keys whose Member is wrapped in a `Call` in source. Steps
+    // NOT in this set are property accesses (e.g. the `.req` getter in
+    // `c.req.param(...)`) and must be emitted without parentheses in the probe.
+    let mut chain_call_keys: HashSet<String> = HashSet::new();
     // Pre-merge imported_names and fl_module_imported_names for type-rooted chain arg detection.
     // Built once here rather than inside the walk closure to avoid cloning per expression.
     let combined_imported_names: HashMap<String, String> = {
@@ -744,27 +748,42 @@ pub(super) fn generate_probe(
         m
     };
     crate::walk::walk_program(program, &mut |expr| {
+        // Every `Call { callee: Member{...} }` identifies a chain step that
+        // must be invoked (not bare-accessed) in the probe, and — at the
+        // outermost such call — is the terminal for a `__chain_call_{key}`
+        // overload-resolution probe.
+        if let ExprKind::Call { callee, .. } = &expr.kind
+            && let ExprKind::Member { .. } = &callee.kind
+        {
+            if let Some(path) = extract_import_chain_path(callee, &imported_names) {
+                chain_call_keys.insert(path.join("$"));
+            }
+            if let Some((type_name, path)) = extract_typed_param_chain_path(callee, &param_type_map)
+            {
+                chain_call_keys.insert(type_rooted_key(&type_name, &path));
+            }
+        }
+
         if matches!(&expr.kind, ExprKind::Member { .. }) {
-            // Try variable-rooted chain (direct import like `import { db }`)
+            // Variable-rooted chain (direct import like `import { db }`)
             if let Some(path) = extract_import_chain_path(expr, &imported_names)
                 && path.len() > 2
             {
                 chain_paths.push(path);
                 return;
             }
-            // Try type-rooted chain (parameter like `db: Database`)
+            // Type-rooted chain (parameter like `db: Database`)
             if let Some((type_name, path)) = extract_typed_param_chain_path(expr, &param_type_map)
                 && path.len() > 2
             {
-                // Replace the variable name with the type name as the root
                 let mut type_path = vec![type_name];
                 type_path.extend(path[1..].iter().cloned());
                 let root_key = type_path[..=1].join("$");
                 type_rooted_chains.insert(root_key.clone());
 
-                // Capture imported arguments at each call step in the chain.
-                // combined_imported_names includes fl_module_imported_names so
-                // args like `snippetsTable` (imported via a .fl module's npm dep) are captured.
+                // `combined_imported_names` includes fl_module_imported_names
+                // so args like `snippetsTable` (imported via a .fl module's
+                // npm dep) are captured for generic preservation.
                 collect_chain_step_args(
                     expr,
                     &combined_imported_names,
@@ -815,12 +834,25 @@ pub(super) fn generate_probe(
                                 expr = format!("{expr}.{method}()");
                             } else if let Some(arg) = chain_step_args.get(&step_key) {
                                 expr = format!("{expr}.{method}({arg})");
-                            } else {
+                            } else if chain_call_keys.contains(&step_key) {
                                 expr = format!("{expr}.{method}(null! as any)");
+                            } else {
+                                // Property access (e.g. getter): emit bare access.
+                                expr = format!("{expr}.{method}");
                             }
                         }
                         let field = &path[end_idx];
                         lines.push(format!("export const {export_name} = {expr}.{field};"));
+                        // `__chain_call_{key}` delegates overload resolution to
+                        // tsgo by invoking the terminal with `null! as any`.
+                        // The checker prefers this over the bare `__chain_{key}`
+                        // property probe when the callee is a Member chain call.
+                        if chain_call_keys.contains(&chain_key) {
+                            let call_name = format!("__chain_call_{chain_key}");
+                            lines.push(format!(
+                                "export const {call_name} = {expr}.{field}(null! as any);"
+                            ));
+                        }
                         // Also capture the result of CALLING the method (the builder value)
                         // and its awaited form. This handles thenable builders (e.g. drizzle's
                         // `.returning()` returns a PromiseLike that resolves to the rows).
@@ -1400,6 +1432,7 @@ fn extract_import_chain_path(
 /// the imported type and path starts with the variable name.
 /// For `db.insert(...).values` where `db: Database`, returns ("Database", ["db", "insert", "values"]).
 /// For `self.client.insert(...).values` where client: Database, returns ("Database", ["self.client", "insert", "values"]).
+/// For `c.req.param(...)` where `c: Context`, returns ("Context", ["c", "req", "param"]).
 fn extract_typed_param_chain_path(
     expr: &Expr,
     param_type_map: &HashMap<String, String>,
@@ -1408,41 +1441,55 @@ fn extract_typed_param_chain_path(
         expr: &Expr,
         param_type_map: &HashMap<String, String>,
     ) -> Option<(String, Vec<String>)> {
-        match &expr.kind {
-            ExprKind::Member { object, field } => match &object.kind {
-                // Direct parameter: db.insert(...)
-                ExprKind::Identifier(name) if param_type_map.contains_key(name) => {
-                    let type_name = param_type_map[name].clone();
-                    Some((type_name, vec![name.clone(), field.clone()]))
-                }
-                // Self field access: self.client.insert(...)
-                ExprKind::Member {
-                    object: inner_obj,
-                    field: inner_field,
-                } if matches!(&inner_obj.kind, ExprKind::Identifier(_)) => {
-                    if let ExprKind::Identifier(name) = &inner_obj.kind {
-                        let key = format!("{name}.{inner_field}");
-                        if let Some(type_name) = param_type_map.get(&key) {
-                            Some((type_name.clone(), vec![key, field.clone()]))
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    }
-                }
-                // Chained call or unwrap: expr().method(...) or expr()?.method(...)
-                ExprKind::Call { callee, .. } | ExprKind::Unwrap(callee) => {
-                    let (type_name, mut path) = extract_inner(callee, param_type_map)?;
-                    path.push(field.clone());
-                    Some((type_name, path))
-                }
-                _ => None,
-            },
-            _ => None,
+        let ExprKind::Member { object, field } = &expr.kind else {
+            return None;
+        };
+
+        // `x.field` where x is a typed parameter
+        if let ExprKind::Identifier(name) = &object.kind
+            && let Some(type_name) = param_type_map.get(name)
+        {
+            return Some((type_name.clone(), vec![name.clone(), field.clone()]));
         }
+
+        // `self.f.field` where `self.f` is keyed in param_type_map
+        if let ExprKind::Member {
+            object: inner_obj,
+            field: inner_field,
+        } = &object.kind
+            && let ExprKind::Identifier(name) = &inner_obj.kind
+        {
+            let key = format!("{name}.{inner_field}");
+            if let Some(type_name) = param_type_map.get(&key) {
+                return Some((type_name.clone(), vec![key, field.clone()]));
+            }
+        }
+
+        // Recurse through Call/Unwrap (mid-chain method call) or a nested
+        // Member (property-access chain like `c.req.param` where `.req` is a
+        // getter, not a method).
+        let inner = match &object.kind {
+            ExprKind::Call { callee, .. } | ExprKind::Unwrap(callee) => callee.as_ref(),
+            ExprKind::Member { .. } => object.as_ref(),
+            _ => return None,
+        };
+        let (type_name, mut path) = extract_inner(inner, param_type_map)?;
+        path.push(field.clone());
+        Some((type_name, path))
     }
     extract_inner(expr, param_type_map)
+}
+
+/// Build a type-rooted chain key from the `(type_name, [var, ...segments])`
+/// shape returned by `extract_typed_param_chain_path` — i.e. swap the
+/// variable-name root for the type name and join with `$`.
+fn type_rooted_key(type_name: &str, path: &[String]) -> String {
+    let mut out = String::from(type_name);
+    for seg in &path[1..] {
+        out.push('$');
+        out.push_str(seg);
+    }
+    out
 }
 
 /// Collect imported arguments at each call step in a chain expression.


### PR DESCRIPTION
closes #1197

## Summary

For `c.req.param(\"code\")` on Hono's `Context<unknown>`, Floe was inferring `Option<unknown>` instead of `Option<string>`. The bug lived in the tsgo chain-probe generator: it didn't recognize property-getter-then-method chains (`c.req.param(...)`), and even when chains were detected, the raw `__chain_{key}` probe exposed overloaded methods as objects with multiple call signatures — and Floe's DTS parser keeps only the first, often picking the wrong one.

**Fix**
- `interop/tsgo/probe_gen.rs`: recurse through nested `Member`s in `extract_typed_param_chain_path`; walk every `Call { callee: Member{...} }` to classify each chain step as method call vs property access; emit bare `.field` for properties and `.field(null! as any)` for calls; emit a new `__chain_call_{key}` probe that invokes the terminal so tsgo resolves the correct overload.
- `checker/expr.rs`: add `lookup_chain_call_probe` delegating through a shared `lookup_prefixed_chain_probe` (which the await lookup now reuses). In `check_call`, prefer the call probe for Member-chain callees.

Delegating overload resolution to tsgo generalizes beyond Hono: any library with computed-type overloads (`UnionToIntersection`, conditional types, etc.) benefits without Floe hand-rolling overload selection.

## Test plan

- [x] `chain_call_probe_resolves_overloaded_method_return_type` — checker test simulating tsgo's emitted `__chain_call_Context$req$param: string | undefined` and verifying the Hono repro compiles cleanly
- [x] `generate_probe_property_getter_then_method_call` — probe_gen test asserting property access emits bare `.req` (not `.req(null! as any)`) and the terminal `.param(...)` gets a `__chain_call_` probe
- [x] Full `floe-core` test suite: 1479 + 33 + 29 passing, no regressions
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Example apps quality gate: `floe fmt` + `floe check` on `examples/todo-app/` and `examples/store/` both pass
- [x] End-to-end verification on real Hono `.d.ts`: `c.req.param(\"code\")` now resolves to `Option<string>` against `integrations/hono/node_modules/hono/dist/types/request.d.ts` (confirmed via `FLOE_DEBUG_PROBE=1` showing `__chain_call_Context\$req\$param: string | undefined` in tsgo output)

## Follow-up

Filed #1202 for an unrelated generic-through-pipes inference bug discovered while testing (Hono `Router<E>` stays `Router<E>` instead of `Router<Bindings>` through a `router() |> get() |> post()` chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)