### PR TITLE
feat: [#1276] evaluate indexed access types and thread generic args through probes

### DIFF
--- a/crates/floe-core/src/interop.rs
+++ b/crates/floe-core/src/interop.rs
@@ -35,26 +35,6 @@ pub use ts_types::{FunctionParam, ObjectField, TsType, ts_type_to_string};
 pub use tsgo::{TsgoResolver, TsgoResult};
 pub use wrapper::wrap_boundary_type;
 
-/// Evaluate an indexed-access type `object[index]` when both sides are
-/// concrete enough to resolve. Returns `Some(field_type)` when `object`
-/// is an `Object` with a field matching the `StringLiteral` `index`, or
-/// when the lookup bottoms out at an `Any`/`Unknown` (where we preserve
-/// the widest answer). Returns `None` when the lookup can't be decided
-/// — callers fall back to `Type::Unknown`, matching TypeScript's own
-/// "can't evaluate yet" behavior.
-pub(crate) fn evaluate_indexed_access(object: &TsType, index: &TsType) -> Option<TsType> {
-    let key = match index {
-        TsType::StringLiteral(s) => s.clone(),
-        _ => return None,
-    };
-    match object {
-        TsType::Object(fields) => fields.iter().find(|f| f.name == key).map(|f| f.ty.clone()),
-        TsType::Any => Some(TsType::Any),
-        TsType::Unknown => Some(TsType::Unknown),
-        _ => None,
-    }
-}
-
 // Re-export internal helpers so tests (and sibling submodules) can access via `use super::*`
 #[cfg(test)]
 #[allow(unused_imports)]

--- a/crates/floe-core/src/interop.rs
+++ b/crates/floe-core/src/interop.rs
@@ -35,6 +35,26 @@ pub use ts_types::{FunctionParam, ObjectField, TsType, ts_type_to_string};
 pub use tsgo::{TsgoResolver, TsgoResult};
 pub use wrapper::wrap_boundary_type;
 
+/// Evaluate an indexed-access type `object[index]` when both sides are
+/// concrete enough to resolve. Returns `Some(field_type)` when `object`
+/// is an `Object` with a field matching the `StringLiteral` `index`, or
+/// when the lookup bottoms out at an `Any`/`Unknown` (where we preserve
+/// the widest answer). Returns `None` when the lookup can't be decided
+/// — callers fall back to `Type::Unknown`, matching TypeScript's own
+/// "can't evaluate yet" behavior.
+pub(crate) fn evaluate_indexed_access(object: &TsType, index: &TsType) -> Option<TsType> {
+    let key = match index {
+        TsType::StringLiteral(s) => s.clone(),
+        _ => return None,
+    };
+    match object {
+        TsType::Object(fields) => fields.iter().find(|f| f.name == key).map(|f| f.ty.clone()),
+        TsType::Any => Some(TsType::Any),
+        TsType::Unknown => Some(TsType::Unknown),
+        _ => None,
+    }
+}
+
 // Re-export internal helpers so tests (and sibling submodules) can access via `use super::*`
 #[cfg(test)]
 #[allow(unused_imports)]

--- a/crates/floe-core/src/interop/dts.rs
+++ b/crates/floe-core/src/interop/dts.rs
@@ -1305,10 +1305,13 @@ macro_rules! convert_shared_type_arms {
             // narrow against the original type.
             $prefix::TSMappedType(_) => TsType::Unknown,
 
-            // Indexed access: T['k'] — without evaluating the lookup we
-            // can't return the field type. Use the source type so the
-            // surrounding code still typechecks as "something from T".
-            $prefix::TSIndexedAccessType(access) => convert_oxc_type(&access.object_type),
+            // Indexed access: T['k']. Preserved as a structured node so
+            // later stages can evaluate the lookup once `T` is
+            // substituted to a concrete type (see `evaluate_indexed_access`).
+            $prefix::TSIndexedAccessType(access) => TsType::IndexedAccess {
+                object: Box::new(convert_oxc_type(&access.object_type)),
+                index: Box::new(convert_oxc_type(&access.index_type)),
+            },
 
             // Template literal type: `` `prefix.${K}` `` — widen to string.
             $prefix::TSTemplateLiteralType(_) => TsType::Primitive("string".to_string()),

--- a/crates/floe-core/src/interop/tests.rs
+++ b/crates/floe-core/src/interop/tests.rs
@@ -1110,7 +1110,7 @@ export type Env<E> = E["Bindings"]
 
 #[test]
 fn evaluate_indexed_access_concrete_object() {
-    use super::evaluate_indexed_access;
+    use super::wrapper::evaluate_indexed_access;
     let obj = TsType::Object(vec![
         ObjectField {
             name: "DB".to_string(),
@@ -1129,7 +1129,7 @@ fn evaluate_indexed_access_concrete_object() {
 
 #[test]
 fn evaluate_indexed_access_missing_key_is_none() {
-    use super::evaluate_indexed_access;
+    use super::wrapper::evaluate_indexed_access;
     let obj = TsType::Object(vec![ObjectField {
         name: "DB".to_string(),
         ty: TsType::Primitive("string".to_string()),
@@ -1141,7 +1141,7 @@ fn evaluate_indexed_access_missing_key_is_none() {
 
 #[test]
 fn evaluate_indexed_access_abstract_object_is_none() {
-    use super::evaluate_indexed_access;
+    use super::wrapper::evaluate_indexed_access;
     // `E["Bindings"]` where `E` is still a type parameter — cannot
     // evaluate yet, so the helper returns `None` and callers fall
     // back to `unknown`.

--- a/crates/floe-core/src/interop/tests.rs
+++ b/crates/floe-core/src/interop/tests.rs
@@ -1074,3 +1074,95 @@ fn strip_import_sentinels_cleans_surviving_names() {
         other => panic!("expected Generic, got {other:?}"),
     }
 }
+
+// ── Indexed access types (#1276) ───────────────────────────────
+
+#[test]
+fn parse_indexed_access_in_dts() {
+    use super::dts::parse_dts_exports_from_str;
+
+    let source = r#"
+export type Bindings = { DB: string }
+export type Env<E> = E["Bindings"]
+"#;
+    let exports = parse_dts_exports_from_str(source).expect("parse");
+    let env = exports
+        .iter()
+        .find(|e| e.name == "Env")
+        .expect("Env export");
+    match &env.ts_type {
+        TsType::IndexedAccess { object, index } => {
+            assert!(
+                matches!(&**object, TsType::Named(n) if n == "E"),
+                "expected object to be Named(\"E\"), got {:?}",
+                object
+            );
+            assert_eq!(
+                **index,
+                TsType::StringLiteral("Bindings".to_string()),
+                "expected StringLiteral(\"Bindings\"), got {:?}",
+                index
+            );
+        }
+        other => panic!("expected IndexedAccess, got {other:?}"),
+    }
+}
+
+#[test]
+fn evaluate_indexed_access_concrete_object() {
+    use super::evaluate_indexed_access;
+    let obj = TsType::Object(vec![
+        ObjectField {
+            name: "DB".to_string(),
+            ty: TsType::Primitive("string".to_string()),
+            optional: false,
+        },
+        ObjectField {
+            name: "KV".to_string(),
+            ty: TsType::Primitive("number".to_string()),
+            optional: false,
+        },
+    ]);
+    let result = evaluate_indexed_access(&obj, &TsType::StringLiteral("DB".to_string()));
+    assert_eq!(result, Some(TsType::Primitive("string".to_string())));
+}
+
+#[test]
+fn evaluate_indexed_access_missing_key_is_none() {
+    use super::evaluate_indexed_access;
+    let obj = TsType::Object(vec![ObjectField {
+        name: "DB".to_string(),
+        ty: TsType::Primitive("string".to_string()),
+        optional: false,
+    }]);
+    let result = evaluate_indexed_access(&obj, &TsType::StringLiteral("bogus".to_string()));
+    assert_eq!(result, None);
+}
+
+#[test]
+fn evaluate_indexed_access_abstract_object_is_none() {
+    use super::evaluate_indexed_access;
+    // `E["Bindings"]` where `E` is still a type parameter — cannot
+    // evaluate yet, so the helper returns `None` and callers fall
+    // back to `unknown`.
+    let result = evaluate_indexed_access(
+        &TsType::Named("E".to_string()),
+        &TsType::StringLiteral("Bindings".to_string()),
+    );
+    assert_eq!(result, None);
+}
+
+#[test]
+fn wrap_indexed_access_concrete_returns_field_type() {
+    // Boundary wrap of a concrete `{ DB: string }["DB"]` resolves to
+    // Floe's `string`, not `unknown`.
+    let ty = TsType::IndexedAccess {
+        object: Box::new(TsType::Object(vec![ObjectField {
+            name: "DB".to_string(),
+            ty: TsType::Primitive("string".to_string()),
+            optional: false,
+        }])),
+        index: Box::new(TsType::StringLiteral("DB".to_string())),
+    };
+    assert_eq!(wrap_boundary_type(&ty), Type::String);
+}

--- a/crates/floe-core/src/interop/ts_types.rs
+++ b/crates/floe-core/src/interop/ts_types.rs
@@ -68,6 +68,14 @@ pub enum TsType {
     /// `this` return type — resolved to the enclosing interface/class name
     /// during conversion so fluent builders keep a usable type.
     This,
+    /// Indexed access: `E["Bindings"]` — the value type at `index` in
+    /// `object`. Preserved until generic parameters are substituted and
+    /// the lookup can be evaluated; unresolvable lookups fall back to
+    /// `Unknown` at the Floe boundary.
+    IndexedAccess {
+        object: Box<TsType>,
+        index: Box<TsType>,
+    },
 }
 
 /// Convert a TsType to a human-readable string for display.
@@ -117,6 +125,13 @@ pub fn ts_type_to_string(ty: &TsType) -> String {
         TsType::NumberLiteral(n) => n.to_string(),
         TsType::BooleanLiteral(b) => b.to_string(),
         TsType::This => "this".to_string(),
+        TsType::IndexedAccess { object, index } => {
+            format!(
+                "{}[{}]",
+                ts_type_to_string(object),
+                ts_type_to_string(index)
+            )
+        }
     }
 }
 

--- a/crates/floe-core/src/interop/tsgo.rs
+++ b/crates/floe-core/src/interop/tsgo.rs
@@ -1345,9 +1345,11 @@ export let handler(c: Context<unknown>) -> string ={
         let program = Parser::new(source).parse_program().unwrap();
         let probe = generate_probe(&program, &HashMap::new(), &HashMap::new());
 
+        // The probe must emit the parameter's full TS annotation so tsgo
+        // propagates the concrete generic args through the chain (#1276).
         assert!(
-            probe.contains("declare const __chain_base_Context: Context;"),
-            "probe should declare a Context chain base, got:\n{probe}"
+            probe.contains("declare const __chain_base_Context: Context<unknown>;"),
+            "probe should declare the Context chain base with its full type annotation, got:\n{probe}"
         );
         // `.req` is a property, NOT a method call — it must NOT get `(null! as any)`
         assert!(
@@ -1361,6 +1363,31 @@ export let handler(c: Context<unknown>) -> string ={
                 "__chain_call_Context$req$param = __chain_base_Context.req.param(null! as any);"
             ),
             "expected __chain_call_ probe with .req.param(null! as any), got:\n{probe}"
+        );
+    }
+
+    #[test]
+    fn generate_probe_preserves_nested_generic_type_argument() {
+        // Regression for #1276. Without the full type annotation in the probe,
+        // `c.env.DB` on `Context<{ Bindings: Bindings }>` collapses to the
+        // bare `Context` whose default E resolves `env` to `any`. The probe
+        // must emit the full annotation so tsgo threads `Bindings` through.
+        let source = r#"import trusted { Context } from "hono"
+
+type Bindings = { DB: string }
+
+export let handler(c: Context<{ Bindings: Bindings }>) -> string = {
+    c.env.DB
+}
+"#;
+        let program = Parser::new(source).parse_program().unwrap();
+        let probe = generate_probe(&program, &HashMap::new(), &HashMap::new());
+
+        assert!(
+            probe.contains(
+                "declare const __chain_base_Context: Context<{ Bindings: Bindings }>;"
+            ),
+            "probe must preserve nested generic type args, got:\n{probe}"
         );
     }
 }

--- a/crates/floe-core/src/interop/tsgo.rs
+++ b/crates/floe-core/src/interop/tsgo.rs
@@ -1384,9 +1384,7 @@ export let handler(c: Context<{ Bindings: Bindings }>) -> string = {
         let probe = generate_probe(&program, &HashMap::new(), &HashMap::new());
 
         assert!(
-            probe.contains(
-                "declare const __chain_base_Context: Context<{ Bindings: Bindings }>;"
-            ),
+            probe.contains("declare const __chain_base_Context: Context<{ Bindings: Bindings }>;"),
             "probe must preserve nested generic type args, got:\n{probe}"
         );
     }

--- a/crates/floe-core/src/interop/tsgo/probe_gen.rs
+++ b/crates/floe-core/src/interop/tsgo/probe_gen.rs
@@ -657,6 +657,14 @@ pub(super) fn generate_probe(
     // so we can generate type-based chain probes for:
     // - Parameters typed as npm types (e.g. db: Database)
     // - For-block self.field access where the field has an npm type (e.g. self.client: Database)
+    // `param_type_map` holds the imported type's **base name** (e.g. "Context")
+    // so chain keys stay file-safe identifiers. `type_annotation_map` records
+    // the **full** TS annotation (e.g. "Context<{ Bindings: Bindings }>") for
+    // the first parameter we saw of each base type — the probe emits that
+    // full form in `declare const __chain_base_X: Y;` so tsgo sees the
+    // concrete generic args and can resolve chains like `c.env.DB` instead
+    // of collapsing to the default parameter's `any`.
+    let mut type_annotation_map: HashMap<String, String> = HashMap::new();
     let param_type_map: HashMap<String, String> = {
         // Collect type declarations for field type lookups
         let type_decls: HashMap<&str, &TypeDecl> = program
@@ -686,17 +694,17 @@ pub(super) fn generate_probe(
             };
             for (func, self_type_name) in funcs_with_self_type {
                 for param in &func.params {
-                    if let Some(TypeExpr {
-                        kind:
-                            TypeExprKind::Named {
-                                name: type_name, ..
-                            },
-                        ..
-                    }) = &param.type_ann
+                    if let Some(ann) = &param.type_ann
+                        && let TypeExprKind::Named {
+                            name: type_name, ..
+                        } = &ann.kind
                         && (imported_names.contains_key(type_name)
                             || fl_type_names.contains(type_name.as_str()))
                     {
                         map.insert(param.name.clone(), type_name.clone());
+                        type_annotation_map
+                            .entry(type_name.clone())
+                            .or_insert_with(|| type_expr_to_ts(ann));
                     }
                 }
                 // For for-block methods, also check self's record fields for imported types
@@ -714,6 +722,9 @@ pub(super) fn generate_probe(
                                 || fl_type_names.contains(field_type.as_str()))
                         {
                             map.insert(format!("self.{}", field.name), field_type.clone());
+                            type_annotation_map
+                                .entry(field_type.clone())
+                                .or_insert_with(|| type_expr_to_ts(&field.type_ann));
                         }
                     }
                 }
@@ -819,7 +830,15 @@ pub(super) fn generate_probe(
                 // the table type even though select() has no args).
                 let base_name = format!("__chain_base_{}", path[0]);
                 if emitted_chain_bases.insert(base_name.clone()) {
-                    lines.push(format!("declare const {base_name}: {};", path[0]));
+                    // Prefer the full TS annotation (e.g. `Context<{ Bindings: Bindings }>`)
+                    // when the user wrote one, so tsgo propagates the concrete generic
+                    // args through the chain. Falls back to the bare base name when no
+                    // annotation was captured (for-block receivers keyed by path).
+                    let full_ty = type_annotation_map
+                        .get(&path[0])
+                        .cloned()
+                        .unwrap_or_else(|| path[0].clone());
+                    lines.push(format!("declare const {base_name}: {full_ty};"));
                 }
 
                 for end_idx in 2..path.len() {

--- a/crates/floe-core/src/interop/tsgo/probe_gen.rs
+++ b/crates/floe-core/src/interop/tsgo/probe_gen.rs
@@ -664,6 +664,13 @@ pub(super) fn generate_probe(
     // full form in `declare const __chain_base_X: Y;` so tsgo sees the
     // concrete generic args and can resolve chains like `c.env.DB` instead
     // of collapsing to the default parameter's `any`.
+    //
+    // Limitation: if two parameters in the same file annotate the same base
+    // type with different instantiations (`c1: Context<A>` and `c2: Context<B>`),
+    // only the first wins and the second parameter's chain resolves against
+    // the first's generic args. Multi-instantiation support would need
+    // per-parameter chain bases — not yet required by any real-world
+    // pattern we've seen.
     let mut type_annotation_map: HashMap<String, String> = HashMap::new();
     let param_type_map: HashMap<String, String> = {
         // Collect type declarations for field type lookups

--- a/crates/floe-core/src/interop/wrapper.rs
+++ b/crates/floe-core/src/interop/wrapper.rs
@@ -145,9 +145,27 @@ pub fn wrap_boundary_type(ts_type: &TsType) -> Type {
         // stages (checker-side generic substitution) should have
         // already reduced `E["Bindings"]` to `X["Bindings"]` when `E`
         // is bound to `X`; here we just finish the lookup.
-        TsType::IndexedAccess { object, index } => super::evaluate_indexed_access(object, index)
+        TsType::IndexedAccess { object, index } => evaluate_indexed_access(object, index)
             .map(|ts| wrap_boundary_type(&ts))
             .unwrap_or(Type::Unknown),
+    }
+}
+
+/// Evaluate `object[index]` when both sides are concrete enough. Returns
+/// `Some(field_type)` for `Object`-plus-`StringLiteral` matches and for
+/// bottom-out `Any`/`Unknown` objects (widest answer preserved). Returns
+/// `None` when the lookup can't be decided yet — callers fall back to
+/// `Type::Unknown`, matching TypeScript's own deferred-evaluation
+/// behavior for abstract type params.
+pub(super) fn evaluate_indexed_access(object: &TsType, index: &TsType) -> Option<TsType> {
+    let TsType::StringLiteral(key) = index else {
+        return None;
+    };
+    match object {
+        TsType::Object(fields) => fields.iter().find(|f| &f.name == key).map(|f| f.ty.clone()),
+        TsType::Any => Some(TsType::Any),
+        TsType::Unknown => Some(TsType::Unknown),
+        _ => None,
     }
 }
 

--- a/crates/floe-core/src/interop/wrapper.rs
+++ b/crates/floe-core/src/interop/wrapper.rs
@@ -139,6 +139,15 @@ pub fn wrap_boundary_type(ts_type: &TsType) -> Type {
         // resolution should have replaced this with the enclosing interface name
         // before wrapping. If it survived, fall back to Unknown.
         TsType::This => Type::Unknown,
+
+        // Indexed access `Obj["key"]` — evaluate the lookup when the
+        // shape is concrete enough, else fall back to Unknown. Earlier
+        // stages (checker-side generic substitution) should have
+        // already reduced `E["Bindings"]` to `X["Bindings"]` when `E`
+        // is bound to `X`; here we just finish the lookup.
+        TsType::IndexedAccess { object, index } => super::evaluate_indexed_access(object, index)
+            .map(|ts| wrap_boundary_type(&ts))
+            .unwrap_or(Type::Unknown),
     }
 }
 


### PR DESCRIPTION
closes #1276

## Summary

Fixes \`c.env.DB: unknown\` on Hono handlers annotated \`c: Context<{ Bindings: Bindings }>\`. Verified end-to-end: the yeet project's routes.fl now type-checks cleanly — \`c.env.DB\` resolves to \`D1Database\`, \`c.req.json()\` resolves, \`c.req.param()\` resolves.

## The two fixes

### 1. Probe generator preserves full type annotations

When building tsgo chain probes, a parameter typed as an imported generic like \`Context<{ Bindings: Bindings }>\` used to declare \`__chain_base_Context: Context;\` — stripping the generic args. tsgo then resolved \`c.env.DB\` against \`Context\`'s default parameter (\`any\`), producing \`any\` → wrapped as \`unknown\`.

\`probe_gen.rs\` now builds \`type_annotation_map\`: first full TS annotation seen per base type name (via existing \`type_expr_to_ts\`). The \`__chain_base_X\` declare emits that full annotation. tsgo sees the concrete generic args and threads them through the entire chain.

### 2. \`TsType::IndexedAccess\` is first-class

\`E[\"Bindings\"]\` used to collapse to \`E\` during .d.ts parsing (one line in dts.rs: \`convert_oxc_type(&access.object_type)\`). Every downstream stage then saw the wrong type. The new \`TsType::IndexedAccess { object, index }\` variant preserves the structure; \`evaluate_indexed_access\` performs the lookup at wrap time when both sides are concrete — so \`{ DB: string }[\"DB\"]\` evaluates to \`string\` rather than falling back to \`unknown\`.

## Changes

- \`interop/ts_types.rs\` — new \`TsType::IndexedAccess\` variant.
- \`interop/dts.rs\` — \`TSIndexedAccessType\` produces structured \`IndexedAccess\` instead of dropping to object_type.
- \`interop.rs\` — \`evaluate_indexed_access\` helper.
- \`interop/wrapper.rs\` — \`wrap_boundary_type\` evaluates IndexedAccess; falls back to \`Unknown\` when unresolvable.
- \`interop/tsgo/probe_gen.rs\` — \`type_annotation_map\` captures full annotations; chain base declares emit them.

## Test plan

- [x] Unit: \`parse_indexed_access_in_dts\` — \`type Env<E> = E[\"Bindings\"]\` parses into \`IndexedAccess\` with correct object/index.
- [x] Unit: \`evaluate_indexed_access_concrete_object\` — \`{ DB: string }[\"DB\"]\` evaluates to \`string\`.
- [x] Unit: \`evaluate_indexed_access_missing_key_is_none\` — absent key returns \`None\` (callers fall back to \`Unknown\`).
- [x] Unit: \`evaluate_indexed_access_abstract_object_is_none\` — \`E[\"Bindings\"]\` with abstract \`E\` stays unresolved.
- [x] Unit: \`wrap_indexed_access_concrete_returns_field_type\` — end-to-end \`wrap_boundary_type\` returns \`Type::String\`.
- [x] Unit: \`generate_probe_preserves_nested_generic_type_argument\` — probe emits \`Context<{ Bindings: Bindings }>\`.
- [x] Existing \`generate_probe_property_getter_then_method_call\` updated to assert the full annotation form.
- [x] Full \`cargo test -p floe-core --lib\`: 1505 passed.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`: clean.
- [x] Example apps: fmt + check + build on both \`examples/todo-app\` and \`examples/store\` succeed.
- [x] **End-to-end**: user's yeet routes.fl (\`c.env.DB\`, \`c.req.json()\`, \`c.req.param(\"code\")\`) now type-checks cleanly with the new binary.