### PR TITLE
fix: [#1211] preserve generic args on Foreign type references

### DIFF
--- a/crates/floe-core/src/checker/expr.rs
+++ b/crates/floe-core/src/checker/expr.rs
@@ -35,6 +35,12 @@ fn extract_chain_key(object: &Expr, field: &str) -> Option<String> {
 
 use super::hydrator::is_single_uppercase as is_generic_param;
 
+/// Strip generic arguments from a Foreign type name for chain-probe lookup.
+/// `Context<unknown>` -> `Context`, `Router<A, B>` -> `Router`, `Foo` -> `Foo`.
+fn foreign_base(name: &str) -> &str {
+    name.split('<').next().unwrap_or(name)
+}
+
 /// When a destructured param's type is unresolved, use heuristics for known field names.
 /// The "error" field maps to Error because Floe's error-handling callbacks (use blocks,
 /// fallbackRender) destructure `{ error }`.
@@ -2400,7 +2406,9 @@ impl Checker {
         let root_name = &segments[0];
         if let Some(root_type) = self.env.lookup(root_name) {
             let type_name = match root_type {
-                Type::Foreign { name, .. } => Some(name.clone()),
+                // Probes are keyed by the base type name (no generic args), so
+                // `Context<unknown>` must lookup as `Context$...`.
+                Type::Foreign { name, .. } => Some(foreign_base(name).to_string()),
                 // Unknown types (not registered locally) and bridge type aliases (= syntax
                 // wrapping a TS type) both use chain probes since resolve_member_type can't
                 // evaluate TypeScript method access for either.
@@ -2428,7 +2436,7 @@ impl Checker {
             if let Some(root_type) = self.env.lookup(root_name) {
                 let member_ty = self.resolve_member_type_silent(root_type, second);
                 let type_name = match &member_ty {
-                    Type::Foreign { name, .. } => Some(name.clone()),
+                    Type::Foreign { name, .. } => Some(foreign_base(name).to_string()),
                     Type::Named(name)
                         if self.env.lookup_type(name).is_none()
                             || self

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -8306,3 +8306,104 @@ export fn main() -> Result<Option<number>, Error> {
         diags.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn foreign_generic_args_distinguish_parameterizations() {
+    // Floe signatures referencing a Foreign type with generic args like
+    // `Router<Alpha>` used to collapse to bare `Foreign("Router")`, so
+    // `Router<Alpha>` and `Router<Beta>` were indistinguishable and a
+    // mismatched call silently succeeded. The resolver now encodes the
+    // args into the Foreign name, and `types_compatible` rejects
+    // same-base-name Foreigns whose full names differ — except when either
+    // side carries a single-letter type-parameter placeholder (covered by
+    // the sibling test below).
+    use crate::interop::{DtsExport, TsType};
+    use std::collections::HashMap;
+
+    let program = crate::parser::Parser::new(
+        r#"
+import trusted { Router } from "@floeorg/hono"
+
+type Alpha { foo: string }
+type Beta { bar: number }
+
+fn takesAlpha(r: Router<Alpha>) -> Router<Alpha> { r }
+fn takesBeta(r: Router<Beta>) -> Router<Beta> { r }
+
+fn mkAlpha() -> Router<Alpha> { takesAlpha(mkAlpha()) }
+
+const _bad = takesBeta(mkAlpha())
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+
+    let router_export = DtsExport {
+        name: "Router".to_string(),
+        ts_type: TsType::Any,
+    };
+    let mut dts_imports = HashMap::new();
+    dts_imports.insert("@floeorg/hono".to_string(), vec![router_export]);
+
+    let checker = Checker::with_all_imports(HashMap::new(), dts_imports);
+    let (diags, _, _, _) = checker.check_with_types(&program);
+
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(
+        errors
+            .iter()
+            .any(|d| d.message.contains("Router<Alpha>") && d.message.contains("Router<Beta>")),
+        "expected a Router<Alpha> vs Router<Beta> mismatch error, got: {:?}",
+        errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn foreign_with_type_param_arg_stays_permissive() {
+    // Imported TS generic signatures like `get<E>(...)->Router<E>` wrap to
+    // `Foreign("Router<E>")` with `E` as an unresolved type parameter
+    // placeholder. Until inference substitutes `E` through the call chain
+    // (tracked separately as #1209), `Router<E>` must stay compatible with
+    // `Router<Env>` / `Router<Bindings>` / etc., or the pre-#1211
+    // user-level behavior regresses.
+    use crate::interop::{DtsExport, TsType};
+    use std::collections::HashMap;
+
+    let program = crate::parser::Parser::new(
+        r#"
+import trusted { Router } from "@floeorg/hono"
+
+type Env { greeting: string }
+
+// Simulate a hono-style signature whose body just returns a fresh value:
+// the point is that `handle`'s annotated Router<Env> input must accept
+// `Router<E>` produced by imported generic functions.
+fn handle(_r: Router<Env>) -> Response { Response("ok") }
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+
+    let router_export = DtsExport {
+        name: "Router".to_string(),
+        ts_type: TsType::Any,
+    };
+    let mut dts_imports = HashMap::new();
+    dts_imports.insert("@floeorg/hono".to_string(), vec![router_export]);
+
+    let checker = Checker::with_all_imports(HashMap::new(), dts_imports);
+    let (diags, _, _, _) = checker.check_with_types(&program);
+
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "Router<Env> declaration should not error, got: {:?}",
+        errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}

--- a/crates/floe-core/src/checker/type_compat.rs
+++ b/crates/floe-core/src/checker/type_compat.rs
@@ -2,6 +2,38 @@ use std::sync::Arc;
 
 use super::*;
 
+/// True if a Foreign type name like `Router<E>` contains an arg that looks
+/// like an unresolved type parameter (single uppercase letter). Used to stay
+/// permissive for same-base-name Foreigns when the checker hasn't yet
+/// substituted a type parameter through the call chain.
+fn has_type_param_arg(foreign_name: &str) -> bool {
+    let Some(open) = foreign_name.find('<') else {
+        return false;
+    };
+    let Some(inner) = foreign_name.get(open + 1..foreign_name.len() - 1) else {
+        return false;
+    };
+    let mut depth = 0;
+    let mut start = 0;
+    let chars: Vec<(usize, char)> = inner.char_indices().collect();
+    let mut ranges: Vec<&str> = Vec::new();
+    for (i, c) in &chars {
+        match c {
+            '<' => depth += 1,
+            '>' => depth -= 1,
+            ',' if depth == 0 => {
+                ranges.push(inner[start..*i].trim());
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    ranges.push(inner[start..].trim());
+    ranges
+        .iter()
+        .any(|a| a.len() == 1 && a.chars().next().is_some_and(|c| c.is_ascii_uppercase()))
+}
+
 impl Checker {
     /// Resolve a `Type::Named` to its concrete underlying type, if possible.
     /// Returns `Some(concrete)` if the type was resolved, `None` if not a Named type.
@@ -156,8 +188,24 @@ impl Checker {
 
         // Foreign types: reject primitives, permissive otherwise.
         // Foreign-vs-Foreign is permissive because npm types often have subtype
-        // relationships (e.g. SQLiteColumn extends SQLWrapper) that Floe can't verify.
-        // TypeScript's own type checker validates the generated code.
+        // relationships (e.g. SQLiteColumn extends SQLWrapper) that Floe can't verify —
+        // EXCEPT when both sides share a base name with fully-resolved (non
+        // type-parameter) generic args: `Router<A>` and `Router<B>` are the
+        // same class with different instantiations and must not be freely
+        // interchangeable. If either side still contains an unresolved
+        // type-parameter placeholder (single uppercase letter like `E`, `T`,
+        // a leftover from a pipe/generic-inference gap), fall back to
+        // permissive because we can't yet decide equivalence.
+        if let (Type::Foreign { name: e_name, .. }, Type::Foreign { name: a_name, .. }) =
+            (expected, actual)
+        {
+            let e_base = e_name.split('<').next().unwrap_or(e_name);
+            let a_base = a_name.split('<').next().unwrap_or(a_name);
+            if e_base == a_base && !has_type_param_arg(e_name) && !has_type_param_arg(a_name) {
+                return e_name == a_name;
+            }
+            return true;
+        }
         if let Type::Foreign { .. } = expected {
             return !actual.is_primitive();
         }

--- a/crates/floe-core/src/checker/type_resolve.rs
+++ b/crates/floe-core/src/checker/type_resolve.rs
@@ -193,9 +193,33 @@ impl Checker {
 
                 // Check if this is a known user-defined type or imported name.
                 // Skip validation during type registration (forward references).
-                // If the env has a Foreign type, preserve it.
+                // If the env has a Foreign type, preserve it — and encode any
+                // concrete type arguments into the name so `Router<Bindings>`
+                // doesn't collapse to `Router` (which would make `Router<A>`
+                // and `Router<B>` indistinguishable). Encoding is skipped when
+                // any argument is a generic type parameter because Type::Generic
+                // isn't substituted through Foreign name strings: baking "E"
+                // into a Foreign name would leak the unresolved placeholder
+                // past instantiation sites.
                 if let Some(Type::Foreign { .. }) = self.env.lookup(name) {
-                    Type::foreign(name.to_string())
+                    if type_args.is_empty() {
+                        Type::foreign(name.to_string())
+                    } else {
+                        let resolved_args: Vec<Type> =
+                            type_args.iter().map(|t| self.resolve_type(t)).collect();
+                        let any_generic = resolved_args.iter().any(|t| {
+                            matches!(t, Type::Var(_))
+                                || matches!(t, Type::Named(n)
+                                    if self.active_type_params.contains_key(n.as_str()))
+                        });
+                        if any_generic {
+                            Type::foreign(name.to_string())
+                        } else {
+                            let args_str: Vec<String> =
+                                resolved_args.iter().map(|t| t.to_string()).collect();
+                            Type::foreign(format!("{}<{}>", name, args_str.join(", ")))
+                        }
+                    }
                 } else if self.registering_types
                     || self.env.lookup_type(name).is_some()
                     || name.contains('.')


### PR DESCRIPTION
closes #1211

## Summary

`fn takesA(r: Router<Alpha>) -> Router<Alpha>` used to wrap into `Function { params: [Foreign(\"Router\")], return_type: Foreign(\"Router\") }` — the `<Alpha>` was stripped at the boundary, so `Router<Alpha>` and `Router<Beta>` looked identical to the checker and mismatched calls compiled silently.

- `type_resolve.rs`: when a name binding resolves to a Foreign, encode concrete type args into the Foreign name string (same convention the boundary wrapper uses for DTS-parsed generics). Args that resolve to `Type::Var` or an active-type-parameter Named are deliberately skipped — baking `E` into the string would leak the placeholder past instantiation sites.
- `type_compat.rs`: same-base-name Foreigns with fully-resolved concrete args now require an exact name match. When either side's args contain a single-uppercase-letter placeholder (e.g. `Router<E>` from an imported TS generic that hasn't been substituted through a pipe chain — tracked in #1209), stay permissive so inference gaps elsewhere don't cascade.
- `expr.rs` `chain_key_by_root_type`: strip generic args from the root's Foreign name before joining so `Context<unknown>$req$param` hits the existing `__chain_Context$req$param` / `__chain_call_Context$req$param` probes.

## Test plan

- [x] `foreign_generic_args_distinguish_parameterizations` — `Router<Alpha>` vs `Router<Beta>` mismatch now errors
- [x] `foreign_with_type_param_arg_stays_permissive` — `Router<Env>` declarations still accepted when imported TS signatures carry `Router<E>` placeholders (backward-compat until #1209 lands)
- [x] Existing chain-probe test (`chain_call_probe_resolves_overloaded_method_return_type`) still passes — `Context<unknown>` hover no longer breaks `__chain_call_Context$req$param` lookup
- [x] `cargo test --workspace`: 1486 tests pass (+2 vs main), no regressions
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `floe fmt --check` / `check` / `build` all pass on `todo-app`, `store`, and `hono-api`

## Related

- Depends on #1210 (integration packages now build on `pnpm install`) which landed first.
- #1209 (bare-identifier pipe generic inference) remains open; when it lands, the `has_type_param_arg` permissive fallback in `type_compat.rs` can be tightened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)