### PR TITLE
fix: [#1227] template literal interpolation spans use outer-file coordinates

### DIFF
--- a/crates/floe-core/src/lower.rs
+++ b/crates/floe-core/src/lower.rs
@@ -97,13 +97,20 @@ impl<'src> Lowerer<'src> {
 
     /// Parse a template literal source text (including backticks) into AST
     /// `TemplatePart`s, properly lowering interpolated expressions.
-    pub(super) fn lower_template_literal(&self, text: &str) -> Vec<TemplatePart> {
-        // Strip backticks
-        let inner = if text.len() >= 2 && text.starts_with('`') && text.ends_with('`') {
-            &text[1..text.len() - 1]
-        } else {
-            text
-        };
+    pub(super) fn lower_template_literal(
+        &self,
+        text: &str,
+        template_token_start: usize,
+    ) -> Vec<TemplatePart> {
+        // Strip backticks. `inner_start_in_outer` is the absolute offset in the
+        // outer file where `inner` begins (1 past the opening backtick when
+        // present, otherwise the template token's own start).
+        let (inner, inner_start_in_outer) =
+            if text.len() >= 2 && text.starts_with('`') && text.ends_with('`') {
+                (&text[1..text.len() - 1], template_token_start + 1)
+            } else {
+                (text, template_token_start)
+            };
 
         let mut parts = Vec::new();
         let mut current_raw = String::new();
@@ -163,8 +170,13 @@ impl<'src> Lowerer<'src> {
                 let interp_end = i;
                 let interp_source = &inner[interp_start..interp_end.min(inner.len())];
 
-                // Parse the interpolation as a Floe expression
-                if let Some(expr) = self.parse_interpolation_expr(interp_source) {
+                // Parse the interpolation as a Floe expression. Pass the
+                // absolute outer-file offset of the interpolation source so
+                // lowered expressions carry spans in outer coordinates —
+                // LSP's tightest-span walk depends on this.
+                let interp_outer_start = inner_start_in_outer + interp_start;
+                if let Some(expr) = self.parse_interpolation_expr(interp_source, interp_outer_start)
+                {
                     parts.push(TemplatePart::Expr(expr));
                 } else {
                     // Fallback: store as raw if parsing fails
@@ -226,7 +238,7 @@ impl<'src> Lowerer<'src> {
     }
 
     /// Parse a string of Floe source code as a single expression.
-    fn parse_interpolation_expr(&self, source: &str) -> Option<Expr> {
+    fn parse_interpolation_expr(&self, source: &str, outer_start: usize) -> Option<Expr> {
         use crate::cst::CstParser;
         use crate::lexer::Lexer;
 
@@ -242,9 +254,15 @@ impl<'src> Lowerer<'src> {
         };
         let program = lowerer.lower_root(&root);
 
-        // Extract the first expression from the program
+        // Extract the first expression; shift every span from interpolation-
+        // source coordinates to outer-file coordinates so downstream tools
+        // (LSP hover, diagnostics, go-to-def) report the right position.
         program.items.into_iter().find_map(|item| {
-            if let ItemKind::Expr(expr) = item.kind {
+            if let ItemKind::Expr(mut expr) = item.kind {
+                crate::walk::walk_expr_mut(&mut expr, &mut |e: &mut Expr| {
+                    e.span.start += outer_start;
+                    e.span.end += outer_start;
+                });
                 Some(expr)
             } else {
                 None
@@ -1178,6 +1196,57 @@ mod tests {
             items.len(),
             1,
             "chained use should nest into a single expression"
+        );
+    }
+
+    // ── Template literal interpolation spans ──────────────────────
+
+    #[test]
+    fn template_interpolation_span_is_in_outer_file_coordinates() {
+        // Regression for #1227. The lowered expression inside `${...}` must
+        // carry spans relative to the outer source, not the interpolation
+        // substring. Otherwise LSP's tightest-span walk sees a `name` expr
+        // claiming offsets (0, 4) and confuses it with an unrelated top-
+        // level binding sitting at offsets (0, 4).
+        let source = "let x = 42\n\nexport let greet(name: string) -> string = {\n    `Hello, ${name}!`\n}\n";
+        let program = lower(source);
+
+        // Walk every Expr and collect any with a span outside [0, source.len()).
+        // Also check that the interpolation `name` identifier's span points
+        // at its real position in the outer source.
+        let mut interp_ident_spans: Vec<crate::lower::Span> = Vec::new();
+        crate::walk::walk_program(&program, &mut |e: &Expr| {
+            if let ExprKind::Identifier(n) = &e.kind
+                && n == "name"
+                && e.span.end <= source.len()
+            {
+                let slice = &source[e.span.start..e.span.end];
+                if slice == "name" {
+                    interp_ident_spans.push(e.span);
+                }
+            }
+            assert!(
+                e.span.end <= source.len(),
+                "expr span {:?} extends past source length {}: kind={:?}",
+                e.span,
+                source.len(),
+                e.kind
+            );
+        });
+
+        let expected = source
+            .match_indices("${name}")
+            .next()
+            .map(|(i, _)| i + 2)
+            .expect("fixture must contain ${name}");
+        assert!(
+            interp_ident_spans
+                .iter()
+                .any(|s| s.start == expected && s.end == expected + 4),
+            "interpolation `name` span should be (outer-file-offset) ({}, {}); got {:?}",
+            expected,
+            expected + 4,
+            interp_ident_spans
         );
     }
 }

--- a/crates/floe-core/src/lower/expr.rs
+++ b/crates/floe-core/src/lower/expr.rs
@@ -244,7 +244,8 @@ impl<'src> Lowerer<'src> {
                     .children_with_tokens()
                     .filter_map(|ct| ct.into_token())
                     .find(|t| t.kind() == SyntaxKind::TEMPLATE_LITERAL)?;
-                let parts = self.lower_template_literal(template.text());
+                let template_start: usize = template.text_range().start().into();
+                let parts = self.lower_template_literal(template.text(), template_start);
                 Some(self.expr(
                     ExprKind::TaggedTemplate {
                         tag: Box::new(tag),
@@ -680,7 +681,7 @@ impl<'src> Lowerer<'src> {
                 Some(self.expr(ExprKind::String(self.unquote_string(text)), span))
             }
             SyntaxKind::TEMPLATE_LITERAL => {
-                let parts = self.lower_template_literal(text);
+                let parts = self.lower_template_literal(text, span.start);
                 Some(self.expr(ExprKind::TemplateLiteral(parts), span))
             }
             SyntaxKind::BOOL => Some(self.expr(ExprKind::Bool(text == "true"), span)),

--- a/tests/lsp/test_hover.py
+++ b/tests/lsp/test_hover.py
@@ -8,12 +8,8 @@ class TestHoverBasic:
     """Hover on constants, functions, and types."""
 
     def test_const_number(self, lsp):
-        # Use a minimal fixture — SIMPLE contains a template literal whose
-        # span miscalculation causes `find_expr_type_at_offset` to treat
-        # unrelated top-level bindings as having string type (known issue).
-        src = "let x = 42\n"
-        open_doc(lsp, URI, src)
-        h = hover_text(lsp.hover(URI, *at(src, "x")))
+        open_doc(lsp, URI, F.SIMPLE)
+        h = hover_text(lsp.hover(URI, *at(F.SIMPLE, "x")))
         assert h is not None and "number" in h, f"Expected number type, got: {h}"
 
     def test_const_string(self, lsp):


### PR DESCRIPTION
closes #1227

## Summary

LSP hover on any top-level binding returned the type of the nearest template-literal interpolation, not the binding's own type. Root cause: `${...}` interpolation expressions were lowered with spans relative to the interpolation substring, so a `name` identifier inside `\`Hello, \${name}!\`` got span (0, 4) — which `find_expr_type_at_offset` then matched against any expression at outer-file offsets (0, 4), typically an unrelated top-level binding.

## Fix

Thread the template token's absolute start offset through `lower_template_literal` and `parse_interpolation_expr`, then shift every lowered interpolation expression's span by that offset via `walk::walk_expr_mut`.

## Test plan

- [x] New regression test in \`crates/floe-core/src/lower.rs\` (\`template_interpolation_span_is_in_outer_file_coordinates\`) — the repro fixture from the issue now lowers to expressions whose spans all stay within the outer source.
- [x] \`tests/lsp/test_hover.py::TestHoverBasic::test_const_number\` is simplified to use the full \`F.SIMPLE\` fixture (which contains a template literal) rather than a minimal workaround src — passes.
- [x] All 83 LSP hover tests pass; all 250 LSP tests pass.
- [x] Full \`cargo test -p floe-core --lib\`: 1494 passed (was 1493).
- [x] \`cargo clippy -p floe-core --all-targets -- -D warnings\`: clean.
- [x] Example apps: fmt + check + build on both \`examples/todo-app\` and \`examples/store\` succeed.