### PR TITLE
fix: [#1253] create GitHub Releases as drafts until binaries upload

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -6,6 +6,7 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "include-component-in-tag": false,
+      "draft": true,
       "extra-files": [
         {
           "type": "generic",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,11 +102,6 @@ jobs:
         with:
           tag_name: ${{ inputs.tag_name }}
           files: artifacts/*
-          # release-please creates the release as a draft so that
-          # `/releases/latest` doesn't surface it until the binaries are
-          # attached. Flip to published once the assets upload so end
-          # users and the install.sh smoke test both see a complete
-          # release.
           draft: false
 
   publish-npm:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,11 +97,17 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      - name: Upload assets to GitHub Release
+      - name: Upload assets and promote draft to published
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.tag_name }}
           files: artifacts/*
+          # release-please creates the release as a draft so that
+          # `/releases/latest` doesn't surface it until the binaries are
+          # attached. Flip to published once the assets upload so end
+          # users and the install.sh smoke test both see a complete
+          # release.
+          draft: false
 
   publish-npm:
     name: Publish to npm


### PR DESCRIPTION
closes #1253

## Summary

Race you hit running `install.sh` right after merging a release PR:
1. release-please publishes the GitHub Release immediately on merge
2. `/releases/latest` returns the new tag
3. Separate release workflow is still building 5 targets (2-3 min)
4. Client hits `releases/download/$TAG/floe-*.tar.gz` → 404

Fix: make release-please create the release as a draft (`/releases/latest` skips drafts), then flip to published after `softprops/action-gh-release@v3` has uploaded all assets.

This also fixes the CI `install-script` smoke test that's been flaking on the same race window.

## Test plan

- [x] `release-please-config.json` is valid JSON
- [x] `release.yml` is valid YAML
- [ ] Next release cycle: draft stays until build finishes, `/releases/latest` points at the previous published release during that window, flips to the new one once assets upload
- [ ] `install-script` smoke test no longer races

🤖 Generated with [Claude Code](https://claude.com/claude-code)