### PR TITLE
fix: [#1209] instantiate + unify generics in bare-identifier pipes

### DIFF
--- a/crates/floe-core/src/checker/expr.rs
+++ b/crates/floe-core/src/checker/expr.rs
@@ -1982,19 +1982,27 @@ impl Checker {
                     return_type,
                     ..
                 } => {
-                    // Validate the piped value as the first (and only) argument
-                    if let Some(first_param) = params.first()
-                        && !self.types_compatible(first_param, left_ty)
-                    {
-                        let (msg, label) = self.type_mismatch_detail(first_param, left_ty);
-                        self.emit_error(
-                            format!("argument 1 to `{name}`: {}", msg),
-                            right.span,
-                            ErrorCode::TypeMismatch,
-                            label,
-                        );
+                    // Instantiate Generic vars as fresh Unbound, then unify
+                    // the first param with the piped-in type so the callee's
+                    // type parameters pick up `left_ty`'s shape. Without this,
+                    // `a |> genericFn` leaves the generic vars unsolved and
+                    // the return type comes back as a bare `?T1`.
+                    let (inst_params, inst_ret) =
+                        hydrator::instantiate_signature(&params, &return_type, &mut self.next_var);
+                    if let Some(first_param) = inst_params.first() {
+                        let unified = unify::unify(first_param, left_ty).is_ok();
+                        let resolved_first = first_param.resolved();
+                        if !unified && !self.types_compatible(&resolved_first, left_ty) {
+                            let (msg, label) = self.type_mismatch_detail(&resolved_first, left_ty);
+                            self.emit_error(
+                                format!("argument 1 to `{name}`: {}", msg),
+                                right.span,
+                                ErrorCode::TypeMismatch,
+                                label,
+                            );
+                        }
                     }
-                    return return_type.as_ref().clone();
+                    return inst_ret.deep_resolved();
                 }
                 // Unknown/Error types: don't error (not enough info or error already emitted)
                 Type::Unknown | Type::Error | Type::Var(_) => {}

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -8407,3 +8407,58 @@ fn handle(_r: Router<Env>) -> Response { Response("ok") }
         errors.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn bare_identifier_pipe_solves_generic_from_piped_type() {
+    // `a |> f` where `f` is a generic bare function used to return a raw
+    // unsolved type variable because `check_pipe_right` read `return_type`
+    // straight off the Function without instantiating generics or unifying
+    // with the piped-in type. The stdlib pipe path already did both —
+    // the non-stdlib bare-identifier path now mirrors it.
+    let program = crate::parser::Parser::new(
+        r#"
+type Bindings { name: string }
+
+fn identity<T>(x: T) -> T { x }
+fn tap<T>(x: T) -> T { x }
+fn chain<T>(x: T, _extra: string) -> T { x }
+
+const _bindings = Bindings(name: "x")
+const _direct = identity<Bindings>(_bindings)
+const _piped_bare = identity<Bindings>(_bindings) |> tap
+const _piped_call = identity<Bindings>(_bindings) |> chain("extra")
+const _piped_chain = identity<Bindings>(_bindings) |> chain("a") |> chain("b")
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+    let (diags, types, _, _) = Checker::new().check_with_types(&program);
+
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "generic pipe should type-check, got: {:?}",
+        errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+
+    let direct = types.get("_direct").map(String::as_str);
+    let piped_bare = types.get("_piped_bare").map(String::as_str);
+    let piped_call = types.get("_piped_call").map(String::as_str);
+    let piped_chain = types.get("_piped_chain").map(String::as_str);
+
+    assert_eq!(direct, Some("Bindings"), "direct call baseline");
+    assert_eq!(
+        piped_bare,
+        Some("Bindings"),
+        "bare-identifier pipe must resolve T to Bindings"
+    );
+    assert_eq!(piped_call, Some("Bindings"), "call-form pipe baseline");
+    assert_eq!(
+        piped_chain,
+        Some("Bindings"),
+        "chained call-form pipe baseline"
+    );
+}


### PR DESCRIPTION
closes #1209

## Summary

`a |> f` where `f` is a generic bare function (e.g. `fn tap<T>(x: T) -> T`) returned a raw unsolved type variable in the pipe result. The bare-identifier branch of `check_pipe_right` read `return_type` straight off the `Function` — no generic instantiation, no unification against the piped-in value — so `T` stayed dangling as `?T1`.

The stdlib pipe path (`validate_stdlib_pipe_call`) already did both steps. The non-stdlib bare-identifier path now mirrors it:
1. `hydrator::instantiate_signature` turns `Generic` vars into fresh `Unbound` vars shared across params + return.
2. `unify::unify(first_param, left_ty)` binds those vars to the piped-in type's shape.
3. `inst_ret.deep_resolved()` returns the resolved return type.

```floe
fn tap<T>(x: T) -> T { x }
const x = identity<Bindings>(v) |> tap    // before: ?T1   after: Bindings
```

Call-form pipes (`|> chain("a")`) and chained pipes already worked — they route through `check_call`, which has the same instantiate + unify logic. Only the bare-identifier form was missing it.

## Test plan

- [x] New regression test `bare_identifier_pipe_solves_generic_from_piped_type` — captures inferred types for `|> tap` (bare), `|> chain("a")` (call), and `|> chain("a") |> chain("b")` (chained); asserts all resolve to `Bindings`
- [x] `cargo test --workspace`: 1487 tests pass (+1 vs main), no regressions
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `floe fmt --check` / `check` all pass on `todo-app`, `store`, `hono-api`

## Related

- Sibling of #1210 (integration build) and #1211 (Foreign generic args), both landed on main.
- #1211's `has_type_param_arg` permissive fallback in `type_compat.rs` can now be tightened in a follow-up, since bare-identifier pipe chains no longer leak placeholder type params into Foreign names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)