### PR TITLE
fix: [#1263] substitute type params inside Foreign type args during unification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "floe"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "ariadne",
  "bincode",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "floe-doc-check"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "floe-lsp"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "floe-core",
  "insta",
@@ -355,14 +355,14 @@ dependencies = [
 
 [[package]]
 name = "floe-test-helpers"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "floe-core",
 ]
 
 [[package]]
 name = "floe-wasm"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "floe-core",
  "serde",

--- a/crates/floe-core/src/checker.rs
+++ b/crates/floe-core/src/checker.rs
@@ -27,6 +27,7 @@ pub use expr::simple_resolve_type_expr;
 pub use prelude::UNKNOWN;
 pub use printer::TypeDisplay;
 pub use problems::Problems;
+pub use type_var::any_nested as type_any_nested;
 pub use types::Type;
 
 use std::collections::{HashMap, HashSet};

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -8612,6 +8612,106 @@ export let app = router<Bindings>() |> post("/", (c) -> c.path)
 }
 
 #[test]
+fn named_handler_with_nested_type_param_matches_generic_callback() {
+    // Regression for #1263. A named handler with an explicit
+    // `Context<{ Bindings: Bindings }>` annotation should pass to a
+    // generic `post<E>` expecting `(c: Context<{ Bindings: E }>) -> ...`
+    // once `E` is inferred to `Bindings` from the first arg. Previously
+    // the Foreign name was eagerly encoded as `Context<{ Bindings: E }>`
+    // (because `E` is nested inside a record arg, not at the top level),
+    // so the string-based compat check saw `Context<{ Bindings: E }>` vs
+    // `Context<{ Bindings: Bindings }>` and rejected the handler.
+    use crate::interop::{DtsExport, FunctionParam, ObjectField, TsType};
+    use std::collections::HashMap;
+
+    let program = crate::parser::Parser::new(
+        r#"
+import trusted { router, post, Context } from "some-router"
+type Bindings = { DB: string }
+
+let handleCreate(_c: Context<{ Bindings: Bindings }>) -> string = { "ok" }
+
+export let app = router<Bindings>() |> post("/", handleCreate)
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+
+    let context_ty = DtsExport {
+        name: "Context".to_string(),
+        ts_type: TsType::Any,
+    };
+    let router_fn = DtsExport {
+        name: "router".to_string(),
+        ts_type: TsType::Function {
+            params: vec![],
+            return_type: Box::new(TsType::Generic {
+                name: "Router".to_string(),
+                args: vec![TsType::Named("E".to_string())],
+            }),
+        },
+    };
+    let ctx_generic = TsType::Generic {
+        name: "Context".to_string(),
+        args: vec![TsType::Object(vec![ObjectField {
+            name: "Bindings".to_string(),
+            ty: TsType::Named("E".to_string()),
+            optional: false,
+        }])],
+    };
+    let post_fn = DtsExport {
+        name: "post".to_string(),
+        ts_type: TsType::Function {
+            params: vec![
+                FunctionParam {
+                    ty: TsType::Generic {
+                        name: "Router".to_string(),
+                        args: vec![TsType::Named("E".to_string())],
+                    },
+                    optional: false,
+                },
+                FunctionParam {
+                    ty: TsType::Primitive("string".to_string()),
+                    optional: false,
+                },
+                FunctionParam {
+                    ty: TsType::Function {
+                        params: vec![FunctionParam {
+                            ty: ctx_generic,
+                            optional: false,
+                        }],
+                        return_type: Box::new(TsType::Primitive("string".to_string())),
+                    },
+                    optional: false,
+                },
+            ],
+            return_type: Box::new(TsType::Generic {
+                name: "Router".to_string(),
+                args: vec![TsType::Named("E".to_string())],
+            }),
+        },
+    };
+    let mut dts_imports = HashMap::new();
+    dts_imports.insert(
+        "some-router".to_string(),
+        vec![context_ty, router_fn, post_fn],
+    );
+
+    let checker = Checker::with_all_imports(HashMap::new(), dts_imports);
+    let (diags, _, _, _) = checker.check_with_types(&program);
+
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "named handler with Context<{{ Bindings: Bindings }}> should type-check against generic post<E>, got: {:?}",
+        errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn lambda_param_hint_not_clobbered_by_adjacent_trusted_calls_in_pipe_chain() {
     // Realistic shape of a Hono routing pipeline: a `router<E>()` returning a
     // wrapper, piped through multiple `post(path, (c) -> ...)` calls. Each

--- a/crates/floe-core/src/checker/type_compat.rs
+++ b/crates/floe-core/src/checker/type_compat.rs
@@ -195,14 +195,26 @@ impl Checker {
         // interchangeable. If either side still contains an unresolved
         // type-parameter placeholder (single uppercase letter like `E`, `T`,
         // a leftover from a pipe/generic-inference gap), fall back to
-        // permissive because we can't yet decide equivalence.
+        // permissive because we can't yet decide equivalence. Bare-vs-encoded
+        // (e.g. `Context` vs `Context<{ Bindings: Bindings }>`) is the same
+        // situation one step earlier: bare Foreigns only arise when the
+        // resolver stripped args containing an active type parameter, so the
+        // real question is whether `Bindings` would unify with that stripped
+        // param — which can't be answered at compat time from a name string.
         if let (Type::Foreign { name: e_name, .. }, Type::Foreign { name: a_name, .. }) =
             (expected, actual)
         {
             let e_base = e_name.split('<').next().unwrap_or(e_name);
             let a_base = a_name.split('<').next().unwrap_or(a_name);
-            if e_base == a_base && !has_type_param_arg(e_name) && !has_type_param_arg(a_name) {
-                return e_name == a_name;
+            if e_base == a_base {
+                let e_has_args = e_name.contains('<');
+                let a_has_args = a_name.contains('<');
+                if e_has_args != a_has_args {
+                    return true;
+                }
+                if !has_type_param_arg(e_name) && !has_type_param_arg(a_name) {
+                    return e_name == a_name;
+                }
             }
             return true;
         }

--- a/crates/floe-core/src/checker/type_resolve.rs
+++ b/crates/floe-core/src/checker/type_resolve.rs
@@ -207,11 +207,9 @@ impl Checker {
                     } else {
                         let resolved_args: Vec<Type> =
                             type_args.iter().map(|t| self.resolve_type(t)).collect();
-                        let any_generic = resolved_args.iter().any(|t| {
-                            matches!(t, Type::Var(_))
-                                || matches!(t, Type::Named(n)
-                                    if self.active_type_params.contains_key(n.as_str()))
-                        });
+                        let any_generic = resolved_args
+                            .iter()
+                            .any(|t| self.type_contains_active_param(t));
                         if any_generic {
                             Type::foreign(name.to_string())
                         } else {
@@ -264,5 +262,20 @@ impl Checker {
                 }
             }
         }
+    }
+
+    /// True if `ty` contains anywhere in its tree an unresolved type-parameter
+    /// marker: a fresh inference `Var`, or a `Named` whose name is a currently-
+    /// active user-written generic (e.g. `E` inside `Context<{ Bindings: E }>`).
+    /// Nested params must trigger the same bare-Foreign fallback as top-level
+    /// ones — otherwise the placeholder leaks into the encoded Foreign name
+    /// string and the Foreign-vs-Foreign compat check rejects legitimate
+    /// instantiations.
+    fn type_contains_active_param(&self, ty: &Type) -> bool {
+        type_var::any_nested(ty, &|t: &Type| match t {
+            Type::Var(_) => true,
+            Type::Named(n) => self.active_type_params.contains_key(n.as_str()),
+            _ => false,
+        })
     }
 }

--- a/crates/floe-core/src/checker/type_var.rs
+++ b/crates/floe-core/src/checker/type_var.rs
@@ -145,6 +145,40 @@ where
     }
 }
 
+/// True if `pred` holds at any node in `ty`'s tree (short-circuits). The
+/// structural walk mirrors `map_children` so new `Type` variants only need
+/// one update here, not at every call site that wants to ask "does this
+/// tree contain X?".
+pub fn any_nested<F>(ty: &Type, pred: &F) -> bool
+where
+    F: Fn(&Type) -> bool,
+{
+    if pred(ty) {
+        return true;
+    }
+    match ty {
+        Type::Promise(inner)
+        | Type::Array(inner)
+        | Type::Settable(inner)
+        | Type::Opaque { base: inner, .. } => any_nested(inner, pred),
+        Type::Set { element } => any_nested(element, pred),
+        Type::Map { key, value } | Type::RecordMap { key, value } => {
+            any_nested(key, pred) || any_nested(value, pred)
+        }
+        Type::Tuple(items) | Type::TsUnion(items) => items.iter().any(|t| any_nested(t, pred)),
+        Type::Record(fields) => fields.iter().any(|(_, t)| any_nested(t, pred)),
+        Type::Function {
+            params,
+            return_type,
+            ..
+        } => params.iter().any(|t| any_nested(t, pred)) || any_nested(return_type, pred),
+        Type::Union { variants, .. } => variants
+            .iter()
+            .any(|(_, fs)| fs.iter().any(|t| any_nested(t, pred))),
+        _ => false,
+    }
+}
+
 /// Recursively resolve all `Type::Var` `Link` chains in a type tree. Unlike
 /// `resolve`, which only follows the outermost link, `deep_resolve` rebuilds
 /// the entire tree so nested unbound-then-linked vars (like `Array<Unbound>`

--- a/crates/floe-core/src/interop/wrapper.rs
+++ b/crates/floe-core/src/interop/wrapper.rs
@@ -61,11 +61,20 @@ pub fn wrap_boundary_type(ts_type: &TsType) -> Type {
                     }
                 }
                 _ => {
-                    // Preserve generic args in the display name
-                    let args_str: Vec<String> = args
-                        .iter()
-                        .map(|a| wrap_boundary_type(a).to_string())
-                        .collect();
+                    // If any arg contains a type-parameter placeholder (a
+                    // single-uppercase-letter `Named`, at any nesting depth —
+                    // e.g. `E` inside `Context<{ Bindings: E }>`), the
+                    // placeholder would leak into the encoded name and block
+                    // later substitution. Fall back to the bare name so the
+                    // Foreign-vs-Foreign compat check can stay permissive
+                    // for unresolved generics (mirrors the same guard in
+                    // `resolve_named_type`).
+                    let wrapped_args: Vec<Type> = args.iter().map(wrap_boundary_type).collect();
+                    if wrapped_args.iter().any(contains_placeholder_param) {
+                        return Type::foreign(name.clone());
+                    }
+                    let args_str: Vec<String> =
+                        wrapped_args.iter().map(|a| a.to_string()).collect();
                     Type::foreign(format!("{}<{}>", name, args_str.join(", ")))
                 }
             }
@@ -317,6 +326,19 @@ fn wrap_non_null_inner(ty: &TsType) -> Type {
         TsType::Null | TsType::Undefined => Type::Unit,
         other => wrap_boundary_type(other),
     }
+}
+
+/// True if `ty` contains anywhere in its tree a single-uppercase-letter
+/// `Named` — the convention for an unresolved TypeScript generic parameter
+/// (`T`, `E`, `U`). Used when deciding whether to encode generic args into
+/// a Foreign name string: a placeholder baked into the string blocks later
+/// substitution during Foreign-vs-Foreign compat.
+fn contains_placeholder_param(ty: &Type) -> bool {
+    crate::checker::type_any_nested(ty, &|t: &Type| match t {
+        Type::Var(_) => true,
+        Type::Named(n) => n.len() == 1 && n.chars().next().is_some_and(|c| c.is_ascii_uppercase()),
+        _ => false,
+    })
 }
 
 /// Unwrap SetStateAction<T> → T. If not a SetStateAction, return as-is.


### PR DESCRIPTION
closes #1263

## Summary

Named handlers typed `Context<{ Bindings: Bindings }>` now pass to a generic `post<E>` expecting `Context<{ Bindings: E }>`. Previously the checker and interop wrapper only looked at the top level of each Foreign generic arg when deciding whether to encode args into the Foreign name string, so a nested type-param placeholder (`E` inside `{ Bindings: E }`) slipped through and got baked into the encoded name — string compare against the concrete actual side then rejected the handler.

## Changes

- `crates/floe-core/src/checker/type_var.rs` — new `any_nested` predicate walker that mirrors `map_children`, so "does this tree contain X?" has one structural definition.
- `crates/floe-core/src/checker/type_resolve.rs` — `resolve_named_type` now scans the full arg tree for active type params before encoding; nested placeholders trigger the bare-Foreign fallback.
- `crates/floe-core/src/interop/wrapper.rs` — `wrap_boundary_type` mirrors the same guard, using the single-uppercase-letter heuristic for .d.ts-sourced generics.
- `crates/floe-core/src/checker/type_compat.rs` — bare-vs-encoded same-base Foreign is permissive; bare Foreigns only arise from active-param stripping, and a name-string compare can't answer the unification question either way.
- `crates/floe-core/src/checker/checker.rs` — re-export `any_nested` as `type_any_nested` for the interop wrapper.

## Test plan

- [x] New regression test `named_handler_with_nested_type_param_matches_generic_callback` in `crates/floe-core/src/checker/tests.rs` — passes.
- [x] Existing `foreign_generic_args_distinguish_parameterizations` still rejects `Router<Alpha>` vs `Router<Beta>` — passes.
- [x] Existing `foreign_with_type_param_arg_stays_permissive` and `lambda_param_inferred_through_generic_trusted_fn` — pass.
- [x] Full `cargo test -p floe-core --lib`: 1493 passed.
- [x] `cargo clippy -p floe-core --all-targets -- -D warnings`: clean.
- [x] Example apps: `floe fmt` + `check` + `build` on `examples/todo-app` and `examples/store` all succeed.
- [x] Real-world verification: user's `@floeorg/hono` routes.fl no longer emits the `Context<{ Bindings: E }>` vs `Context<{ Bindings: Bindings }>` mismatch.

## Follow-ups

Does not address TS default type parameters (#1264), string-literal inference through generics (#1265), or template-literal types (#1266).