### PR TITLE
docs: flag Floe as experimental across README, docs, and site

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
 
 A functional language that compiles to TypeScript. Pipes, pattern matching, Result/Option types, and full npm interop.
 
+> [!WARNING]
+> **Floe is experimental.** The language is pre-1.0, under active development, and should not be used in production. Expect bugs, rough edges, and breaking changes to the syntax, compiler output, and public APIs between releases. Pin your version and read the [CHANGELOG](CHANGELOG.md) before upgrading.
+
 ```floe
 import trusted { useState } from "react"
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,5 +1,7 @@
 # Floe — Design Decisions
 
+> **Status: Experimental.** Floe is pre-1.0 and under active development. The language, compiler output, and public APIs are unstable and may change between releases without deprecation. This document describes the current intended design; behavior may lag behind, and some sections describe target state rather than what the compiler actually does today.
+
 ## Vision
 
 A Gleam-inspired language that compiles to vanilla TypeScript + React. Familiar syntax for TS/React developers, but with pipes, exhaustive matching, no escape hatches, and compile-time safety that eliminates entire categories of bugs. Zero runtime dependencies — the compiler does all the work, the output is boring `.tsx`.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,5 +1,7 @@
 # Floe Language — LLM Quick Reference
 
+**Status: Experimental.** Floe is pre-1.0 and under active development. The language, compiler output, and public APIs can change between releases. Bugs and rough edges should be expected. Not recommended for production use.
+
 Floe is a programming language that compiles to TypeScript. It targets TypeScript/React developers who want stronger guarantees. The syntax is familiar but stricter: no null, no any, no classes, no exceptions. Output is clean, readable .ts/.tsx files with zero runtime dependencies.
 
 ## Core Syntax

--- a/docs/site/src/content/docs/docs/guide/installation.md
+++ b/docs/site/src/content/docs/docs/guide/installation.md
@@ -2,6 +2,10 @@
 title: Installation
 ---
 
+:::caution[Experimental]
+Floe is pre-1.0 software. The compiler may have bugs, and the language syntax, compiler output, and public APIs can change between releases. Pin the compiler version in CI and in any `package.json` that depends on `@floeorg/*` packages.
+:::
+
 ## Install the Compiler
 
 Floe ships as a single Rust binary called `floe`.

--- a/docs/site/src/content/docs/docs/guide/introduction.md
+++ b/docs/site/src/content/docs/docs/guide/introduction.md
@@ -2,6 +2,10 @@
 title: Introduction
 ---
 
+:::caution[Experimental]
+Floe is pre-1.0 and under active development. Expect bugs, rough edges, and breaking changes to the syntax, compiler output, and public APIs between releases. It is not yet recommended for production use. Pin your version and check the [changelog](https://github.com/floeorg/floe/blob/main/CHANGELOG.md) before upgrading.
+:::
+
 Floe is a programming language that compiles to TypeScript. It's designed for TypeScript and React developers who want stronger guarantees without leaving their ecosystem.
 
 ## Why Floe?

--- a/docs/site/src/content/docs/docs/index.md
+++ b/docs/site/src/content/docs/docs/index.md
@@ -10,3 +10,7 @@ hero:
       link: https://github.com/floeorg/floe
       variant: minimal
 ---
+
+:::caution[Experimental]
+Floe is pre-1.0 and under active development. Expect bugs, rough edges, and breaking changes to the syntax, compiler output, and public APIs between releases. Not yet recommended for production use.
+:::

--- a/docs/site/src/pages/index.astro
+++ b/docs/site/src/pages/index.astro
@@ -165,6 +165,34 @@ import floeLang from "../../../../editors/vscode/syntaxes/floe.tmLanguage.json";
         padding-bottom: 96px;
       }
 
+      .status-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 14px;
+        margin-bottom: 24px;
+        border-radius: 999px;
+        background: var(--pill-bg);
+        border: 1px solid var(--pill-border);
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--text-dim);
+        transition: color 0.15s, border-color 0.15s;
+      }
+
+      .status-pill:hover {
+        color: var(--text);
+        border-color: var(--text-faint);
+      }
+
+      .status-dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: #e0b84d;
+        box-shadow: 0 0 0 3px rgba(224, 184, 77, 0.18);
+      }
+
       .hero h1 {
         font-size: clamp(32px, 5vw, 50px);
         font-weight: 800;
@@ -436,6 +464,10 @@ import floeLang from "../../../../editors/vscode/syntaxes/floe.tmLanguage.json";
     </nav>
 
     <section class="hero wrap">
+      <a href="/docs/guide/introduction/" class="status-pill">
+        <span class="status-dot"></span>
+        Experimental — pre-1.0, APIs and syntax may change
+      </a>
       <h1>A functional language for the TypeScript ecosystem</h1>
       <p>
         Import any TypeScript library into Floe. Import Floe from TypeScript.


### PR DESCRIPTION
## Summary
- Make the pre-1.0 / experimental status visible wherever a user first encounters Floe so expectations about stability, breaking changes, and production-readiness are set up front.
- Adds a `[!WARNING]` callout to `README.md`, an amber status pill in the marketing landing hero (`docs/site/src/pages/index.astro`), and Starlight `:::caution` asides on the docs home, introduction, and installation pages.
- Adds status notes to `docs/design.md` and `docs/llms.txt` so LLM-generated content also surfaces the warning.

## Test plan
- [ ] `pnpm --filter floe-docs build` succeeds with no broken links or MDX errors
- [ ] Visit the rendered landing page and confirm the status pill is visible in both dark and light themes
- [ ] Confirm the Starlight cautions render correctly on the docs home, introduction, and installation pages
- [ ] Confirm the GitHub README displays the `[!WARNING]` callout correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)