### PR TITLE
fix: [#1271] LSP hover/goto-def on for-block headers and dependent rechecks

### DIFF
--- a/crates/floe-core/src/checker/attach.rs
+++ b/crates/floe-core/src/checker/attach.rs
@@ -252,6 +252,7 @@ impl Attacher<'_> {
         ForBlock {
             type_name: self.type_expr(block.type_name),
             trait_name: block.trait_name,
+            trait_name_span: block.trait_name_span,
             functions: block
                 .functions
                 .into_iter()

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -4820,6 +4820,7 @@ fn for_block_same_fn_name_different_types_no_conflict() {
             span: dummy_span,
         },
         trait_name: None,
+        trait_name_span: None,
         functions: vec![FunctionDecl {
             exported: true,
             async_fn: false,

--- a/crates/floe-core/src/lower/items.rs
+++ b/crates/floe-core/src/lower/items.rs
@@ -387,6 +387,7 @@ impl<'src> Lowerer<'src> {
         // Find the type expression (first TYPE_EXPR child)
         let mut type_name = None;
         let mut trait_name = None;
+        let mut trait_name_span = None;
         let mut functions = Vec::new();
 
         // Collect idents that appear after a colon (trait name)
@@ -401,6 +402,7 @@ impl<'src> Lowerer<'src> {
                         saw_colon = true;
                     } else if saw_colon && token.kind() == SyntaxKind::IDENT {
                         trait_name = Some(token.text().to_string());
+                        trait_name_span = Some(self.token_span(&token));
                         saw_colon = false;
                     }
                 }
@@ -423,6 +425,7 @@ impl<'src> Lowerer<'src> {
         Some(ForBlock {
             type_name: type_name?,
             trait_name,
+            trait_name_span,
             functions,
             span,
         })

--- a/crates/floe-core/src/parser/ast.rs
+++ b/crates/floe-core/src/parser/ast.rs
@@ -406,6 +406,8 @@ pub struct ForBlock<T = ()> {
     pub type_name: TypeExpr<T>,
     /// Optional trait bound: `for User: Display { ... }`
     pub trait_name: Option<String>,
+    /// Span of the trait name identifier in the header, for hover/goto-def.
+    pub trait_name_span: Option<Span>,
     pub functions: Vec<FunctionDecl<T>>,
     pub span: Span,
 }

--- a/crates/floe-core/src/parser/tests.rs
+++ b/crates/floe-core/src/parser/tests.rs
@@ -1632,6 +1632,26 @@ export for User: Display {
 }
 
 #[test]
+fn for_block_trait_name_span_points_at_identifier() {
+    let input = r#"
+type User = { name: string }
+trait Display { let display(self) -> string }
+for User: Display {
+    let display(self) -> string = { self.name }
+}
+"#;
+    let program = parse_ok(input);
+    let ItemKind::ForBlock(block) = &program.items[2].kind else {
+        panic!("expected ForBlock");
+    };
+    let span = block
+        .trait_name_span
+        .as_ref()
+        .expect("trait_name_span should be set when header has a trait");
+    assert_eq!(&input[span.start..span.end], "Display");
+}
+
+#[test]
 fn per_method_export_still_works_on_for_block() {
     let input = r#"
 type User = { name: string }

--- a/crates/floe-core/src/resolve.rs
+++ b/crates/floe-core/src/resolve.rs
@@ -420,6 +420,10 @@ fn resolve_single_cached(
                     return Some(cached_imports.clone());
                 }
                 // Cache miss — parse the already-read bytes (no second read).
+                // Record the dep as visited so dep_paths reports it to the
+                // caller (LSP uses this to maintain reverse-dep rechecks) and
+                // so transitive cycles terminate.
+                visited.insert(canonical.clone());
                 let source_code = String::from_utf8(dep_bytes).ok()?;
                 let resolved =
                     resolve_from_source(&dep_path, &source_code, visited, tsconfig_paths)?;

--- a/crates/floe-lsp/src/handlers.rs
+++ b/crates/floe-lsp/src/handlers.rs
@@ -63,15 +63,14 @@ impl LanguageServer for FloeLsp {
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
         let uri = params.text_document.uri;
         if let Some(change) = params.content_changes.into_iter().next_back() {
-            self.update_document(uri, &change.text).await;
+            self.update_document(uri.clone(), &change.text).await;
+            self.recheck_dependents(&uri).await;
         }
     }
 
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
-        self.documents
-            .write()
-            .await
-            .remove(&params.text_document.uri);
+        let uri = params.text_document.uri;
+        self.forget_document(&uri).await;
     }
 
     // ── Hover ───────────────────────────────────────────────────

--- a/crates/floe-lsp/src/index.rs
+++ b/crates/floe-lsp/src/index.rs
@@ -134,6 +134,26 @@ fn collect_items(items: &[TypedItem], symbols: &mut Vec<Symbol>) {
                         variant_shape: None,
                     });
                 }
+                // `import { for TraitName }` brings the trait name into scope
+                // for use in `for Type: TraitName { ... }` headers. Register
+                // each for-specifier as an import symbol so hover and goto-def
+                // on the trait name resolve to the source module.
+                for for_spec in &decl.for_specifiers {
+                    symbols.push(Symbol {
+                        name: for_spec.type_name.clone(),
+                        kind: SymbolKind::INTERFACE,
+                        start: for_spec.span.start,
+                        end: for_spec.span.end,
+                        import_source: Some(decl.source.clone()),
+                        detail: format!(
+                            "import {{ for {} }} from \"{}\"",
+                            for_spec.type_name, decl.source
+                        ),
+                        first_param_type: None,
+                        owner_type: None,
+                        variant_shape: None,
+                    });
+                }
             }
             ItemKind::Const(decl) => {
                 let name = match &decl.binding {
@@ -395,6 +415,42 @@ fn collect_items(items: &[TypedItem], symbols: &mut Vec<Symbol>) {
             }
             ItemKind::ForBlock(block) => {
                 let type_str = type_expr_to_string(&block.type_name);
+
+                // Index the type name in the header so hover shows the type
+                // signature at the cursor position inside `for Type: ...`.
+                if let TypeExprKind::Named { name, .. } = &block.type_name.kind {
+                    symbols.push(Symbol {
+                        name: name.clone(),
+                        kind: SymbolKind::TYPE_PARAMETER,
+                        start: block.type_name.span.start,
+                        end: block.type_name.span.end,
+                        import_source: None,
+                        detail: format!("for {type_str}"),
+                        first_param_type: None,
+                        owner_type: None,
+                        variant_shape: None,
+                    });
+                }
+
+                // Index the trait name in the header. Hover shows the trait
+                // reference; goto-def falls through to the import specifier
+                // (registered above) via the cursor-on-def-name skip.
+                if let (Some(trait_name), Some(trait_span)) =
+                    (&block.trait_name, &block.trait_name_span)
+                {
+                    symbols.push(Symbol {
+                        name: trait_name.clone(),
+                        kind: SymbolKind::INTERFACE,
+                        start: trait_span.start,
+                        end: trait_span.end,
+                        import_source: None,
+                        detail: format!("trait {trait_name}"),
+                        first_param_type: None,
+                        owner_type: None,
+                        variant_shape: None,
+                    });
+                }
+
                 for func in &block.functions {
                     symbols.push(for_block_function_symbol(
                         func,

--- a/crates/floe-lsp/src/lib.rs
+++ b/crates/floe-lsp/src/lib.rs
@@ -200,6 +200,10 @@ struct Document {
     /// consults it for precise definition spans so intra-module jumps
     /// don't rely on name-based index lookups.
     references: ReferenceTracker,
+    /// Canonical paths of every `.fl` file this document transitively
+    /// imports. Used to maintain the reverse-dependency index so edits
+    /// to an imported file re-check the files that depend on it.
+    dep_paths: HashSet<PathBuf>,
 }
 
 // ── LSP Protocol Constants ──────────────────────────────────────
@@ -257,6 +261,10 @@ pub struct FloeLsp {
     /// are reused without re-parsing. Avoids re-walking every
     /// imported `.fl` module on each keystroke.
     resolve_cache: Arc<RwLock<HashMap<PathBuf, (u64, floe_core::resolve::ResolvedImports)>>>,
+    /// Reverse-dependency index: canonical file path → open documents
+    /// that transitively import it. Edits to a dependency trigger a
+    /// re-check of every dependent so diagnostics don't go stale.
+    reverse_deps: Arc<RwLock<HashMap<PathBuf, HashSet<Url>>>>,
 }
 
 impl FloeLsp {
@@ -267,6 +275,7 @@ impl FloeLsp {
             dts_cache: Arc::new(RwLock::new(HashMap::new())),
             logged_projects: Arc::new(RwLock::new(HashSet::new())),
             resolve_cache: Arc::new(RwLock::new(HashMap::new())),
+            reverse_deps: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -325,14 +334,17 @@ impl FloeLsp {
         source_path: &Path,
         program: &floe_core::parser::ast::Program,
         tsconfig_paths: &floe_core::resolve::TsconfigPaths,
-    ) -> HashMap<String, floe_core::resolve::ResolvedImports> {
+    ) -> (
+        HashMap<String, floe_core::resolve::ResolvedImports>,
+        HashSet<PathBuf>,
+    ) {
         // Snapshot the cache under a read lock so concurrent LSP
         // handlers don't block on each other. The resolve function
         // writes fresh entries into the snapshot; we merge them back
         // under a write lock only if there were misses.
         let snapshot = self.resolve_cache.read().await.clone();
         let mut working = snapshot;
-        let (resolved, _dep_paths) = floe_core::resolve::resolve_imports_cached(
+        let (resolved, dep_paths) = floe_core::resolve::resolve_imports_cached(
             source_path,
             program,
             tsconfig_paths,
@@ -342,7 +354,7 @@ impl FloeLsp {
         if working.len() > self.resolve_cache.read().await.len() {
             *self.resolve_cache.write().await = working;
         }
-        resolved
+        (resolved, dep_paths)
     }
 
     /// Resolve `.fl` imports, tsgo exports, and ambient declarations for a
@@ -358,6 +370,7 @@ impl FloeLsp {
         Option<PathBuf>,
         Option<PathBuf>,
         floe_core::resolve::TsconfigPaths,
+        HashSet<PathBuf>,
     ) {
         let Ok(source_path) = uri.to_file_path() else {
             return (
@@ -366,13 +379,14 @@ impl FloeLsp {
                 None,
                 None,
                 Default::default(),
+                HashSet::new(),
             );
         };
         let source_dir = source_path.parent().unwrap_or(Path::new(".")).to_path_buf();
         let project_dir = find_project_dir(&source_dir);
         let tsconfig_paths = floe_core::resolve::TsconfigPaths::from_project_dir(&project_dir);
         self.log_project_info(&project_dir, &tsconfig_paths).await;
-        let resolved_imports = self
+        let (resolved_imports, dep_paths) = self
             .resolve_imports_cached(&source_path, program, &tsconfig_paths)
             .await;
 
@@ -393,6 +407,7 @@ impl FloeLsp {
             Some(project_dir),
             Some(source_dir),
             tsconfig_paths,
+            dep_paths,
         )
     }
 
@@ -411,18 +426,19 @@ impl FloeLsp {
 
         // Partial trees from lossy parses skip import/extern resolution
         // since the module inputs may be incomplete.
-        let (resolved_imports, externs, project_dir, source_dir, tsconfig_paths) = if full_parse_ok
-        {
-            self.gather_module_inputs(&uri, &program).await
-        } else {
-            (
-                HashMap::new(),
-                ExternTypes::default(),
-                None,
-                None,
-                Default::default(),
-            )
-        };
+        let (resolved_imports, externs, project_dir, source_dir, tsconfig_paths, dep_paths) =
+            if full_parse_ok {
+                self.gather_module_inputs(&uri, &program).await
+            } else {
+                (
+                    HashMap::new(),
+                    ExternTypes::default(),
+                    None,
+                    None,
+                    Default::default(),
+                    HashSet::new(),
+                )
+            };
 
         let analysed = analyse::analyse_parsed(
             program,
@@ -471,6 +487,8 @@ impl FloeLsp {
         let references = analysed.references;
         let typed_program = Some(typed_program);
 
+        self.update_reverse_deps(&uri, &dep_paths).await;
+
         self.documents.write().await.insert(
             uri.clone(),
             Document {
@@ -479,12 +497,88 @@ impl FloeLsp {
                 type_map,
                 typed_program,
                 references,
+                dep_paths,
             },
         );
 
         self.client
             .publish_diagnostics(uri, diagnostics, None)
             .await;
+    }
+
+    /// Update the reverse-dependency index so that `uri` is listed as a
+    /// dependent for every path in `new_deps`, and removed from paths it
+    /// no longer imports.
+    async fn update_reverse_deps(&self, uri: &Url, new_deps: &HashSet<PathBuf>) {
+        let old_deps = self
+            .documents
+            .read()
+            .await
+            .get(uri)
+            .map(|d| d.dep_paths.clone())
+            .unwrap_or_default();
+        let mut reverse = self.reverse_deps.write().await;
+        for path in old_deps.difference(new_deps) {
+            if let Some(set) = reverse.get_mut(path) {
+                set.remove(uri);
+                if set.is_empty() {
+                    reverse.remove(path);
+                }
+            }
+        }
+        for path in new_deps.difference(&old_deps) {
+            reverse.entry(path.clone()).or_default().insert(uri.clone());
+        }
+    }
+
+    /// Files whose diagnostics depend on `changed_uri`. Looked up via the
+    /// reverse-dependency index so we can re-check them after an edit.
+    async fn dependents_of(&self, changed_uri: &Url) -> Vec<Url> {
+        let Ok(path) = changed_uri.to_file_path() else {
+            return Vec::new();
+        };
+        let canonical = path.canonicalize().unwrap_or(path);
+        self.reverse_deps
+            .read()
+            .await
+            .get(&canonical)
+            .map(|set| set.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Re-check every open document that imports `changed_uri`. Called
+    /// after the changed file itself has been updated, so dependents see
+    /// fresh export info when their imports are resolved.
+    pub(crate) async fn recheck_dependents(&self, changed_uri: &Url) {
+        let dependents = self.dependents_of(changed_uri).await;
+        for dep_uri in dependents {
+            let source = self
+                .documents
+                .read()
+                .await
+                .get(&dep_uri)
+                .map(|d| d.content.clone());
+            if let Some(source) = source {
+                Box::pin(self.update_document(dep_uri, &source)).await;
+            }
+        }
+    }
+
+    /// Drop the document's state and remove it from the reverse-dependency
+    /// index so closed files no longer receive cascade rechecks.
+    pub(crate) async fn forget_document(&self, uri: &Url) {
+        let removed = self.documents.write().await.remove(uri);
+        if let Some(doc) = removed {
+            let mut reverse = self.reverse_deps.write().await;
+            for path in &doc.dep_paths {
+                if let Some(set) = reverse.get_mut(path) {
+                    set.remove(uri);
+                    if set.is_empty() {
+                        reverse.remove(path);
+                    }
+                }
+            }
+        }
     }
 
     /// Convert Floe diagnostics to LSP diagnostics.

--- a/crates/floe-lsp/src/lib.rs
+++ b/crates/floe-lsp/src/lib.rs
@@ -517,6 +517,12 @@ impl FloeLsp {
             .get(uri)
             .map(|d| d.dep_paths.clone())
             .unwrap_or_default();
+        // Keystroke edits typically don't change the import set. Skip the
+        // write lock when nothing changed so hover/completion handlers
+        // don't contend with us on every keypress.
+        if old_deps == *new_deps {
+            return;
+        }
         let mut reverse = self.reverse_deps.write().await;
         for path in old_deps.difference(new_deps) {
             if let Some(set) = reverse.get_mut(path) {

--- a/tests/lsp/test_for_block_header.py
+++ b/tests/lsp/test_for_block_header.py
@@ -1,0 +1,158 @@
+"""Tests for LSP support on `for Type: Trait { ... }` headers.
+
+Covers three gaps fixed in #1271:
+- Hover on the type name in a for-block header
+- Goto-definition on the trait name in a for-block header
+- Re-checking dependent files when a trait file changes
+"""
+
+import time
+
+from .conftest import (
+    at,
+    def_locations,
+    diag_codes,
+    hover_text,
+    open_doc,
+    open_and_diagnose,
+)
+
+
+SINGLE_FILE = """\
+type Container = { label: string }
+
+trait Greeter {
+    let hello(self) -> string
+}
+
+for Container: Greeter {
+    export let hello(self) -> string = {
+        self.label
+    }
+}
+"""
+
+
+class TestForBlockHeaderHover:
+    def test_hover_on_type_name(self, lsp):
+        uri = "file:///tmp/for_hover_type.fl"
+        open_doc(lsp, uri, SINGLE_FILE)
+        line, col = at(SINGLE_FILE, "for Container", offset=4)
+        h = hover_text(lsp.hover(uri, line, col))
+        assert h is not None, "expected hover on type name in for-header"
+        assert "Container" in h, f"expected Container in hover, got: {h}"
+
+    def test_hover_on_trait_name(self, lsp):
+        uri = "file:///tmp/for_hover_trait.fl"
+        open_doc(lsp, uri, SINGLE_FILE)
+        line, col = at(SINGLE_FILE, ": Greeter", offset=2)
+        h = hover_text(lsp.hover(uri, line, col))
+        assert h is not None, "expected hover on trait name in for-header"
+        assert "Greeter" in h, f"expected Greeter in hover, got: {h}"
+
+
+class TestForBlockHeaderGotoDef:
+    def test_goto_type_in_header(self, lsp):
+        uri = "file:///tmp/for_goto_type.fl"
+        open_doc(lsp, uri, SINGLE_FILE)
+        line, col = at(SINGLE_FILE, "for Container", offset=4)
+        locs = def_locations(lsp.goto_definition(uri, line, col))
+        assert locs, "goto-def on type name in for-header returned nothing"
+
+    def test_goto_trait_in_header_cross_file(self, lsp, tmp_path):
+        trait_src = (
+            "export trait Greeter {\n"
+            "    let hello(self) -> string\n"
+            "}\n"
+        )
+        impl_src = (
+            'import { for Greeter } from "./greeter"\n'
+            "export type MyGreeter = { prefix: string }\n"
+            "for MyGreeter: Greeter {\n"
+            "    export let hello(self) -> string = { self.prefix }\n"
+            "}\n"
+        )
+        trait_path = tmp_path / "greeter.fl"
+        impl_path = tmp_path / "impl.fl"
+        trait_path.write_text(trait_src)
+        impl_path.write_text(impl_src)
+        trait_uri = f"file://{trait_path}"
+        impl_uri = f"file://{impl_path}"
+        open_doc(lsp, trait_uri, trait_src)
+        open_doc(lsp, impl_uri, impl_src)
+
+        line, col = at(impl_src, ": Greeter", offset=2)
+        locs = def_locations(lsp.goto_definition(impl_uri, line, col))
+        assert locs, "goto-def on imported trait name returned nothing"
+        target = locs[0].get("uri", "")
+        assert "greeter" in target, f"goto-def should jump to trait file, got: {target}"
+
+
+class TestDependentRecheck:
+    def test_trait_change_refreshes_impl_diagnostics(self, lsp, tmp_path):
+        """Editing a trait file must refresh diagnostics on open files
+        that implement it — the symptom reported in the original bug
+        was that a new required method did not appear as missing until
+        the language server was restarted."""
+        trait_src_v1 = (
+            "export trait Greeter {\n"
+            "    let hello(self) -> string\n"
+            "}\n"
+        )
+        trait_src_v2 = (
+            "export trait Greeter {\n"
+            "    let hello(self) -> string\n"
+            "    let bye(self) -> string\n"
+            "}\n"
+        )
+        impl_src = (
+            'import { for Greeter } from "./greeter"\n'
+            "export type MyGreeter = { prefix: string }\n"
+            "for MyGreeter: Greeter {\n"
+            "    export let hello(self) -> string = { self.prefix }\n"
+            "}\n"
+        )
+        trait_path = tmp_path / "greeter.fl"
+        impl_path = tmp_path / "impl.fl"
+        trait_path.write_text(trait_src_v1)
+        impl_path.write_text(impl_src)
+        trait_uri = f"file://{trait_path}"
+        impl_uri = f"file://{impl_path}"
+
+        open_doc(lsp, trait_uri, trait_src_v1)
+        impl_diag = open_and_diagnose(lsp, impl_uri, impl_src)
+        assert "E023" not in impl_diag.codes, (
+            f"impl should have no missing-method error initially, got: {impl_diag.codes}"
+        )
+
+        # Write new trait content to disk and notify via didChange so the
+        # LSP cascades a recheck onto the impl file.
+        trait_path.write_text(trait_src_v2)
+        lsp.send(
+            "textDocument/didChange",
+            {
+                "textDocument": {"uri": trait_uri, "version": 2},
+                "contentChanges": [{"text": trait_src_v2}],
+            },
+            notification=True,
+        )
+
+        # Collect diagnostics across both files; the cascade republishes
+        # diagnostics on the impl file.
+        deadline = time.time() + 5.0
+        impl_codes: list[str] = []
+        while time.time() < deadline:
+            notifs = lsp.collect_notifications(
+                "textDocument/publishDiagnostics", timeout=1.0
+            )
+            impl_notifs = [
+                n for n in notifs if n.get("params", {}).get("uri") == impl_uri
+            ]
+            if impl_notifs:
+                impl_codes = diag_codes(impl_notifs)
+                break
+
+        assert "E023" in impl_codes, (
+            f"impl should report missing-method error after trait changed, "
+            f"got codes: {impl_codes}"
+        )


### PR DESCRIPTION
closes #1271

Three related LSP gaps around `for Type: Trait { ... }` blocks.

## Summary
- **Hover on for-block header identifiers**: `ForBlock` now carries a `trait_name_span`, and the LSP indexer registers symbols for both the type name and the trait name in the header so hover returns a result.
- **Goto-definition on imported trait names**: import `for_specifiers` (`import { for TraitName }`) are indexed as imports with an `import_source`, so goto-def on the trait name in a for-header follows the import to the source file.
- **Dependent rechecks on file change**: the LSP maintains a reverse-dependency index (canonical file path → open documents that transitively import it) and `recheck_dependents` runs after `did_change`, so editing a trait file refreshes diagnostics on every open implementor without restarting the language server.
- **resolve.rs cache-miss fix**: `resolve_single_cached` now inserts the dep's canonical path into `visited` on cache miss, so `dep_paths` reports every `.fl` file the LSP needs to track.

## Test plan
- [x] `cargo test --workspace` — 1495+ tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `python3 -m pytest tests/lsp/ --floe-bin=./target/debug/floe` — 255 pass
- [x] `floe fmt --check` + `floe check` on `examples/todo-app/src/` and `examples/store/src/`
- [x] Manual smoke: hover on `DrizzleSnippetRepository` and `SnippetRepository` in `for DrizzleSnippetRepository: SnippetRepository { ... }` now returns content; goto-def on the trait name jumps to the imported trait file; adding a method to the trait surfaces `E023 missing method` on implementors without restarting the LSP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)