### PR TITLE
chore: [#1247] pin @types/vscode in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,12 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+    ignore:
+      # ovsx publish rejects the VS Code extension when
+      # @types/vscode > engines.vscode. Bumping the types without also
+      # raising the minimum supported VS Code version breaks the Open VSX
+      # release, so pin this and lift it by hand together with engines.vscode.
+      - dependency-name: "@types/vscode"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Partial resolution of #1247.

## Summary

Dependabot ignore rule for `@types/vscode` with a comment explaining why (ovsx requires types ≤ engines.vscode). The dep will only move when a human also lifts `engines.vscode`.

## Not in this PR: crates.io publish order

The crates.io half of #1247 is blocked — `floe-core` is already taken on crates.io by an unrelated project (`malon64/floe`), so renaming `floe-core` (and likely `floe-lsp` too for consistency) is required before the publish-order fix can land. Tracking that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)