### PR TITLE
feat: [#1217] support multiple _ placeholders in partial application

### DIFF
--- a/crates/floe-core/src/checker/error_codes.rs
+++ b/crates/floe-core/src/checker/error_codes.rs
@@ -73,8 +73,6 @@ pub enum ErrorCode {
     AccessOnUnknown,
     /// Access on promise - use `Promise.await` first.
     AccessOnPromise,
-    /// Only one `_` placeholder allowed per call.
-    MultiplePlaceholders,
 
     // ── Type registration errors ─────────────────────────────────────
     /// Type name must start with uppercase letter.
@@ -172,7 +170,6 @@ impl ErrorCode {
             Self::UnsafeNarrowing => "E024",
             Self::AccessOnUnknown => "E025",
             Self::AccessOnPromise => "E026",
-            Self::MultiplePlaceholders => "E027",
             Self::TypeNameCase => "E028",
             Self::InvalidEnumSpread => "E029",
             Self::DuplicateField => "E030",

--- a/crates/floe-core/src/checker/expr.rs
+++ b/crates/floe-core/src/checker/expr.rs
@@ -920,25 +920,14 @@ impl Checker {
             self.ctx.lambda_param_hints = vec![(**elem_ty).clone()];
         }
 
-        // Detect placeholder args for partial application
-        let placeholder_count = args
-            .iter()
-            .filter(|a| match a {
-                Arg::Positional(e) | Arg::Named { value: e, .. } => {
-                    matches!(e.kind, ExprKind::Placeholder)
-                }
-            })
-            .count();
-        let has_placeholder = placeholder_count > 0;
-
-        if placeholder_count > 1 {
-            self.emit_error(
-                "only one `_` placeholder allowed per call - use `(x, y) -> f(x, y)` for multiple parameters",
-                span,
-                ErrorCode::MultiplePlaceholders,
-                "multiple `_` placeholders",
-            );
-        }
+        // Detect placeholder args for partial application. Each `_` becomes
+        // a parameter of the resulting function in left-to-right order —
+        // `add3(_, 5, _)` lowers to `(a, c) => add3(a, 5, c)`.
+        let has_placeholder = args.iter().any(|a| match a {
+            Arg::Positional(e) | Arg::Named { value: e, .. } => {
+                matches!(e.kind, ExprKind::Placeholder)
+            }
+        });
 
         let callee_ty = self.check_expr(callee);
         // Pass 1: check non-arrow args now. Arrow args are deferred (marked

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -4544,17 +4544,61 @@ let _result = "hello" |> add(3, _)
 }
 
 #[test]
-fn multiple_placeholders_error() {
-    let diags = check(
-        r#"
-let add(a: number, b: number) -> number = { a + b }
-let _f = add(_, _)
+fn multiple_placeholders_build_multi_arg_function() {
+    // Regression for #1217. `add3(_, 5, _)` partially applies the middle
+    // slot, leaving two open params whose types come from the function's
+    // signature. The result is a two-arg function taking (number, number).
+    let (diags, types, _, _) = Checker::new().check_with_types(
+        &crate::parser::Parser::new(
+            r#"
+let add3(a: number, b: number, c: number) -> number = { a + b + c }
+let _f = add3(_, 5, _)
 "#,
+        )
+        .parse_program()
+        .expect("should parse"),
     );
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
     assert!(
-        has_error_containing(&diags, "only one `_` placeholder allowed per call"),
-        "multiple placeholders should produce error, got: {:?}",
-        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        errors.is_empty(),
+        "multi-placeholder partial application should type-check, got: {:?}",
+        errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        types.get("_f").map(String::as_str),
+        Some("(number, number) -> number"),
+        "expected two-arg partial, got {:?}",
+        types.get("_f")
+    );
+}
+
+#[test]
+fn four_arg_partial_with_three_placeholders() {
+    let (diags, types, _, _) = Checker::new().check_with_types(
+        &crate::parser::Parser::new(
+            r#"
+let add4(a: number, b: number, c: number, d: number) -> number = { a + b + c + d }
+let _g = add4(_, _, 10, _)
+"#,
+        )
+        .parse_program()
+        .expect("should parse"),
+    );
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "three-placeholder partial should type-check, got: {:?}",
+        errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        types.get("_g").map(String::as_str),
+        Some("(number, number, number) -> number"),
     );
 }
 

--- a/crates/floe-core/src/codegen/tests.rs
+++ b/crates/floe-core/src/codegen/tests.rs
@@ -467,6 +467,20 @@ fn partial_application() {
     assert_eq!(emit("add(10, _)"), "(_x) => add(10, _x);");
 }
 
+#[test]
+fn partial_application_multiple_placeholders() {
+    // add3(_, 5, _) -> (_x0, _x1) => add3(_x0, 5, _x1)
+    assert_eq!(emit("add3(_, 5, _)"), "(_x0, _x1) => add3(_x0, 5, _x1);");
+}
+
+#[test]
+fn partial_application_three_placeholders() {
+    assert_eq!(
+        emit("add4(_, _, 10, _)"),
+        "(_x0, _x1, _x2) => add4(_x0, _x1, 10, _x2);"
+    );
+}
+
 // ── Result / Option ──────────────────────────────────────────
 
 #[test]

--- a/crates/floe-core/src/codegen/typescript/expression.rs
+++ b/crates/floe-core/src/codegen/typescript/expression.rs
@@ -772,28 +772,50 @@ impl<'a> TypeScriptGenerator<'a> {
         callee: &TypedExpr,
         args: &[TypedArg],
     ) -> Document {
-        let param_name = "_x";
+        // Each `_` placeholder becomes a distinct arrow parameter. A single
+        // placeholder keeps the historical `_x` name for compact output;
+        // two or more use indexed names `_x0, _x1, …` in left-to-right
+        // source order.
+        let placeholder_count = args
+            .iter()
+            .filter(|a| match a {
+                Arg::Positional(e) | Arg::Named { value: e, .. } => {
+                    matches!(e.kind, ExprKind::Placeholder)
+                }
+            })
+            .count();
+        let name_for = |idx: usize| {
+            if placeholder_count == 1 {
+                "_x".to_string()
+            } else {
+                format!("_x{idx}")
+            }
+        };
+
+        let param_list = (0..placeholder_count)
+            .map(name_for)
+            .collect::<Vec<_>>()
+            .join(", ");
+
         let mut docs = vec![
-            pretty::str(format!("({param_name}) => ")),
+            pretty::str(format!("({param_list}) => ")),
             self.emit_expr(callee),
             pretty::str("("),
         ];
+        let mut placeholder_idx = 0;
         for (i, arg) in args.iter().enumerate() {
             if i > 0 {
                 docs.push(pretty::str(", "));
             }
-            match arg {
-                Arg::Positional(expr) if matches!(expr.kind, ExprKind::Placeholder) => {
-                    docs.push(pretty::str(param_name));
-                }
-                Arg::Positional(expr) => docs.push(self.emit_expr(expr)),
-                Arg::Named { value, .. } => {
-                    if matches!(value.kind, ExprKind::Placeholder) {
-                        docs.push(pretty::str(param_name));
-                    } else {
-                        docs.push(self.emit_expr(value));
-                    }
-                }
+            let value_expr = match arg {
+                Arg::Positional(expr) => expr,
+                Arg::Named { value, .. } => value,
+            };
+            if matches!(value_expr.kind, ExprKind::Placeholder) {
+                docs.push(pretty::str(name_for(placeholder_idx)));
+                placeholder_idx += 1;
+            } else {
+                docs.push(self.emit_expr(value_expr));
             }
         }
         docs.push(pretty::str(")"));

--- a/docs/design.md
+++ b/docs/design.md
@@ -214,8 +214,10 @@ users
 "hello" |> String.padStart(_, 10)      // padStart("hello", 10)
 42 |> wrap("[", _, "]")                // wrap("[", 42, "]")
 
-// _ also works outside pipes — partial application
+// _ also works outside pipes — partial application. Multiple _ placeholders
+// become parameters in left-to-right order.
 let addTen = add(10, _)              // (x) -> add(10, x)
+let between = add3(_, 5, _)          // (a, c) -> add3(a, 5, c)
 [1, 2, 3] |> map(multiply(_, 2))      // [2, 4, 6]
 
 // Dot shorthand — .field creates an implicit closure

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -235,8 +235,10 @@ let result = value
 5 |> add(3, _)              // add(3, 5) — 5 goes to second arg
 42 |> wrap("[", _, "]")     // wrap("[", 42, "]") — 42 goes to second arg
 
-// _ outside pipes creates partial application
-let addTen = add(10, _)   // (x) -> add(10, x)
+// _ outside pipes creates partial application. Multiple _ placeholders
+// become parameters in left-to-right order.
+let addTen = add(10, _)       // (x) -> add(10, x)
+let sandwich = wrap(_, "-", _) // (a, c) -> wrap(a, "-", c)
 
 // tap for side effects mid-pipeline
 users


### PR DESCRIPTION
closes #1217

## Summary

\`add3(_, 5, _)\` now compiles to \`(_x0, _x1) => add3(_x0, 5, _x1)\`. Each \`_\` becomes a parameter of the resulting function in left-to-right source order. Single-placeholder calls keep the compact \`(_x) => …\` form.

## Changes

- \`crates/floe-core/src/checker/expr.rs\` — drop the \`placeholder_count > 1\` error gate; the checker already collected placeholder param types in order.
- \`crates/floe-core/src/checker/error_codes.rs\` — delete the now-unused \`MultiplePlaceholders\` (E027) variant.
- \`crates/floe-core/src/codegen/typescript/expression.rs\` — \`emit_partial_application\` walks placeholders and assigns each a distinct arrow parameter (\`_x0, _x1, …\`), preserving the old \`_x\` name when there's exactly one.
- \`docs/llms.txt\`, \`docs/design.md\` — document the relaxed rule with an example.

## Test plan

- [x] Checker: \`multiple_placeholders_build_multi_arg_function\` — \`add3(_, 5, _)\` types as \`(number, number) -> number\`.
- [x] Checker: \`four_arg_partial_with_three_placeholders\` — \`add4(_, _, 10, _)\` types as \`(number, number, number) -> number\`.
- [x] Codegen: \`partial_application_multiple_placeholders\`, \`partial_application_three_placeholders\` cover 2- and 3-placeholder emission.
- [x] Existing \`partial_application\` codegen test (single \`_\` ⇒ \`(_x) => …\`) still passes — output is unchanged for the common case.
- [x] Full \`cargo test -p floe-core --lib\`: 1497 passed.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`: clean.
- [x] Example apps: fmt + check + build on both \`examples/todo-app\` and \`examples/store\` succeed.