### PR TITLE
fix: [#1274, #1275] function-type alias unfold + closure body formatter

### DIFF
--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -9043,3 +9043,81 @@ let _x = twoArgs()
         errors.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+// ── Function-type aliases are structural (#1274) ─────────────
+
+#[test]
+fn function_type_alias_accepts_zero_arg_closure() {
+    let diags = check(
+        r#"
+type CreatePoop = () -> string
+export let poop: CreatePoop = () -> "poop"
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::TypeMismatch),
+        "closure should satisfy structural function alias, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn function_type_alias_accepts_one_arg_closure() {
+    let diags = check(
+        r#"
+type F = (number) -> number
+export let f: F = (x) -> x + 1
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::TypeMismatch),
+        "one-arg closure should satisfy structural function alias, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn function_type_alias_call_site_returns_unwrapped_type() {
+    let diags = check(
+        r#"
+type F = () -> string
+let f: F = () -> "x"
+export let s: string = f()
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::TypeMismatch),
+        "calling an alias-typed value should return the alias's return type, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn function_type_alias_as_parameter_accepts_closure_literal() {
+    let diags = check(
+        r#"
+type F = () -> string
+let run(g: F) -> string = { g() }
+export let r: string = run(() -> "z")
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::TypeMismatch),
+        "passing a closure to an alias-typed parameter should check, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn nominal_newtype_still_rejects_raw_payload() {
+    let diags = check(
+        r#"
+type OrderId = OrderId(number)
+export let id: OrderId = 42
+"#,
+    );
+    assert!(
+        has_error(&diags, ErrorCode::TypeMismatch),
+        "nominal newtype must keep rejecting raw payload values"
+    );
+}

--- a/crates/floe-core/src/checker/type_compat.rs
+++ b/crates/floe-core/src/checker/type_compat.rs
@@ -64,6 +64,26 @@ impl Checker {
         Some(format!("{}<{}>", base, padded.join(", ")))
     }
 
+    /// Unfold a `Type::Named` that resolves to a `TypeDef::Alias` (structural
+    /// alias). Nominal defs (record / union / newtype / opaque) and names that
+    /// don't refer to a user-declared type return `None`.
+    pub(crate) fn unfold_structural_alias(&self, ty: &Type) -> Option<Type> {
+        let Type::Named(name) = ty else {
+            return None;
+        };
+        let info = self.env.lookup_type(name)?;
+        if info.opaque {
+            return None;
+        }
+        if !matches!(info.def, crate::parser::ast::TypeDef::Alias(_)) {
+            return None;
+        }
+        Some(
+            self.env
+                .resolve_to_concrete(ty, &expr::simple_resolve_type_expr),
+        )
+    }
+
     /// Resolve a `Type::Named` to its concrete underlying type, if possible.
     /// Returns `Some(concrete)` if the type was resolved, `None` if not a Named type.
     pub(crate) fn resolve_named_to_concrete(&self, ty: &Type) -> Option<Type> {
@@ -207,6 +227,17 @@ impl Checker {
         // `never` is compatible with any type (it means "this code never returns")
         if matches!(actual, Type::Never) || matches!(expected, Type::Never) {
             return true;
+        }
+
+        // Structural alias unfolding: `type F = () -> string` is a structural
+        // alias per docs/design.md, so `Named("F")` must unfold to its RHS
+        // before comparison. Nominal types (record defs, tagged unions,
+        // newtypes, opaque) stay nominal — only `TypeDef::Alias` unfolds.
+        if let Some(unfolded) = self.unfold_structural_alias(expected) {
+            return self.types_compatible(&unfolded, actual);
+        }
+        if let Some(unfolded) = self.unfold_structural_alias(actual) {
+            return self.types_compatible(expected, &unfolded);
         }
 
         // Result<T, E> is never compatible with a non-Result expected type.

--- a/crates/floe-core/src/formatter.rs
+++ b/crates/floe-core/src/formatter.rs
@@ -471,29 +471,6 @@ impl<'src> Formatter<'src> {
             .map(|t| t.text().to_string())
     }
 
-    /// Format expression after `=>`
-    pub(crate) fn fmt_expr_after_fat_arrow(&mut self, node: &SyntaxNode) -> Document {
-        let mut found_arrow = false;
-        for t in node.children_with_tokens() {
-            if let Some(tok) = t.as_token() {
-                if tok.kind() == SyntaxKind::FAT_ARROW {
-                    found_arrow = true;
-                    continue;
-                }
-                if found_arrow && !tok.kind().is_trivia() {
-                    return pretty::str(tok.text());
-                }
-            }
-            if let Some(child) = t.into_node()
-                && found_arrow
-                && child.kind() != SyntaxKind::PARAM
-            {
-                return self.fmt_node(&child);
-            }
-        }
-        pretty::nil()
-    }
-
     /// Check if a JSX element will format as multiline (heuristic).
     pub(crate) fn is_multiline_jsx(&self, node: &SyntaxNode) -> bool {
         if node.kind() != SyntaxKind::JSX_ELEMENT {

--- a/crates/floe-core/src/formatter/expr.rs
+++ b/crates/floe-core/src/formatter/expr.rs
@@ -1039,54 +1039,37 @@ impl Formatter<'_> {
         parts.push(pretty::str(")"));
 
         // Body may be a child node (block, binary expr, call, …) or a bare
-        // token (identifier, string, number, bool). Walk the children in
-        // order and take the first meaningful content after the thin arrow.
-        let mut past_arrow = false;
-        let mut body_node: Option<SyntaxNode> = None;
-        let mut body_token: Option<String> = None;
-        for t in node.children_with_tokens() {
-            match t {
-                rowan::NodeOrToken::Token(tok) => {
-                    if tok.kind() == SyntaxKind::THIN_ARROW {
-                        past_arrow = true;
-                        continue;
-                    }
-                    if past_arrow
-                        && !tok.kind().is_trivia()
-                        && body_node.is_none()
-                        && body_token.is_none()
-                    {
-                        body_token = Some(tok.text().to_string());
-                    }
-                }
-                rowan::NodeOrToken::Node(child) => {
-                    if past_arrow
-                        && child.kind() != SyntaxKind::PARAM
-                        && body_node.is_none()
-                        && body_token.is_none()
-                    {
-                        body_node = Some(child);
-                    }
-                }
-            }
-        }
+        // token (identifier, string, number, bool), since single-token
+        // expressions like `"poop"` aren't wrapped in a node.
+        let body = node
+            .children_with_tokens()
+            .skip_while(|t| {
+                t.as_token()
+                    .is_none_or(|tok| tok.kind() != SyntaxKind::THIN_ARROW)
+            })
+            .skip(1)
+            .find(|t| match t {
+                rowan::NodeOrToken::Token(tok) => !tok.kind().is_trivia(),
+                rowan::NodeOrToken::Node(child) => child.kind() != SyntaxKind::PARAM,
+            });
 
-        if let Some(body) = body_node {
-            if self.is_multiline_jsx(&body) {
+        match body {
+            Some(rowan::NodeOrToken::Node(body)) if self.is_multiline_jsx(&body) => {
                 parts.push(pretty::str(" ->"));
                 parts.push(pretty::nest(
                     4,
                     pretty::concat(vec![pretty::line(), self.fmt_node(&body)]),
                 ));
-            } else {
+            }
+            Some(rowan::NodeOrToken::Node(body)) => {
                 parts.push(pretty::str(" -> "));
                 parts.push(self.fmt_node(&body));
             }
-        } else if let Some(tok_text) = body_token {
-            parts.push(pretty::str(" -> "));
-            parts.push(pretty::str(tok_text));
-        } else {
-            parts.push(pretty::str(" ->"));
+            Some(rowan::NodeOrToken::Token(tok)) => {
+                parts.push(pretty::str(" -> "));
+                parts.push(pretty::str(tok.text().to_string()));
+            }
+            None => parts.push(pretty::str(" ->")),
         }
 
         pretty::concat(parts)

--- a/crates/floe-core/src/formatter/expr.rs
+++ b/crates/floe-core/src/formatter/expr.rs
@@ -1038,9 +1038,40 @@ impl Formatter<'_> {
         }
         parts.push(pretty::str(")"));
 
-        let body = node.children().find(|c| c.kind() != SyntaxKind::PARAM);
+        // Body may be a child node (block, binary expr, call, …) or a bare
+        // token (identifier, string, number, bool). Walk the children in
+        // order and take the first meaningful content after the thin arrow.
+        let mut past_arrow = false;
+        let mut body_node: Option<SyntaxNode> = None;
+        let mut body_token: Option<String> = None;
+        for t in node.children_with_tokens() {
+            match t {
+                rowan::NodeOrToken::Token(tok) => {
+                    if tok.kind() == SyntaxKind::THIN_ARROW {
+                        past_arrow = true;
+                        continue;
+                    }
+                    if past_arrow
+                        && !tok.kind().is_trivia()
+                        && body_node.is_none()
+                        && body_token.is_none()
+                    {
+                        body_token = Some(tok.text().to_string());
+                    }
+                }
+                rowan::NodeOrToken::Node(child) => {
+                    if past_arrow
+                        && child.kind() != SyntaxKind::PARAM
+                        && body_node.is_none()
+                        && body_token.is_none()
+                    {
+                        body_node = Some(child);
+                    }
+                }
+            }
+        }
 
-        if let Some(body) = body {
+        if let Some(body) = body_node {
             if self.is_multiline_jsx(&body) {
                 parts.push(pretty::str(" ->"));
                 parts.push(pretty::nest(
@@ -1051,9 +1082,11 @@ impl Formatter<'_> {
                 parts.push(pretty::str(" -> "));
                 parts.push(self.fmt_node(&body));
             }
-        } else {
+        } else if let Some(tok_text) = body_token {
             parts.push(pretty::str(" -> "));
-            parts.push(self.fmt_expr_after_fat_arrow(node));
+            parts.push(pretty::str(tok_text));
+        } else {
+            parts.push(pretty::str(" ->"));
         }
 
         pretty::concat(parts)

--- a/crates/floe-core/src/formatter/tests.rs
+++ b/crates/floe-core/src/formatter/tests.rs
@@ -991,3 +991,43 @@ fn idempotent_todo_app_todo_fl() {
     let src = include_str!("../../../../examples/todo-app/src/todo.fl");
     assert_idempotent(src);
 }
+
+// ── Single-expression closures keep their body (#1275) ──────
+
+#[test]
+fn format_zero_arg_closure_string_body() {
+    assert_fmt(r#"let f = () -> "poop""#, r#"let f = () -> "poop""#);
+}
+
+#[test]
+fn format_zero_arg_closure_with_alias_annotation() {
+    assert_fmt(
+        "type F = () -> string\nlet f: F = () -> \"poop\"",
+        "type F = () -> string\n\nlet f: F = () -> \"poop\"",
+    );
+}
+
+#[test]
+fn format_one_arg_closure_single_expression_body() {
+    assert_fmt("let f = (x) -> x + 1", "let f = (x) -> x + 1");
+}
+
+#[test]
+fn format_zero_arg_closure_identifier_body() {
+    assert_fmt("let f = () -> x", "let f = () -> x");
+}
+
+#[test]
+fn format_zero_arg_closure_block_body() {
+    assert_fmt(r#"let f = () -> { "x" }"#, "let f = () -> {\n    \"x\"\n}");
+}
+
+#[test]
+fn idempotent_zero_arg_closure_with_alias() {
+    assert_idempotent("type F = () -> string\n\nlet f: F = () -> \"poop\"\n");
+}
+
+#[test]
+fn idempotent_one_arg_closure_single_expression() {
+    assert_idempotent("let f = (x) -> x + 1\n");
+}


### PR DESCRIPTION
closes #1274
closes #1275

## Summary

Two small, related bugs from the same repro:

```floe
type CreatePoop = () -> string
export let poop: CreatePoop = () -> "poop"
```

**#1274** — the checker rejected the closure with `E001 expected CreatePoop, found () -> string`. `types_compatible` now unfolds `TypeDef::Alias` on either side before comparing, so a structural function-type alias (per `docs/llms.txt:69`) accepts a structurally-matching closure. Nominal defs (record, tagged union, newtype, opaque) continue to compare by name.

**#1275** — `floe fmt` silently stripped the closure body, leaving `() ->` with no RHS. `fmt_arrow` looked for a child *node* as the body and fell back to a helper that scanned for `=>`, but arrows use `->` and single-token bodies (identifier, string, number, bool) aren't wrapped in a node. `fmt_arrow` now walks `children_with_tokens` after the `THIN_ARROW` and keeps either a node or a token body. The unused fat-arrow fallback is deleted.

## Test plan

- [x] Repro file type-checks cleanly and round-trips through `floe fmt` unchanged
- [x] `cargo test -p floe-core` — 1511 + 33 + 29 + 104 passing
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `floe check` / `floe build` on `examples/todo-app` and `examples/store`
- [x] Regression: `type OrderId = OrderId(number); let id: OrderId = 42` still errors