### PR TITLE
fix: [#1231] drop let from VSCode invalid keyword list

### DIFF
--- a/editors/vscode/syntaxes/floe.tmLanguage.json
+++ b/editors/vscode/syntaxes/floe.tmLanguage.json
@@ -108,7 +108,7 @@
         },
         {
           "name": "invalid.illegal.keyword.floe",
-          "match": "\\b(let|var|class|enum|throw|null|undefined|any|as|function)\\b"
+          "match": "\\b(var|class|enum|throw|null|undefined|any|as|function)\\b"
         }
       ]
     },


### PR DESCRIPTION
closes #1231

## Summary

`let` is Floe syntax but the VSCode TextMate grammar listed it under `invalid.illegal.keyword.floe` alongside TypeScript reserved words (`var`, `class`, `function`, …). Since `#keywords` is included before `#storage` in the root patterns, the invalid rule won and `let` rendered as an error instead of highlighting as a storage keyword.

Tree-sitter and Neovim queries were already correct — this was VSCode-only.

## Test plan

- [ ] Reload the VSCode extension (or run the extension host) and open an example like `examples/todo-app/src/*.fl`
- [ ] Confirm `let` highlights as a storage keyword (same colour as `fn`, `type`) instead of an error
- [ ] Confirm `var`, `class`, `function`, etc. are still flagged as invalid