### PR TITLE
chore: [#1250] drop crates.io publishing from release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,23 +103,6 @@ jobs:
           tag_name: ${{ inputs.tag_name }}
           files: artifacts/*
 
-  publish-crate:
-    name: Publish to crates.io
-    needs: release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.tag_name }}
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: "1.94.0"
-
-      - name: Publish
-        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
   publish-npm:
     name: Publish to npm
     needs: release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,15 +50,20 @@ This project uses **conventional commits** + **release-please** for automated ve
 4. **The tag triggers the release workflow** which:
    - Cross-compiles binaries for macOS (arm64 + x86), Linux (x86 + arm64), Windows
    - Uploads them as assets on the GitHub Release
-   - Publishes `floe` to crates.io
-   - Publishes `@floeorg/vite-plugin` to npm
+   - Publishes `@floeorg/vite-plugin` (and the other `@floeorg/*` packages) to npm
    - Publishes the VS Code extension to Open VSX
+
+Floe is not distributed on crates.io — the compiler CLI is an end-user
+tool, not a library for other Rust projects, and `cargo install` compiles
+from source which is slow and assumes the Rust toolchain is installed.
+Users install via the prebuilt binaries in the GitHub Release or the npm
+integrations, following the same pattern as Gleam.
 
 ### Package names
 
 | Package | Registry | Name |
 |---|---|---|
-| Compiler CLI | crates.io | `floe` |
+| Compiler CLI | GitHub Releases | `floe` binary |
 | Vite plugin | npm | `@floeorg/vite-plugin` |
 | VS Code extension | Open VSX | `floeorg.floe` |
 


### PR DESCRIPTION
closes #1250

## Summary

Following the Gleam pattern: skip crates.io entirely and ship prebuilt binaries + an install script instead.

**Drop crates.io publish** — the step has been broken since the workspace split (#1102), and unblocking it would require renaming `floe-core` (already taken by an unrelated project on crates.io) and publishing 3 crates in dependency order. Not worth it for a feature whose audience is TS/React devs, not Rust users.

**Add `install.sh`** — `curl -fsSL https://raw.githubusercontent.com/floeorg/floe/main/install.sh | sh` detects OS/arch, fetches the latest GitHub Release tarball, extracts to `$INSTALL_DIR` (default `~/.local/bin`), and runs `floe --version`. Override target with `FLOE_VERSION=v0.5.4` or path with `INSTALL_DIR=/usr/local/bin`.

**CI smoke test** — new `install-script` job runs the script against the real latest release on `ubuntu-latest` and `macos-latest`, plus `shellcheck` on Ubuntu. Catches regressions if someone touches the script without testing.

**Docs** — `docs/site/.../installation.md` now recommends the script first, with `cargo install --path crates/floe-cli` preserved as the from-source option for compiler hackers. `CLAUDE.md` updated so agents don't try to resurrect the cargo publish path.

## Test plan

- [x] `shellcheck -s sh install.sh` clean
- [x] End-to-end locally: `INSTALL_DIR=/tmp/floe-install-test sh install.sh` downloaded v0.5.4, extracted, and `floe --version` printed `floe 0.5.4`
- [ ] CI `install-script` job passes on both runners
- [ ] Next release tag completes without the crates.io failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)