### PR TITLE
fix: [#1204] defer arrow args in check_call so lambda hints propagate

### DIFF
--- a/crates/floe-core/src/checker/expr.rs
+++ b/crates/floe-core/src/checker/expr.rs
@@ -941,10 +941,21 @@ impl Checker {
         }
 
         let callee_ty = self.check_expr(callee);
+        // Pass 1: check non-arrow args now. Arrow args are deferred (marked
+        // with `Type::Unknown`) until the callee's parameter types are known
+        // so lambda-param hints can flow in. Without this, a destructured
+        // lambda param resolves to a fresh type var and its body comes back
+        // as `unknown` (#1204).
         let mut arg_types: Vec<Type> = args
             .iter()
             .map(|arg| match arg {
-                Arg::Positional(e) | Arg::Named { value: e, .. } => self.check_expr(e),
+                Arg::Positional(e) | Arg::Named { value: e, .. } => {
+                    if matches!(e.kind, ExprKind::Arrow { .. }) {
+                        Type::Unknown
+                    } else {
+                        self.check_expr(e)
+                    }
+                }
             })
             .collect();
         self.ctx.lambda_param_hints.clear();
@@ -1179,6 +1190,34 @@ impl Checker {
                             self.expr_types
                                 .insert(e.id, std::sync::Arc::new(resolved.clone()));
                             arg_types[i + param_offset] = resolved;
+                        }
+                    }
+
+                    // Pass 2 for arrow args (deferred during pass 1 above):
+                    // now that `params` is resolved, set lambda_param_hints
+                    // from the expected callback type so destructured params
+                    // get the right field types and the body return-type
+                    // infers against the hinted shape.
+                    for (i, arg) in args.iter().enumerate() {
+                        let e = match arg {
+                            Arg::Positional(e) | Arg::Named { value: e, .. } => e,
+                        };
+                        if !matches!(e.kind, ExprKind::Arrow { .. }) {
+                            continue;
+                        }
+                        let idx = i + param_offset;
+                        if let Some(param_ty) = params.get(idx)
+                            && let Type::Function {
+                                params: fn_params, ..
+                            } = param_ty.resolved()
+                        {
+                            self.ctx.lambda_param_hints =
+                                fn_params.iter().map(|p| p.resolved()).collect();
+                        }
+                        let actual_ty = self.check_expr(e);
+                        self.ctx.lambda_param_hints.clear();
+                        if idx < arg_types.len() {
+                            arg_types[idx] = actual_ty;
                         }
                     }
 

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -8462,3 +8462,36 @@ const _piped_chain = identity<Bindings>(_bindings) |> chain("a") |> chain("b")
         "chained call-form pipe baseline"
     );
 }
+
+#[test]
+fn destructured_lambda_param_infers_body_return_type() {
+    // Lambda with object-destructured param used to lose body return-type
+    // inference because arrow args were checked before the callee's
+    // expected param types were available as hints — destructured bindings
+    // fell through to `Type::Unknown`, so `a + b` returned `unknown`. The
+    // main call path now defers arrow args and re-checks them with hints.
+    let program = crate::parser::Parser::new(
+        r#"
+fn call(cb: ({ a: number, b: number }) -> number) -> number {
+    cb({ a: 1, b: 2 })
+}
+
+const _plain = call(({ a, b }) => a + b)
+const _alias = call(({ a: x, b: y }) => x + y)
+const _ident = call((o) => o.a + o.b)
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+    let (diags, _, _, _) = Checker::new().check_with_types(&program);
+
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "destructured-lambda call should type-check, got: {:?}",
+        errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
closes #1204

## Summary

`call(({ a, b }) => a + b)` errored with `expected ({ a: number, b: number }) -> number, found ({ a: number, b: number }) -> unknown`. The param type flowed in correctly but the body return type came back as `unknown`.

Root cause: `check_call` eagerly type-checked every argument — arrows included — before the callee's expected parameter types were known. With no `lambda_param_hints` in scope the arrow's destructured param resolved to a fresh type variable, `define_destructured_bindings` took the unresolved-type branch and bound each field to `Unknown`, and `a + b` inherited that.

The stdlib pipe path (`validate_stdlib_pipe_call`) already uses a two-pass approach. This commit mirrors it in the main non-stdlib call path:
1. Pass 1 checks non-arrow args (so their concrete types can unify into the callee's generic vars) and leaves arrow slots as `Type::Unknown`.
2. Pass 2 sets `lambda_param_hints` from the resolved callee params and checks each arrow; the existing unify/compat loop then sees real return types.

Plain single-ident arrows (`(o) => o.a + o.b`) stay on the same path and continue to check. Destructured arrows now work for plain fields (`{ a, b }`) and renames (`{ a: x, b: y }`) alike.

## Test plan

- [x] New regression test `destructured_lambda_param_infers_body_return_type` covers plain destructure, rename destructure, and the single-ident baseline.
- [x] `cargo test --workspace`: 1488 tests pass (+1 vs main), no regressions.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `floe check` passes on `todo-app`, `store`, and `hono-api`.

## Related

- Unblocks the object-destructure form of `use` from #1200 (`use { a, b } <- provideValues`) — the parser/lower/codegen were correct; only the checker was dropping the body return type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)