### PR TITLE
feat: [#1264] apply TypeScript default type parameters to .d.ts generics

### DIFF
--- a/crates/floe-cli/src/main.rs
+++ b/crates/floe-cli/src/main.rs
@@ -141,6 +141,7 @@ fn compile_source(file_path: &Path, filename: &str, source: &str) -> Result<Comp
             resolved_imports: resolved.clone(),
             externs: ExternTypes {
                 dts_imports: tsgo_result.exports,
+                dts_generic_params: tsgo_result.generic_param_defs,
                 ambient,
                 ts_imports_missing_tsgo: tsgo_result.ts_imports_missing_tsgo,
             },

--- a/crates/floe-core/src/analyse.rs
+++ b/crates/floe-core/src/analyse.rs
@@ -25,6 +25,11 @@ use crate::resolve::ResolvedImports;
 #[derive(Debug, Default, Clone)]
 pub struct ExternTypes {
     pub dts_imports: HashMap<String, Vec<DtsExport>>,
+    /// Generic type parameter metadata (name + optional default) keyed
+    /// by the generic's declaration name. Populated alongside
+    /// `dts_imports` so the checker can pad partial type argument lists
+    /// with TypeScript's own defaults.
+    pub dts_generic_params: HashMap<String, Vec<crate::interop::GenericParamInfo>>,
     pub ambient: Option<AmbientDeclarations>,
     pub ts_imports_missing_tsgo: HashSet<String>,
 }
@@ -84,6 +89,9 @@ pub fn analyse_parsed(
         inputs.externs.ambient,
         inputs.externs.ts_imports_missing_tsgo,
     );
+    if !inputs.externs.dts_generic_params.is_empty() {
+        checker.set_dts_generic_params(inputs.externs.dts_generic_params);
+    }
     let (diagnostics, name_types, expr_types, invalid_exprs) = checker.check_all(&program);
     let name_type_map = checker.take_name_type_map();
     let references = std::mem::take(&mut checker.references);

--- a/crates/floe-core/src/build/package_compiler.rs
+++ b/crates/floe-core/src/build/package_compiler.rs
@@ -222,6 +222,7 @@ impl PackageCompiler {
                 resolved_imports: resolved.clone(),
                 externs: ExternTypes {
                     dts_imports: tsgo_result.exports,
+                    dts_generic_params: tsgo_result.generic_param_defs,
                     ambient: self.ambient.clone(),
                     ts_imports_missing_tsgo: tsgo_result.ts_imports_missing_tsgo,
                 },

--- a/crates/floe-core/src/checker.rs
+++ b/crates/floe-core/src/checker.rs
@@ -214,6 +214,12 @@ pub struct Checker {
     resolved_imports: HashMap<String, ResolvedImports>,
     /// Pre-resolved .d.ts exports for npm imports, keyed by specifier (e.g. "react").
     dts_imports: HashMap<String, Vec<DtsExport>>,
+    /// Generic type parameter metadata (name + optional default) captured
+    /// from .d.ts declarations, keyed by the generic's simple name
+    /// (e.g. "Context"). Used to pad partial type argument lists with
+    /// TypeScript's own defaults so a 1-arg user reference can unify with
+    /// a 3-arg library reference when the declaration has defaults.
+    dts_generic_params: HashMap<String, Vec<crate::interop::GenericParamInfo>>,
     /// Tracks consumed probe exports to prevent reuse.
     /// Uses (specifier_name, export_index) pairs for stable identification
     /// across HashMap iteration orders.
@@ -454,6 +460,7 @@ impl Checker {
             registering_types: false,
             resolved_imports: HashMap::new(),
             dts_imports: HashMap::new(),
+            dts_generic_params: HashMap::new(),
             probe_consumed: HashSet::new(),
             name_types: HashMap::new(),
             name_type_map: HashMap::new(),
@@ -488,6 +495,18 @@ impl Checker {
             dts_imports,
             ..Self::new()
         }
+    }
+
+    /// Register generic type parameter metadata (including defaults) from
+    /// .d.ts declarations. Each entry maps a generic's simple name to its
+    /// positional parameter list. Called by `from_context` with data
+    /// parsed from imported `.d.ts` files; exposed publicly so tests can
+    /// exercise the default-padding logic with inline fixtures.
+    pub fn set_dts_generic_params(
+        &mut self,
+        params: HashMap<String, Vec<crate::interop::GenericParamInfo>>,
+    ) {
+        self.dts_generic_params = params;
     }
 
     /// Create a checker with all available type context.

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -8863,3 +8863,139 @@ let _name = withUser((u) -> u.name)
         errors.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+// ── #1264 default type parameters ──────────────────────────────
+
+#[test]
+fn dts_generic_default_fills_missing_type_arg() {
+    // Regression for #1264. When a .d.ts generic declares defaults like
+    // `interface Foo<A = string, B = number>`, a user's 1-arg reference
+    // `Foo<boolean>` must resolve to the same Foreign as a 2-arg
+    // `Foo<boolean, number>` produced elsewhere in the same program.
+    use crate::interop::{DtsExport, GenericParamInfo, TsType};
+    use std::collections::HashMap;
+
+    let program = crate::parser::Parser::new(
+        r#"
+import trusted { Foo, pair } from "some-lib"
+
+let expectPadded(_x: Foo<boolean, number>) -> number = { 0 }
+let _usePartial = expectPadded(pair())
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+
+    let foo_export = DtsExport {
+        name: "Foo".to_string(),
+        ts_type: TsType::Any,
+    };
+    // pair(): Foo<boolean>  — library function returning a 1-arg form.
+    // Defaults should pad the second slot with `number`, making the
+    // return type equivalent to `Foo<boolean, number>`.
+    let pair_fn = DtsExport {
+        name: "pair".to_string(),
+        ts_type: TsType::Function {
+            params: vec![],
+            return_type: Box::new(TsType::Generic {
+                name: "Foo".to_string(),
+                args: vec![TsType::Primitive("boolean".to_string())],
+            }),
+        },
+    };
+
+    let mut dts_imports = HashMap::new();
+    dts_imports.insert("some-lib".to_string(), vec![foo_export, pair_fn]);
+
+    let mut generic_params = HashMap::new();
+    generic_params.insert(
+        "Foo".to_string(),
+        vec![
+            GenericParamInfo {
+                name: "A".to_string(),
+                default: Some(TsType::Primitive("string".to_string())),
+            },
+            GenericParamInfo {
+                name: "B".to_string(),
+                default: Some(TsType::Primitive("number".to_string())),
+            },
+        ],
+    );
+
+    let mut checker = Checker::with_all_imports(HashMap::new(), dts_imports);
+    checker.set_dts_generic_params(generic_params);
+    let (diags, _, _, _) = checker.check_with_types(&program);
+
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "Foo<boolean> (defaulted to Foo<boolean, number>) should unify with Foo<boolean, number>, got: {:?}",
+        errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn dts_generic_default_stops_at_first_missing_default() {
+    // If a parameter without a default sits before one with a default,
+    // padding cannot continue past it. `Foo<A, B = number>` called as
+    // `Foo<>` should leave A unresolved; we don't invent a value.
+    use crate::interop::{DtsExport, GenericParamInfo, TsType};
+    use std::collections::HashMap;
+
+    let program = crate::parser::Parser::new(
+        r#"
+import trusted { twoArgs } from "some-lib"
+let _x = twoArgs()
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+
+    let two_args_fn = DtsExport {
+        name: "twoArgs".to_string(),
+        ts_type: TsType::Function {
+            params: vec![],
+            return_type: Box::new(TsType::Generic {
+                name: "Foo".to_string(),
+                args: vec![
+                    TsType::Primitive("boolean".to_string()),
+                    TsType::Primitive("string".to_string()),
+                ],
+            }),
+        },
+    };
+    let mut dts_imports = HashMap::new();
+    dts_imports.insert("some-lib".to_string(), vec![two_args_fn]);
+
+    let mut generic_params = HashMap::new();
+    generic_params.insert(
+        "Foo".to_string(),
+        vec![
+            GenericParamInfo {
+                name: "A".to_string(),
+                default: None,
+            },
+            GenericParamInfo {
+                name: "B".to_string(),
+                default: Some(TsType::Primitive("number".to_string())),
+            },
+        ],
+    );
+
+    let mut checker = Checker::with_all_imports(HashMap::new(), dts_imports);
+    checker.set_dts_generic_params(generic_params);
+    let (diags, _, _, _) = checker.check_with_types(&program);
+
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "missing-default gap should not block legitimate usage, got: {:?}",
+        errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}

--- a/crates/floe-core/src/checker/type_compat.rs
+++ b/crates/floe-core/src/checker/type_compat.rs
@@ -2,39 +2,68 @@ use std::sync::Arc;
 
 use super::*;
 
-/// True if a Foreign type name like `Router<E>` contains an arg that looks
-/// like an unresolved type parameter (single uppercase letter). Used to stay
-/// permissive for same-base-name Foreigns when the checker hasn't yet
-/// substituted a type parameter through the call chain.
-fn has_type_param_arg(foreign_name: &str) -> bool {
-    let Some(open) = foreign_name.find('<') else {
-        return false;
-    };
-    let Some(inner) = foreign_name.get(open + 1..foreign_name.len() - 1) else {
-        return false;
-    };
+/// Split a Foreign type name like `Foo<a, b<c>>` into a (base, args) pair
+/// where args are the top-level comma-separated segments. Returns `None`
+/// when the name carries no generic arguments.
+fn split_foreign_name(foreign_name: &str) -> Option<(&str, Vec<&str>)> {
+    let open = foreign_name.find('<')?;
+    let base = &foreign_name[..open];
+    let inner = foreign_name.get(open + 1..foreign_name.len() - 1)?;
     let mut depth = 0;
     let mut start = 0;
-    let chars: Vec<(usize, char)> = inner.char_indices().collect();
-    let mut ranges: Vec<&str> = Vec::new();
-    for (i, c) in &chars {
+    let mut args: Vec<&str> = Vec::new();
+    for (i, c) in inner.char_indices() {
         match c {
             '<' => depth += 1,
             '>' => depth -= 1,
             ',' if depth == 0 => {
-                ranges.push(inner[start..*i].trim());
+                args.push(inner[start..i].trim());
                 start = i + 1;
             }
             _ => {}
         }
     }
-    ranges.push(inner[start..].trim());
-    ranges
-        .iter()
+    args.push(inner[start..].trim());
+    Some((base, args))
+}
+
+/// True if a Foreign type name like `Router<E>` contains an arg that looks
+/// like an unresolved type parameter (single uppercase letter). Used to stay
+/// permissive for same-base-name Foreigns when the checker hasn't yet
+/// substituted a type parameter through the call chain.
+fn has_type_param_arg(foreign_name: &str) -> bool {
+    let Some((_, args)) = split_foreign_name(foreign_name) else {
+        return false;
+    };
+    args.iter()
         .any(|a| a.len() == 1 && a.chars().next().is_some_and(|c| c.is_ascii_uppercase()))
 }
 
 impl Checker {
+    /// Pad a Foreign type name with .d.ts-declared default type parameters.
+    /// Returns `None` when no padding applied (either the name isn't in the
+    /// registry, its arg count already matches the declaration, or there
+    /// are no trailing defaults to supply). Callers should fall back to
+    /// the original string when `None` is returned.
+    fn normalize_foreign_name(&self, name: &str) -> Option<String> {
+        let (base, args) = split_foreign_name(name)?;
+        let param_infos = self.dts_generic_params.get(base)?;
+        if args.len() >= param_infos.len() {
+            return None;
+        }
+        let mut padded: Vec<String> = args.iter().map(|s| (*s).to_string()).collect();
+        for info in &param_infos[args.len()..] {
+            let Some(default_ts) = &info.default else {
+                break;
+            };
+            padded.push(crate::interop::wrap_boundary_type(default_ts).to_string());
+        }
+        if padded.len() == args.len() {
+            return None;
+        }
+        Some(format!("{}<{}>", base, padded.join(", ")))
+    }
+
     /// Resolve a `Type::Named` to its concrete underlying type, if possible.
     /// Returns `Some(concrete)` if the type was resolved, `None` if not a Named type.
     pub(crate) fn resolve_named_to_concrete(&self, ty: &Type) -> Option<Type> {
@@ -204,16 +233,24 @@ impl Checker {
         if let (Type::Foreign { name: e_name, .. }, Type::Foreign { name: a_name, .. }) =
             (expected, actual)
         {
-            let e_base = e_name.split('<').next().unwrap_or(e_name);
-            let a_base = a_name.split('<').next().unwrap_or(a_name);
+            // Normalize both sides against the .d.ts default-type-parameter
+            // registry so a user's 1-arg `Foo<A>` can match a library's
+            // 3-arg `Foo<A, any, {}>` when the declaration supplies the
+            // missing defaults.
+            let e_normalized = self.normalize_foreign_name(e_name);
+            let a_normalized = self.normalize_foreign_name(a_name);
+            let e_ref = e_normalized.as_deref().unwrap_or(e_name);
+            let a_ref = a_normalized.as_deref().unwrap_or(a_name);
+            let e_base = e_ref.split('<').next().unwrap_or(e_ref);
+            let a_base = a_ref.split('<').next().unwrap_or(a_ref);
             if e_base == a_base {
-                let e_has_args = e_name.contains('<');
-                let a_has_args = a_name.contains('<');
+                let e_has_args = e_ref.contains('<');
+                let a_has_args = a_ref.contains('<');
                 if e_has_args != a_has_args {
                     return true;
                 }
-                if !has_type_param_arg(e_name) && !has_type_param_arg(a_name) {
-                    return e_name == a_name;
+                if !has_type_param_arg(e_ref) && !has_type_param_arg(a_ref) {
+                    return e_ref == a_ref;
                 }
             }
             return true;

--- a/crates/floe-core/src/checker/type_resolve.rs
+++ b/crates/floe-core/src/checker/type_resolve.rs
@@ -202,11 +202,16 @@ impl Checker {
                 // into a Foreign name would leak the unresolved placeholder
                 // past instantiation sites.
                 if let Some(Type::Foreign { .. }) = self.env.lookup(name) {
-                    if type_args.is_empty() {
+                    let mut resolved_args: Vec<Type> =
+                        type_args.iter().map(|t| self.resolve_type(t)).collect();
+                    // Pad with .d.ts-declared defaults when the user supplied
+                    // fewer args than the generic has params. Stops at the
+                    // first param with no default, matching TypeScript's own
+                    // behavior (defaults must form a contiguous tail).
+                    self.pad_with_dts_defaults(name, &mut resolved_args);
+                    if resolved_args.is_empty() {
                         Type::foreign(name.to_string())
                     } else {
-                        let resolved_args: Vec<Type> =
-                            type_args.iter().map(|t| self.resolve_type(t)).collect();
                         let any_generic = resolved_args
                             .iter()
                             .any(|t| self.type_contains_active_param(t));
@@ -277,5 +282,36 @@ impl Checker {
             Type::Named(n) => self.active_type_params.contains_key(n.as_str()),
             _ => false,
         })
+    }
+
+    /// Pad `args` with .d.ts-declared default type parameters for generic
+    /// `name`, so a user-written `Foo<A>` materializes as `Foo<A, DefB>`
+    /// when the declaration reads `Foo<A, B = DefB>`. Padding stops at the
+    /// first param with no default; TypeScript requires defaults to form a
+    /// contiguous tail, and we mirror that.
+    fn pad_with_dts_defaults(&self, name: &str, args: &mut Vec<Type>) {
+        pad_foreign_args_with_defaults(&self.dts_generic_params, name, args);
+    }
+}
+
+/// Module-level helper so `wrap_boundary_type` callers can apply the same
+/// padding without going through a `Checker` method. `args` is mutated in
+/// place — padding stops at the first parameter with no default.
+pub(crate) fn pad_foreign_args_with_defaults(
+    registry: &std::collections::HashMap<String, Vec<crate::interop::GenericParamInfo>>,
+    name: &str,
+    args: &mut Vec<Type>,
+) {
+    let Some(param_infos) = registry.get(name) else {
+        return;
+    };
+    if args.len() >= param_infos.len() {
+        return;
+    }
+    for info in &param_infos[args.len()..] {
+        let Some(default_ts) = &info.default else {
+            break;
+        };
+        args.push(crate::interop::wrap_boundary_type(default_ts));
     }
 }

--- a/crates/floe-core/src/interop.rs
+++ b/crates/floe-core/src/interop.rs
@@ -28,7 +28,9 @@ use std::process::Command;
 use crate::checker::Type;
 
 // Re-export public API
-pub use dts::{DtsExport, parse_dts_exports};
+pub use dts::{
+    DtsExport, GenericParamInfo, collect_generic_param_defs_from_source, parse_dts_exports,
+};
 pub use ts_types::{FunctionParam, ObjectField, TsType, ts_type_to_string};
 pub use tsgo::{TsgoResolver, TsgoResult};
 pub use wrapper::wrap_boundary_type;

--- a/crates/floe-core/src/interop/dts.rs
+++ b/crates/floe-core/src/interop/dts.rs
@@ -21,6 +21,17 @@ pub struct DtsExport {
     pub ts_type: TsType,
 }
 
+/// Generic type parameter metadata captured at declaration time. Used to
+/// pad partial type argument lists with TypeScript's own defaults so that
+/// `Context<{ Bindings: B }>` and `Context<{ Bindings: B }, any, {}>`
+/// resolve to the same Foreign type when the declaration reads
+/// `interface Context<E = Env, P extends string = any, I extends Input = {}>`.
+#[derive(Debug, Clone)]
+pub struct GenericParamInfo {
+    pub name: String,
+    pub default: Option<TsType>,
+}
+
 /// Reads a .d.ts file and extracts its named exports.
 ///
 /// Uses oxc_parser to parse the declaration file AST and extract exports.
@@ -2157,5 +2168,107 @@ fn resolve_generic_params(ty: &mut TsType, bounds: &HashMap<String, TsType>) {
             }
         }
         _ => {}
+    }
+}
+
+/// Collect generic type-parameter defaults for interfaces and type aliases
+/// so the checker can pad partial type-argument lists. Keyed by the
+/// generic's declaration name (e.g. "Context"), value is one entry per
+/// positional type parameter in source order.
+pub fn collect_generic_param_defs_from_source(
+    source: &str,
+) -> Result<HashMap<String, Vec<GenericParamInfo>>, String> {
+    use oxc_allocator::Allocator;
+    use oxc_parser::{ParseOptions, Parser as OxcParser};
+    use oxc_span::SourceType;
+
+    let allocator = Allocator::default();
+    let source_type = SourceType::ts();
+    let ret = OxcParser::new(&allocator, source, source_type)
+        .with_options(ParseOptions {
+            parse_regular_expression: false,
+            ..ParseOptions::default()
+        })
+        .parse();
+    if !ret.errors.is_empty() {
+        return Err(format!("parse errors: {:?}", ret.errors));
+    }
+    let mut out: HashMap<String, Vec<GenericParamInfo>> = HashMap::new();
+    for stmt in &ret.program.body {
+        collect_generic_param_defs(stmt, &mut out);
+    }
+    Ok(out)
+}
+
+/// Walk a single statement (recursively into module blocks and export
+/// declarations) and record the generic parameter list for each
+/// interface and type alias declaration.
+fn collect_generic_param_defs(
+    stmt: &Statement<'_>,
+    out: &mut HashMap<String, Vec<GenericParamInfo>>,
+) {
+    use oxc_ast::ast::{Declaration, TSModuleDeclarationBody};
+
+    match stmt {
+        Statement::TSInterfaceDeclaration(iface) => {
+            record_generic_params(&iface.id.name, iface.type_parameters.as_deref(), out);
+        }
+        Statement::TSTypeAliasDeclaration(type_decl) => {
+            record_generic_params(
+                &type_decl.id.name,
+                type_decl.type_parameters.as_deref(),
+                out,
+            );
+        }
+        Statement::ExportNamedDeclaration(export_decl) => {
+            if let Some(ref decl) = export_decl.declaration {
+                match decl {
+                    Declaration::TSInterfaceDeclaration(iface) => {
+                        record_generic_params(
+                            &iface.id.name,
+                            iface.type_parameters.as_deref(),
+                            out,
+                        );
+                    }
+                    Declaration::TSTypeAliasDeclaration(type_decl) => {
+                        record_generic_params(
+                            &type_decl.id.name,
+                            type_decl.type_parameters.as_deref(),
+                            out,
+                        );
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Statement::TSModuleDeclaration(ns_decl) => {
+            if let Some(TSModuleDeclarationBody::TSModuleBlock(block)) = &ns_decl.body {
+                for inner in &block.body {
+                    collect_generic_param_defs(inner, out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn record_generic_params(
+    name: &str,
+    type_params: Option<&oxc_ast::ast::TSTypeParameterDeclaration<'_>>,
+    out: &mut HashMap<String, Vec<GenericParamInfo>>,
+) {
+    let Some(tp) = type_params else {
+        return;
+    };
+    let infos: Vec<GenericParamInfo> = tp
+        .params
+        .iter()
+        .map(|p| GenericParamInfo {
+            name: p.name.to_string(),
+            default: p.default.as_ref().map(convert_oxc_type),
+        })
+        .collect();
+    if !infos.is_empty() {
+        out.insert(name.to_string(), infos);
     }
 }

--- a/crates/floe-core/src/interop/tsgo.rs
+++ b/crates/floe-core/src/interop/tsgo.rs
@@ -35,6 +35,12 @@ use specifier_map::build_specifier_map;
 pub struct TsgoResult {
     /// Resolved exports per import specifier.
     pub exports: HashMap<String, Vec<DtsExport>>,
+    /// Generic type parameter metadata (name + optional default) collected
+    /// from .d.ts declarations, keyed by the generic's declaration name
+    /// (e.g. "Context"). Lets the checker pad partial type argument lists
+    /// with TypeScript's own defaults when a library writes
+    /// `interface Context<E = Env, P = any, I = {}>`.
+    pub generic_param_defs: HashMap<String, Vec<super::dts::GenericParamInfo>>,
     /// Import sources that resolve to `.ts`/`.tsx` files but could not be
     /// resolved because tsgo is not installed.
     pub ts_imports_missing_tsgo: HashSet<String>,
@@ -96,6 +102,7 @@ impl TsgoResolver {
             let _ = (program, resolved_imports, source_dir, tsconfig_paths);
             return TsgoResult {
                 exports: HashMap::new(),
+                generic_param_defs: HashMap::new(),
                 ts_imports_missing_tsgo: HashSet::new(),
             };
         }
@@ -126,11 +133,56 @@ impl TsgoResolver {
             // DTS parsing, typeof resolution, and LSP hover for unresolved types.
             let mut result = self.run_probe(program, resolved_imports, effective_ts_imports);
             self.enhance_import_types(&mut result, program, effective_ts_imports);
+            // Collect generic type parameter defaults from every resolved
+            // .d.ts source so the checker can pad partial type argument
+            // lists (e.g. Hono's `Context<E = Env, P extends string = any,
+            // I extends Input = {}>`).
+            let generic_param_defs = self.collect_generic_param_defs(program, resolved_imports);
             TsgoResult {
                 exports: result,
+                generic_param_defs,
                 ts_imports_missing_tsgo: missing_tsgo,
             }
         }
+    }
+
+    /// Collect generic type parameter defaults (e.g. `E = Env`) from every
+    /// npm package .d.ts referenced by the program. tsgo's probe output
+    /// loses original interface declarations, so we re-read the source
+    /// .d.ts for each specifier and collect defaults directly.
+    #[cfg(feature = "native")]
+    fn collect_generic_param_defs(
+        &self,
+        program: &Program,
+        resolved_imports: &HashMap<String, crate::resolve::ResolvedImports>,
+    ) -> HashMap<String, Vec<super::dts::GenericParamInfo>> {
+        let mut out: HashMap<String, Vec<super::dts::GenericParamInfo>> = HashMap::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        for item in &program.items {
+            let crate::parser::ast::ItemKind::Import(imp) = &item.kind else {
+                continue;
+            };
+            let specifier = imp.source.trim_matches('"');
+            if resolved_imports.contains_key(specifier) {
+                continue;
+            }
+            if !seen.insert(specifier.to_string()) {
+                continue;
+            }
+            let Some(dts_path) = typeof_resolve::find_package_dts(&self.project_dir, specifier)
+            else {
+                continue;
+            };
+            let Ok(content) = std::fs::read_to_string(&dts_path) else {
+                continue;
+            };
+            if let Ok(defs) = super::dts::collect_generic_param_defs_from_source(&content) {
+                for (k, v) in defs {
+                    out.entry(k).or_insert(v);
+                }
+            }
+        }
+        out
     }
 
     /// Run the probe system for call-site type resolution.

--- a/crates/floe-lsp/src/lib.rs
+++ b/crates/floe-lsp/src/lib.rs
@@ -383,6 +383,7 @@ impl FloeLsp {
 
         let externs = ExternTypes {
             dts_imports: tsgo_result.exports,
+            dts_generic_params: tsgo_result.generic_param_defs,
             ambient,
             ts_imports_missing_tsgo: tsgo_result.ts_imports_missing_tsgo,
         };


### PR DESCRIPTION
closes #1264

## Summary

TypeScript interfaces and type aliases with default type parameters — e.g. Hono's \`interface Context<E = Env, P extends string = any, I extends Input = {}>\` — now pad partial type argument lists with those defaults at the checker boundary. A user's \`Context<{ Bindings: B }>\` (1 arg) and a library's \`Context<{ Bindings: B }, any, {}>\` (3 args) resolve to the same Foreign type instead of failing unification.

Second item in the #1263/#1264/#1265/#1266 Hono DX series.

## Changes

- **\`interop/dts.rs\`** — parses defaults from \`TSInterfaceDeclaration\` and \`TSTypeAliasDeclaration\` (including export and namespace wrappers) into new \`GenericParamInfo { name, default }\`. Public helper \`collect_generic_param_defs_from_source(&str)\`.
- **\`interop/tsgo.rs\`** — \`TsgoResult\` carries \`generic_param_defs\`; \`TsgoResolver::collect_generic_param_defs\` walks every npm specifier referenced by the program and re-reads its root .d.ts for defaults (tsgo probe output loses original interface declarations).
- **\`analyse.rs\`** — \`ExternTypes\` gains a \`dts_generic_params\` field; \`analyse_parsed\` hands it to the checker.
- **\`checker.rs\`** — new \`dts_generic_params\` field + \`set_dts_generic_params\` setter.
- **\`checker/type_resolve.rs\`** — \`resolve_named_type\` pads user-written Foreign references up front via \`pad_with_dts_defaults\`.
- **\`checker/type_compat.rs\`** — \`types_compatible\` normalizes Foreign name strings at comparison time so library-side references (already string-encoded before the registry was available) also benefit; \`split_foreign_name\` replaces the old inline inner-arg parser.
- **CLI, package compiler, LSP** — populate \`ExternTypes.dts_generic_params\` from \`TsgoResult.generic_param_defs\`.

## Test plan

- [x] \`dts_generic_default_fills_missing_type_arg\` — user \`Foo<boolean>\` unifies with library \`Foo<boolean, number>\` via defaults.
- [x] \`dts_generic_default_stops_at_first_missing_default\` — when a leading parameter has no default, padding stops at the gap (matches TypeScript's contiguous-tail rule).
- [x] Full \`cargo test -p floe-core --lib\`: 1496 passed.
- [x] \`cargo test --workspace\`: all crates green.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`: clean.
- [x] Example apps: fmt + check + build on both \`examples/todo-app\` and \`examples/store\` succeed.

## Follow-ups

The remaining \`c.env.DB: unknown\` error in the Hono yeet fixture is not fixed by #1264 — that's indexed-access / conditional types (#1265 + #1266 territory). #1264 specifically unblocks interfaces and type aliases that rely on defaults to resolve partial instantiations symmetrically.