### PR TITLE
fix: switch release-please from draft to prerelease so tags exist

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -6,7 +6,7 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "include-component-in-tag": false,
-      "draft": true,
+      "prerelease": true,
       "extra-files": [
         {
           "type": "generic",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,12 +97,13 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      - name: Upload assets and promote draft to published
+      - name: Upload assets and promote prerelease to latest
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.tag_name }}
           files: artifacts/*
-          draft: false
+          prerelease: false
+          make_latest: "true"
 
   publish-npm:
     name: Publish to npm


### PR DESCRIPTION
## Summary

#1254 turned on `draft: true` in release-please-config to dodge the `install.sh` race. But GitHub draft releases don't create Git tags, so the `release` workflow's first step (`checkout ref: v0.5.6`) fails — no tag, no build, no binaries. v0.5.6 is currently stuck as an unpublishable draft with no assets.

Switch to `prerelease: true`:

- Prereleases create real Git tags, so the workflow can check them out and build
- `GET /releases/latest` skips prereleases too, so the install script and its CI smoke test still see the previous complete release during the build window
- The `release` job promotes the prerelease to "latest" via `softprops/action-gh-release@v3` (`prerelease: false` + `make_latest: true`) after all assets upload

## Recovery

The v0.5.6 draft is stranded. Simplest cleanup: delete it in the GitHub UI and push an empty commit after this merges, which gives release-please a fresh run → opens a 0.5.7 PR. With the fix in place, 0.5.7 will cut cleanly.

## Test plan

- [x] JSON + YAML parse
- [ ] Delete v0.5.6 draft
- [ ] After merge + empty commit, verify 0.5.7 goes out end-to-end: prerelease → assets upload → flips to latest → install.sh picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)