### PR TITLE
fix: [#1229] override cross linker so release builds don't break on missing clang

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,11 @@ jobs:
         run: cargo install cross --locked
 
       - name: Build
+        env:
+          # .cargo/config.toml pins clang+mold for linux targets to speed up native builds,
+          # but the cross-rs container ships neither. Override back to the container default.
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS: ""
         run: |
           if [ "${{ matrix.cross }}" = "true" ]; then
             cross build --release --target ${{ matrix.target }}


### PR DESCRIPTION
## Summary

- v0.5.0 release failed: `error: linker \`clang\` not found` inside the aarch64-unknown-linux-gnu cross container
- Root cause: `.cargo/config.toml` pins `linker = \"clang\"` + mold rustflags for Linux targets to speed up native builds, but cross-rs's container ships neither
- Override the linker and rustflags back to the container default via `CARGO_TARGET_*` env vars in the Build step; cross forwards `CARGO_*` env vars by default

Closes #1229

## Test plan

- [ ] Workflow YAML validates
- [ ] On the next release tag cut, the aarch64-unknown-linux-gnu job completes and uploads the archive
- [ ] x86_64-unknown-linux-gnu still builds (unchanged path: ubuntu-latest has clang+mold preinstalled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)