### PR TITLE
fix: [#1210] build @floeorg/* integrations on pnpm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,16 +92,19 @@ jobs:
         run: |
           ./floe fmt --check examples/todo-app/src/
           ./floe fmt --check examples/store/src/
+          ./floe fmt --check examples/hono-api/src/
 
       - name: Floe check examples
         run: |
           ./floe check examples/todo-app/src/
           ./floe check examples/store/src/
+          ./floe check examples/hono-api/src/
 
       - name: Floe build examples
         run: |
           ./floe build examples/todo-app/src/
           ./floe build examples/store/src/
+          ./floe build examples/hono-api/src/
 
       - name: TypeScript type-check examples
         run: |

--- a/examples/hono-api/src/main.fl
+++ b/examples/hono-api/src/main.fl
@@ -13,9 +13,7 @@ fn echo(_c: unknown) -> Response {
 }
 
 export fn build() -> Router<Env> {
-    router<Env>()
-        |> get("/hello", hello)
-        |> post("/echo", echo)
+    router<Env>() |> get("/hello", hello) |> post("/echo", echo)
 }
 
 export fn serve(request: Request, env: Env) -> unknown {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "scripts": {
+    "postinstall": "pnpm --filter \"./integrations/*\" build",
     "build:plugin": "pnpm --filter @floeorg/vite-plugin build",
     "dev:todo": "pnpm build:plugin && pnpm --filter floe-todo-app dev",
     "dev:store": "pnpm build:plugin && pnpm --filter floe-store dev",


### PR DESCRIPTION
closes #1210

## Summary

Integration packages under `integrations/` (`@floeorg/hono`, `@floeorg/core`, `@floeorg/esbuild-plugin`, `@floeorg/register`, `@floeorg/vite-plugin`) declare `\"types\": \"dist/index.d.ts\"` in their `package.json`, but no step was building those `dist/` folders. `pnpm install` just workspace-linked the source directories, so tsgo couldn't resolve module types — every integration symbol arrived at the checker as a bare `Type::Foreign { name }`, which in turn made `check_call` take the \"standalone Foreign identifier\" path, emit a silent warning, and return `Type::Error`. Downstream expressions propagated the `Error` invisibly, so real bugs (wrong arg counts, bad generic args) slipped through.

This is the TypeScript-aligned fix: build the workspace packages before downstream type-checking, same as any TS monorepo.

**Changes:**
- Root `package.json`: add `postinstall: pnpm --filter \"./integrations/*\" build` so `pnpm install` auto-builds all five integrations.
- CI: extend `fmt --check` / `check` / `build` gates to cover `examples/hono-api/` (previously only `todo-app` and `store`, neither of which imports an integration).
- `examples/hono-api/src/main.fl`: single-line reformat to satisfy the new `fmt --check` gate.

No compiler code changed.

## Test plan

- [x] `pnpm install` produces `dist/index.d.ts` in all five `integrations/*` packages
- [x] `floe check examples/hono-api/src/main.fl` passes against real `@floeorg/hono` types
- [x] Wrong-arity call (`router<Bindings>() |> get(\"/hello\")`) now errors with `E001: \"get\" expects 3 arguments, found 2` — before this fix it was silently accepted via the Foreign bypass
- [x] `cargo test --workspace`: 1484 floe-core tests pass, no regressions
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `floe fmt --check` / `check` / `build` pass on `todo-app`, `store`, and `hono-api`

## Related follow-ups (separate issues)

- #1209 — bare-identifier pipe loses generics. Unblocked by this fix (the hono chain can now be cleanly reproduced).
- #1211 — Floe signatures referencing `Router<Bindings>` strip generic args. Surfaced more clearly now that integrations type as `Function` instead of `Foreign`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)