### PR TITLE
fix: [#1239] strip .cargo/config.toml in release cross build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,12 +53,20 @@ jobs:
         if: matrix.cross
         run: cargo install cross --locked
 
+      - name: Strip .cargo/config.toml for cross build
+        if: matrix.cross
+        shell: bash
+        run: |
+          # The committed .cargo/config.toml pins `linker = "clang"` +
+          # `-fuse-ld=mold` for Linux targets so native dev/CI builds go
+          # fast. The cross-rs container ships neither tool, and the
+          # previous attempt (#1230) to override via CARGO_TARGET_* env
+          # vars wasn't reliably forwarded into the container. Empty the
+          # file during the cross step so the container toolchain
+          # defaults win (aarch64-linux-gnu-gcc).
+          : > .cargo/config.toml
+
       - name: Build
-        env:
-          # .cargo/config.toml pins clang+mold for linux targets to speed up native builds,
-          # but the cross-rs container ships neither. Override back to the container default.
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS: ""
         run: |
           if [ "${{ matrix.cross }}" = "true" ]; then
             cross build --release --target ${{ matrix.target }}


### PR DESCRIPTION
closes #1239

## Summary

- v0.5.2 release failed again on aarch64-unknown-linux-gnu with `error: linker 'clang' not found`
- PR #1230 env-var override wasn't reliably forwarded into the cross container
- Empty `.cargo/config.toml` in the cross step so the container toolchain default (`aarch64-linux-gnu-gcc`) wins

## Test plan

- [ ] Workflow YAML validates
- [ ] Re-run Release workflow for `v0.5.2` tag after merge and confirm aarch64-linux archive uploads
- [ ] x86_64-linux native build still works (separate matrix job, doesn't use cross, clang installed via apt on ubuntu-latest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)