### PR TITLE
feat: add install.sh for prebuilt binaries + CI smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,3 +134,27 @@ jobs:
 
       - name: LSP integration tests
         run: python3 -m pytest tests/lsp/ --floe-bin=./floe -v --tb=short
+
+  install-script:
+    name: Install script smoke test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: shellcheck
+        if: matrix.os == 'ubuntu-latest'
+        run: shellcheck -s sh install.sh
+
+      - name: Run install.sh against the latest release
+        # The script pulls from the GitHub Release, not this commit — we
+        # just verify the OS/arch detection + tarball path still resolve
+        # and the binary runs.
+        env:
+          INSTALL_DIR: ${{ runner.temp }}/floe-install
+        run: |
+          sh install.sh
+          "$INSTALL_DIR/floe" --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,9 +152,11 @@ jobs:
       - name: Run install.sh against the latest release
         # The script pulls from the GitHub Release, not this commit — we
         # just verify the OS/arch detection + tarball path still resolve
-        # and the binary runs.
+        # and the binary runs. GITHUB_TOKEN lifts the API rate limit so
+        # the shared-NAT macOS runner doesn't 403 on `releases/latest`.
         env:
           INSTALL_DIR: ${{ runner.temp }}/floe-install
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           sh install.sh
           "$INSTALL_DIR/floe" --version

--- a/docs/site/src/content/docs/docs/guide/installation.md
+++ b/docs/site/src/content/docs/docs/guide/installation.md
@@ -8,15 +8,29 @@ Floe is pre-1.0 software. The compiler may have bugs, and the language syntax, c
 
 ## Install the Compiler
 
-Floe ships as a single Rust binary called `floe`.
+Floe ships as a single prebuilt binary called `floe`. The install script detects your OS and architecture and drops the binary into `~/.local/bin`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/floeorg/floe/main/install.sh | sh
+```
+
+Pin a specific version with `FLOE_VERSION`, or pick a different install directory with `INSTALL_DIR`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/floeorg/floe/main/install.sh \
+  | FLOE_VERSION=v0.5.4 INSTALL_DIR=/usr/local/bin sh
+```
+
+Supported targets: macOS (arm64 + x86_64) and Linux (x86_64 + aarch64). On Windows, download the zip from the [latest release](https://github.com/floeorg/floe/releases/latest) and add the extracted directory to your `PATH`.
 
 ### From Source
 
+If you already have Rust installed and want to hack on the compiler itself:
+
 ```bash
-# Clone and build
 git clone https://github.com/floeorg/floe
 cd floe
-cargo install --path .
+cargo install --path crates/floe-cli
 
 # Verify
 floe --version
@@ -24,8 +38,8 @@ floe --version
 
 ### Prerequisites
 
-- [Rust](https://rustup.rs/) 1.85+ (for building from source)
 - [Node.js](https://nodejs.org/) 18+ (for your project's build toolchain)
+- [Rust](https://rustup.rs/) 1.94+ (only if you're building from source)
 
 ## Create a Project
 

--- a/install.sh
+++ b/install.sh
@@ -33,10 +33,19 @@ target="${arch}-${os}"
 
 if [ "$VERSION" = "latest" ]; then
     msg "Resolving latest release tag"
-    VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+    api_url="https://api.github.com/repos/$REPO/releases/latest"
+    # Authenticate when GITHUB_TOKEN is present. Shared NAT pools (GHA
+    # macOS runners, corporate networks) hit the 60/hour anonymous limit
+    # quickly, and the token lifts it to 5000/hour.
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+        release_json=$(curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" "$api_url")
+    else
+        release_json=$(curl -fsSL "$api_url")
+    fi
+    VERSION=$(printf '%s' "$release_json" \
         | sed -n 's/.*"tag_name" *: *"\([^"]*\)".*/\1/p' \
         | head -n 1)
-    [ -n "$VERSION" ] || die "failed to resolve latest tag — GitHub API may be rate-limiting. Set FLOE_VERSION explicitly (e.g. FLOE_VERSION=v0.5.4)."
+    [ -n "$VERSION" ] || die "failed to resolve latest tag — GitHub API may be rate-limiting. Set FLOE_VERSION explicitly (e.g. FLOE_VERSION=v0.5.4) or export GITHUB_TOKEN."
 fi
 
 url="https://github.com/$REPO/releases/download/$VERSION/floe-${target}.tar.gz"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Install the Floe compiler by downloading a prebuilt binary from the latest
+# (or a pinned) GitHub Release and dropping it into a bin directory on $PATH.
+#
+#   curl -fsSL https://raw.githubusercontent.com/floeorg/floe/main/install.sh | sh
+#
+# Environment overrides:
+#   FLOE_VERSION   tag to install (default: latest). Use e.g. "v0.5.4".
+#   INSTALL_DIR    where to write the binary (default: "$HOME/.local/bin").
+
+set -eu
+
+REPO="floeorg/floe"
+VERSION="${FLOE_VERSION:-latest}"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+
+msg()  { printf '==> %s\n' "$*"; }
+die()  { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+case "$(uname -s)" in
+    Darwin) os="apple-darwin" ;;
+    Linux)  os="unknown-linux-gnu" ;;
+    *)      die "unsupported OS: $(uname -s). Download a prebuilt binary from https://github.com/$REPO/releases or build from source." ;;
+esac
+
+case "$(uname -m)" in
+    x86_64|amd64)   arch="x86_64" ;;
+    aarch64|arm64)  arch="aarch64" ;;
+    *)              die "unsupported architecture: $(uname -m)" ;;
+esac
+
+target="${arch}-${os}"
+
+if [ "$VERSION" = "latest" ]; then
+    msg "Resolving latest release tag"
+    VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+        | sed -n 's/.*"tag_name" *: *"\([^"]*\)".*/\1/p' \
+        | head -n 1)
+    [ -n "$VERSION" ] || die "failed to resolve latest tag — GitHub API may be rate-limiting. Set FLOE_VERSION explicitly (e.g. FLOE_VERSION=v0.5.4)."
+fi
+
+url="https://github.com/$REPO/releases/download/$VERSION/floe-${target}.tar.gz"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+msg "Downloading $url"
+curl -fsSL "$url" -o "$tmp/floe.tar.gz" \
+    || die "download failed. Check https://github.com/$REPO/releases/tag/$VERSION for available assets."
+
+tar -xzf "$tmp/floe.tar.gz" -C "$tmp"
+[ -f "$tmp/floe" ] || die "archive did not contain a 'floe' binary"
+
+mkdir -p "$INSTALL_DIR"
+mv "$tmp/floe" "$INSTALL_DIR/floe"
+chmod +x "$INSTALL_DIR/floe"
+
+msg "Installed floe $VERSION to $INSTALL_DIR/floe"
+
+case ":$PATH:" in
+    *":$INSTALL_DIR:"*) ;;
+    *)
+        # shellcheck disable=SC2016 # `$PATH` is intentionally literal — we're
+        # printing the line the user should paste into their shell rc.
+        printf '\nNote: %s is not on your $PATH. Add this to your shell rc:\n\n    export PATH="%s:$PATH"\n\n' "$INSTALL_DIR" "$INSTALL_DIR"
+        ;;
+esac
+
+"$INSTALL_DIR/floe" --version


### PR DESCRIPTION
Follow-up to #1251. Now that crates.io is out of the picture, users need a one-liner install.

## Summary

- `install.sh` at the repo root follows the rustup / bun / deno pattern
- Detects OS (Darwin / Linux) + arch (x86_64 / aarch64), resolves the latest tag via the GitHub API, downloads the matching release tarball, drops the binary into `$INSTALL_DIR` (default `~/.local/bin`), runs `floe --version`
- Override with `FLOE_VERSION=v0.5.4 INSTALL_DIR=/usr/local/bin`
- Warns if `$INSTALL_DIR` isn't on `$PATH`
- CI job `install-script` runs the script against the real latest release on `ubuntu-latest` + `macos-latest`, plus `shellcheck` on Ubuntu
- `docs/site/.../installation.md` now recommends the script first; `cargo install --path crates/floe-cli` remains documented for compiler hackers

Users will be able to run:
```bash
curl -fsSL https://raw.githubusercontent.com/floeorg/floe/main/install.sh | sh
```

## Test plan

- [x] `shellcheck -s sh install.sh` clean
- [x] Local end-to-end: `INSTALL_DIR=/tmp/floe-install-test sh install.sh` downloaded v0.5.4, extracted, `floe --version` printed `floe 0.5.4`
- [ ] CI `install-script` job passes on both runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)