### PR TITLE
[#1273] support optional parameter labels in function-type aliases

### DIFF
--- a/crates/floe-core/src/checker/attach.rs
+++ b/crates/floe-core/src/checker/attach.rs
@@ -288,6 +288,14 @@ impl Attacher<'_> {
         }
     }
 
+    fn fn_type_param(&self, param: FnTypeParam<()>) -> FnTypeParam<Arc<Type>> {
+        FnTypeParam {
+            label: param.label,
+            type_ann: self.type_expr(param.type_ann),
+            span: param.span,
+        }
+    }
+
     fn type_expr_kind(&self, kind: TypeExprKind<()>) -> TypeExprKind<Arc<Type>> {
         match kind {
             TypeExprKind::Named {
@@ -306,7 +314,7 @@ impl Attacher<'_> {
                 params,
                 return_type,
             } => TypeExprKind::Function {
-                params: params.into_iter().map(|t| self.type_expr(t)).collect(),
+                params: params.into_iter().map(|p| self.fn_type_param(p)).collect(),
                 return_type: Box::new(self.type_expr(*return_type)),
             },
             TypeExprKind::Array(t) => TypeExprKind::Array(Box::new(self.type_expr(*t))),

--- a/crates/floe-core/src/checker/error_codes.rs
+++ b/crates/floe-core/src/checker/error_codes.rs
@@ -137,6 +137,9 @@ pub enum ErrorCode {
     BareStringLiteralUnion,
     /// Inline record type in function signature — declare a named type first.
     InlineRecordTypeInSignature,
+    /// Function-type parameter is missing a label in a named position
+    /// (top-level type alias or record field) — labels are required there.
+    MissingFnTypeParamLabel,
 }
 
 impl ErrorCode {
@@ -199,6 +202,7 @@ impl ErrorCode {
             Self::TraitImportWithoutFor => "E053",
             Self::BareStringLiteralUnion => "E201",
             Self::InlineRecordTypeInSignature => "E202",
+            Self::MissingFnTypeParamLabel => "E203",
         }
     }
 }

--- a/crates/floe-core/src/checker/error_codes.rs
+++ b/crates/floe-core/src/checker/error_codes.rs
@@ -137,9 +137,6 @@ pub enum ErrorCode {
     BareStringLiteralUnion,
     /// Inline record type in function signature — declare a named type first.
     InlineRecordTypeInSignature,
-    /// Function-type parameter is missing a label in a named position
-    /// (top-level type alias or record field) — labels are required there.
-    MissingFnTypeParamLabel,
 }
 
 impl ErrorCode {
@@ -202,7 +199,6 @@ impl ErrorCode {
             Self::TraitImportWithoutFor => "E053",
             Self::BareStringLiteralUnion => "E201",
             Self::InlineRecordTypeInSignature => "E202",
-            Self::MissingFnTypeParamLabel => "E203",
         }
     }
 }

--- a/crates/floe-core/src/checker/expr.rs
+++ b/crates/floe-core/src/checker/expr.rs
@@ -3081,7 +3081,10 @@ pub fn simple_resolve_type_expr<T>(type_expr: &crate::parser::ast::TypeExpr<T>) 
             params,
             return_type,
         } => {
-            let param_types: Vec<_> = params.iter().map(simple_resolve_type_expr).collect();
+            let param_types: Vec<_> = params
+                .iter()
+                .map(|p| simple_resolve_type_expr(&p.type_ann))
+                .collect();
             let ret = simple_resolve_type_expr(return_type);
             let required_params = param_types.len();
             Type::Function {

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -9045,78 +9045,24 @@ let _x = twoArgs()
 }
 
 #[test]
-fn fn_type_alias_with_labels_is_accepted() {
+fn fn_type_alias_accepts_labelled_and_unlabelled_params() {
+    // Labels are documentation only — both forms parse and check cleanly.
     let diags = check(
         r#"
 type Handler = (req: number) -> number
-let _h: Handler = (x) -> x
+type Predicate = (number) -> boolean
+let _h(f: Handler, x: number) -> number = { f(x) }
+let _p(f: Predicate, x: number) -> boolean = { f(x) }
 "#,
     );
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
     assert!(
-        !has_error(&diags, ErrorCode::MissingFnTypeParamLabel),
-        "labelled fn type alias should not fire E203, got: {:?}",
-        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
-    );
-}
-
-#[test]
-fn fn_type_alias_without_labels_errors() {
-    let diags = check(
-        r#"
-type Handler = (number) -> number
-"#,
-    );
-    assert!(
-        has_error(&diags, ErrorCode::MissingFnTypeParamLabel),
-        "unlabelled fn type alias should fire E203, got: {:?}",
-        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
-    );
-}
-
-#[test]
-fn fn_typed_record_field_without_labels_errors() {
-    let diags = check(
-        r#"
-type Props = {
-    onClick: (number) -> (),
-}
-"#,
-    );
-    assert!(
-        has_error(&diags, ErrorCode::MissingFnTypeParamLabel),
-        "unlabelled fn-typed record field should fire E203, got: {:?}",
-        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
-    );
-}
-
-#[test]
-fn fn_typed_record_field_with_labels_is_accepted() {
-    let diags = check(
-        r#"
-type Props = {
-    onClick: (id: number) -> (),
-}
-"#,
-    );
-    assert!(
-        !has_error(&diags, ErrorCode::MissingFnTypeParamLabel),
-        "labelled fn-typed record field should not fire E203, got: {:?}",
-        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
-    );
-}
-
-#[test]
-fn higher_order_fn_param_without_labels_is_accepted() {
-    // Inline higher-order params keep labels optional.
-    let diags = check(
-        r#"
-let _twice(f: (number) -> number, x: number) -> number = { f(f(x)) }
-"#,
-    );
-    assert!(
-        !has_error(&diags, ErrorCode::MissingFnTypeParamLabel),
-        "higher-order fn params should not require labels, got: {:?}",
-        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        errors.is_empty(),
+        "labelled and unlabelled fn-type aliases should both check cleanly, got: {:?}",
+        errors.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
 

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -9043,3 +9043,100 @@ let _x = twoArgs()
         errors.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn fn_type_alias_with_labels_is_accepted() {
+    let diags = check(
+        r#"
+type Handler = (req: number) -> number
+let _h: Handler = (x) -> x
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::MissingFnTypeParamLabel),
+        "labelled fn type alias should not fire E203, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn fn_type_alias_without_labels_errors() {
+    let diags = check(
+        r#"
+type Handler = (number) -> number
+"#,
+    );
+    assert!(
+        has_error(&diags, ErrorCode::MissingFnTypeParamLabel),
+        "unlabelled fn type alias should fire E203, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn fn_typed_record_field_without_labels_errors() {
+    let diags = check(
+        r#"
+type Props = {
+    onClick: (number) -> (),
+}
+"#,
+    );
+    assert!(
+        has_error(&diags, ErrorCode::MissingFnTypeParamLabel),
+        "unlabelled fn-typed record field should fire E203, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn fn_typed_record_field_with_labels_is_accepted() {
+    let diags = check(
+        r#"
+type Props = {
+    onClick: (id: number) -> (),
+}
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::MissingFnTypeParamLabel),
+        "labelled fn-typed record field should not fire E203, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn higher_order_fn_param_without_labels_is_accepted() {
+    // Inline higher-order params keep labels optional.
+    let diags = check(
+        r#"
+let _twice(f: (number) -> number, x: number) -> number = { f(f(x)) }
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::MissingFnTypeParamLabel),
+        "higher-order fn params should not require labels, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn fn_type_param_label_does_not_collide_with_call_site_arguments() {
+    // Labels are documentation only — call sites use positional args without
+    // having to refer to the label.
+    let diags = check(
+        r#"
+type Apply = (n: number) -> number
+let _twice(f: Apply, x: number) -> number = { f(f(x)) }
+"#,
+    );
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "labelled fn type should accept positional calls, got: {:?}",
+        errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}

--- a/crates/floe-core/src/checker/type_registration.rs
+++ b/crates/floe-core/src/checker/type_registration.rs
@@ -58,6 +58,20 @@ impl Checker {
                 self.check_no_intersection_in_type_def(&decl.def, span);
             }
 
+            match &decl.def {
+                TypeDef::Alias(type_expr) => {
+                    self.check_named_fn_type_labels(type_expr);
+                }
+                TypeDef::Record(entries) => {
+                    for entry in entries {
+                        if let RecordEntry::Field(field) = entry {
+                            self.check_named_fn_type_labels(&field.type_ann);
+                        }
+                    }
+                }
+                _ => {}
+            }
+
             if let TypeDef::StringLiteralUnion(variants) = &decl.def
                 && !decl.opaque
             {
@@ -175,6 +189,26 @@ impl Checker {
         None
     }
 
+    /// Emit E203 for any function-type parameter that lacks a label when the
+    /// function type sits at a named position (alias RHS or record field).
+    /// Only the outermost function type is checked — nested ones inside the
+    /// return type or generic args are still inline glue.
+    pub(crate) fn check_named_fn_type_labels(&mut self, type_expr: &TypeExpr) {
+        if let TypeExprKind::Function { params, .. } = &type_expr.kind {
+            for param in params {
+                if param.label.is_none() {
+                    self.emit_error_with_help(
+                        "function-type parameter is missing a label",
+                        param.span,
+                        ErrorCode::MissingFnTypeParamLabel,
+                        "missing label",
+                        "add a label, e.g. `(name: Type) -> ...`",
+                    );
+                }
+            }
+        }
+    }
+
     /// Check that `&` intersection types don't appear in `{ }` type definitions.
     pub(crate) fn check_no_intersection_in_type_def(&mut self, def: &TypeDef, span: Span) {
         fn has_intersection(ty: &TypeExpr) -> bool {
@@ -185,7 +219,10 @@ impl Checker {
                 TypeExprKind::Function {
                     params,
                     return_type,
-                } => params.iter().any(has_intersection) || has_intersection(return_type),
+                } => {
+                    params.iter().any(|p| has_intersection(&p.type_ann))
+                        || has_intersection(return_type)
+                }
                 TypeExprKind::Named { type_args, .. } => type_args.iter().any(has_intersection),
                 TypeExprKind::Record(fields) => {
                     fields.iter().any(|f| has_intersection(&f.type_ann))

--- a/crates/floe-core/src/checker/type_registration.rs
+++ b/crates/floe-core/src/checker/type_registration.rs
@@ -58,20 +58,6 @@ impl Checker {
                 self.check_no_intersection_in_type_def(&decl.def, span);
             }
 
-            match &decl.def {
-                TypeDef::Alias(type_expr) => {
-                    self.check_named_fn_type_labels(type_expr);
-                }
-                TypeDef::Record(entries) => {
-                    for entry in entries {
-                        if let RecordEntry::Field(field) = entry {
-                            self.check_named_fn_type_labels(&field.type_ann);
-                        }
-                    }
-                }
-                _ => {}
-            }
-
             if let TypeDef::StringLiteralUnion(variants) = &decl.def
                 && !decl.opaque
             {
@@ -187,26 +173,6 @@ impl Checker {
             }
         }
         None
-    }
-
-    /// Emit E203 for any function-type parameter that lacks a label when the
-    /// function type sits at a named position (alias RHS or record field).
-    /// Only the outermost function type is checked — nested ones inside the
-    /// return type or generic args are still inline glue.
-    pub(crate) fn check_named_fn_type_labels(&mut self, type_expr: &TypeExpr) {
-        if let TypeExprKind::Function { params, .. } = &type_expr.kind {
-            for param in params {
-                if param.label.is_none() {
-                    self.emit_error_with_help(
-                        "function-type parameter is missing a label",
-                        param.span,
-                        ErrorCode::MissingFnTypeParamLabel,
-                        "missing label",
-                        "add a label, e.g. `(name: Type) -> ...`",
-                    );
-                }
-            }
-        }
     }
 
     /// Check that `&` intersection types don't appear in `{ }` type definitions.

--- a/crates/floe-core/src/checker/type_resolve.rs
+++ b/crates/floe-core/src/checker/type_resolve.rs
@@ -27,7 +27,10 @@ impl Checker {
                 params,
                 return_type,
             } => {
-                let param_types: Vec<_> = params.iter().map(|p| self.resolve_type(p)).collect();
+                let param_types: Vec<_> = params
+                    .iter()
+                    .map(|p| self.resolve_type(&p.type_ann))
+                    .collect();
                 let ret = self.resolve_type(return_type);
                 let required_params = param_types.len();
                 Type::Function {

--- a/crates/floe-core/src/codegen/typescript/types.rs
+++ b/crates/floe-core/src/codegen/typescript/types.rs
@@ -78,8 +78,9 @@ impl<'a> TypeScriptGenerator<'a> {
                     if i > 0 {
                         docs.push(pretty::str(", "));
                     }
-                    docs.push(pretty::str(format!("_p{i}: ")));
-                    docs.push(self.emit_type_expr(param));
+                    let name = param.label.clone().unwrap_or_else(|| format!("_p{i}"));
+                    docs.push(pretty::str(format!("{name}: ")));
+                    docs.push(self.emit_type_expr(&param.type_ann));
                 }
                 docs.push(pretty::str(") => "));
                 docs.push(self.emit_type_expr(return_type));

--- a/crates/floe-core/src/cst/types.rs
+++ b/crates/floe-core/src/cst/types.rs
@@ -94,11 +94,25 @@ impl<'src> CstParser<'src> {
     fn parse_function_type(&mut self) {
         self.expect(TokenKind::LeftParen);
         self.eat_trivia();
-        self.parse_comma_separated(Self::parse_type_expr, TokenKind::RightParen);
+        self.parse_comma_separated(Self::parse_fn_type_param, TokenKind::RightParen);
         self.expect(TokenKind::RightParen);
         self.eat_trivia();
         self.expect(TokenKind::ThinArrow);
         self.eat_trivia();
         self.parse_type_expr();
+    }
+
+    /// Parse a single parameter in a function type:
+    ///   `IDENT ':' TYPE_EXPR` (labelled) or `TYPE_EXPR` (bare).
+    fn parse_fn_type_param(&mut self) {
+        self.builder.start_node(SyntaxKind::FN_TYPE_PARAM.into());
+        if self.is_ident() && self.peek_is(TokenKind::Colon) {
+            self.bump(); // ident
+            self.eat_trivia();
+            self.bump(); // :
+            self.eat_trivia();
+        }
+        self.parse_type_expr();
+        self.builder.finish_node();
     }
 }

--- a/crates/floe-core/src/formatter/items.rs
+++ b/crates/floe-core/src/formatter/items.rs
@@ -664,6 +664,20 @@ impl Formatter<'_> {
 
     // ── Type Expressions ────────────────────────────────────────
 
+    pub(crate) fn fmt_fn_type_param(&mut self, node: &SyntaxNode) -> Document {
+        let label = self.collect_idents(node).into_iter().next();
+        let type_expr = node.children().find(|c| c.kind() == SyntaxKind::TYPE_EXPR);
+        let mut parts = Vec::new();
+        if let Some(label) = label {
+            parts.push(pretty::str(label));
+            parts.push(pretty::str(": "));
+        }
+        if let Some(te) = type_expr {
+            parts.push(self.fmt_type_expr(&te));
+        }
+        pretty::concat(parts)
+    }
+
     pub(crate) fn fmt_type_expr(&mut self, node: &SyntaxNode) -> Document {
         let idents = self.collect_idents(node);
         let has_fat_arrow = self.has_token(node, SyntaxKind::THIN_ARROW);
@@ -705,18 +719,18 @@ impl Formatter<'_> {
             return pretty::concat(parts);
         }
 
-        // Function type: (params) => ReturnType
+        // Function type: (params) -> ReturnType
         if has_fat_arrow {
+            let fn_params: Vec<_> = node
+                .children()
+                .filter(|c| c.kind() == SyntaxKind::FN_TYPE_PARAM)
+                .collect();
             let mut parts = vec![pretty::str("(")];
-            let param_count = child_type_exprs.len().saturating_sub(1);
-            for (i, te) in child_type_exprs.iter().enumerate() {
-                if i == param_count {
-                    break;
-                }
+            for (i, param) in fn_params.iter().enumerate() {
                 if i > 0 {
                     parts.push(pretty::str(", "));
                 }
-                parts.push(self.fmt_type_expr(te));
+                parts.push(self.fmt_fn_type_param(param));
             }
             parts.push(pretty::str(") -> "));
             if let Some(ret) = child_type_exprs.last() {

--- a/crates/floe-core/src/interop/tsgo/probe_gen.rs
+++ b/crates/floe-core/src/interop/tsgo/probe_gen.rs
@@ -1150,7 +1150,7 @@ fn collect_typeof_names(type_expr: &TypeExpr, callback: &mut dyn FnMut(&str)) {
             return_type,
         } => {
             for p in params {
-                collect_typeof_names(p, callback);
+                collect_typeof_names(&p.type_ann, callback);
             }
             collect_typeof_names(return_type, callback);
         }
@@ -1195,7 +1195,7 @@ fn type_expr_references_imports(
         } => {
             params
                 .iter()
-                .any(|p| type_expr_references_imports(p, imported_names))
+                .any(|p| type_expr_references_imports(&p.type_ann, imported_names))
                 || type_expr_references_imports(return_type, imported_names)
         }
         TypeExprKind::Record(fields) => fields
@@ -1681,7 +1681,10 @@ pub(super) fn type_expr_to_ts(ty: &TypeExpr) -> String {
             let ps: Vec<String> = params
                 .iter()
                 .enumerate()
-                .map(|(i, p)| format!("_p{i}: {}", type_expr_to_ts(p)))
+                .map(|(i, p)| {
+                    let name = p.label.clone().unwrap_or_else(|| format!("_p{i}"));
+                    format!("{name}: {}", type_expr_to_ts(&p.type_ann))
+                })
                 .collect();
             format!("({}) => {}", ps.join(", "), type_expr_to_ts(return_type))
         }

--- a/crates/floe-core/src/lower/types.rs
+++ b/crates/floe-core/src/lower/types.rs
@@ -175,6 +175,20 @@ impl<'src> Lowerer<'src> {
         })
     }
 
+    pub(super) fn lower_fn_type_param(&mut self, node: &SyntaxNode) -> Option<FnTypeParam> {
+        let span = self.node_span(node);
+        let label = self.collect_idents_direct(node).first().cloned();
+        let type_expr_node = node
+            .children()
+            .find(|c| c.kind() == SyntaxKind::TYPE_EXPR)?;
+        let type_ann = self.lower_type_expr(&type_expr_node)?;
+        Some(FnTypeParam {
+            label,
+            type_ann,
+            span,
+        })
+    }
+
     pub(super) fn lower_type_expr(&mut self, node: &SyntaxNode) -> Option<TypeExpr> {
         let span = self.node_span(node);
 
@@ -298,17 +312,21 @@ impl<'src> Lowerer<'src> {
 
         // Function type: (params) -> ReturnType
         if has_fat_arrow || has_thin_arrow {
-            let type_exprs: Vec<TypeExpr> = node
+            let params: Vec<FnTypeParam> = node
                 .children()
-                .filter(|c| c.kind() == SyntaxKind::TYPE_EXPR)
-                .filter_map(|c| self.lower_type_expr(&c))
+                .filter(|c| c.kind() == SyntaxKind::FN_TYPE_PARAM)
+                .filter_map(|c| self.lower_fn_type_param(&c))
                 .collect();
+            let return_type = node
+                .children()
+                .find(|c| c.kind() == SyntaxKind::TYPE_EXPR)
+                .and_then(|c| self.lower_type_expr(&c));
 
-            if let Some((return_type, params)) = type_exprs.split_last() {
+            if let Some(return_type) = return_type {
                 return Some(TypeExpr {
                     kind: TypeExprKind::Function {
-                        params: params.to_vec(),
-                        return_type: Box::new(return_type.clone()),
+                        params,
+                        return_type: Box::new(return_type),
                     },
                     span,
                 });

--- a/crates/floe-core/src/parser/ast.rs
+++ b/crates/floe-core/src/parser/ast.rs
@@ -451,8 +451,14 @@ pub enum TypeExprKind<T = ()> {
     /// Record type inline: `{ name: string, age: number }`
     Record(Vec<RecordField<T>>),
     /// Function type: `(a: number, b: string) -> Result<T, E>`
+    ///
+    /// Each parameter carries an optional label. Labels are required in
+    /// top-level type aliases (`type F = (x: T) -> U`) and on function-typed
+    /// record fields, and remain optional inside higher-order parameter
+    /// positions like `fn map(xs: Array<A>, f: (A) -> B)`. Labels are
+    /// documentation only and never affect structural assignability.
     Function {
-        params: Vec<TypeExpr<T>>,
+        params: Vec<FnTypeParam<T>>,
         return_type: Box<TypeExpr<T>>,
     },
     /// Array type: `Array<T>`
@@ -465,6 +471,13 @@ pub enum TypeExprKind<T = ()> {
     Intersection(Vec<TypeExpr<T>>),
     /// String literal type: `"div"`, `"button"` (for npm interop like `ComponentProps<"div">`)
     StringLiteral(String),
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct FnTypeParam<T = ()> {
+    pub label: Option<String>,
+    pub type_ann: TypeExpr<T>,
+    pub span: Span,
 }
 
 // ── Expressions ──────────────────────────────────────────────────

--- a/crates/floe-core/src/parser/tests.rs
+++ b/crates/floe-core/src/parser/tests.rs
@@ -941,6 +941,43 @@ fn type_alias() {
 }
 
 #[test]
+fn fn_type_alias_with_labelled_params() {
+    match first_item("type Handler = (cmd: number, retries: number) -> number") {
+        ItemKind::TypeDecl(decl) => match decl.def {
+            TypeDef::Alias(ref te) => match &te.kind {
+                TypeExprKind::Function { params, .. } => {
+                    assert_eq!(params.len(), 2);
+                    assert_eq!(params[0].label.as_deref(), Some("cmd"));
+                    assert_eq!(params[1].label.as_deref(), Some("retries"));
+                }
+                other => panic!("expected function, got {other:?}"),
+            },
+            ref other => panic!("expected alias, got {other:?}"),
+        },
+        other => panic!("expected type decl, got {other:?}"),
+    }
+}
+
+#[test]
+fn fn_type_alias_without_labels_still_parses() {
+    // Parser still accepts unlabelled fn types — the missing-label diagnostic
+    // is emitted later by the checker, not the parser.
+    match first_item("type Handler = (number) -> number") {
+        ItemKind::TypeDecl(decl) => match decl.def {
+            TypeDef::Alias(ref te) => match &te.kind {
+                TypeExprKind::Function { params, .. } => {
+                    assert_eq!(params.len(), 1);
+                    assert!(params[0].label.is_none());
+                }
+                other => panic!("expected function, got {other:?}"),
+            },
+            ref other => panic!("expected alias, got {other:?}"),
+        },
+        other => panic!("expected type decl, got {other:?}"),
+    }
+}
+
+#[test]
 fn type_record() {
     match first_item("type User = { id: UserId, name: string }") {
         ItemKind::TypeDecl(decl) => {

--- a/crates/floe-core/src/resolve.rs
+++ b/crates/floe-core/src/resolve.rs
@@ -828,7 +828,7 @@ fn collect_type_names(type_expr: &TypeExpr, names: &mut HashSet<String>) {
             return_type,
         } => {
             for param in params {
-                collect_type_names(param, names);
+                collect_type_names(&param.type_ann, names);
             }
             collect_type_names(return_type, names);
         }

--- a/crates/floe-core/src/syntax.rs
+++ b/crates/floe-core/src/syntax.rs
@@ -133,6 +133,10 @@ pub enum SyntaxKind {
     TYPE_EXPR_FUNCTION,
     TYPE_EXPR_RECORD,
     TYPE_EXPR_TUPLE,
+    /// Single parameter inside a function type, e.g. `cmd: Cmd` in
+    /// `(cmd: Cmd) -> Result<...>`. Wraps an optional `IDENT COLON`
+    /// label followed by a `TYPE_EXPR`.
+    FN_TYPE_PARAM,
     PARAM,
     PARAM_LIST,
     ARG_LIST,

--- a/crates/floe-lsp/src/index.rs
+++ b/crates/floe-lsp/src/index.rs
@@ -749,7 +749,13 @@ pub(super) fn type_expr_to_string<T>(ty: &TypeExpr<T>) -> String {
             params,
             return_type,
         } => {
-            let ps: Vec<String> = params.iter().map(type_expr_to_string).collect();
+            let ps: Vec<String> = params
+                .iter()
+                .map(|p| match &p.label {
+                    Some(label) => format!("{label}: {}", type_expr_to_string(&p.type_ann)),
+                    None => type_expr_to_string(&p.type_ann),
+                })
+                .collect();
             format!(
                 "({}) -> {}",
                 ps.join(", "),

--- a/docs/design.md
+++ b/docs/design.md
@@ -128,7 +128,7 @@ The last expression in a block is the return value — no `return` keyword.
 | Tagged sums | `type Route = Home \| Profile(string) \| Settings { tab: string }` | discriminated union. `(Type, ...)` variants are positional; `{ name: Type, ... }` variants are named. Mixing the two forms in one variant is a parse error. Leading `\|` optional. |
 | String literal unions | `type Method = OneOf<"GET", "POST", "PUT">` | `"GET" \| "POST" \| "PUT"` (structural — for npm interop) |
 | Intersections | `type AdminCard = Intersect<ButtonProps, { role: "admin" }>` | `ButtonProps & { role: "admin" }` (structural) |
-| Function-type alias | `type Handler = (req: Request) => Response` | `type Handler = (req: Request) => Response` (parameter labels required in named positions; documentation only — labels never affect assignability) |
+| Function-type alias | `type Handler = (req: Request) => Response` | `type Handler = (req: Request) => Response` (parameter labels are optional documentation; LSP hover surfaces them but they never affect assignability) |
 | Nested sums | `type ApiError = Network(NetworkError) \| NotFound` | nested discriminated union (compiler generates tags) |
 | Multi-depth match | `Network(Timeout(ms)) -> ...` | nested if/else with tag checks |
 | Type constructors | `User(name: "Ryan", email: e)` | `{ name: "Ryan", email: e }` (compiler adds tags for unions) |
@@ -641,11 +641,11 @@ type HttpMethod = OneOf<"GET", "POST", "PUT", "DELETE">
 // Structural intersection
 type AdminCard = Intersect<ButtonProps, { role: "admin" }>
 
-// Function-type alias — structural. Parameter labels are required in
-// named positions (top-level alias, function-typed record field) and act
-// as documentation; they don't influence assignability.
+// Function-type alias — structural. Parameter labels are optional
+// documentation; LSP hover surfaces them and they never influence
+// assignability.
 type Handler = (req: Request) -> Promise<Response>
-type Predicate<T> = (value: T) -> boolean
+type Predicate<T> = (T) -> boolean
 
 // Sums can contain sums — nest as deep as you want
 type NetworkError =

--- a/docs/design.md
+++ b/docs/design.md
@@ -128,7 +128,7 @@ The last expression in a block is the return value — no `return` keyword.
 | Tagged sums | `type Route = Home \| Profile(string) \| Settings { tab: string }` | discriminated union. `(Type, ...)` variants are positional; `{ name: Type, ... }` variants are named. Mixing the two forms in one variant is a parse error. Leading `\|` optional. |
 | String literal unions | `type Method = OneOf<"GET", "POST", "PUT">` | `"GET" \| "POST" \| "PUT"` (structural — for npm interop) |
 | Intersections | `type AdminCard = Intersect<ButtonProps, { role: "admin" }>` | `ButtonProps & { role: "admin" }` (structural) |
-| Function-type alias | `type Handler = (Request) => Response` | `type Handler = (arg: Request) => Response` |
+| Function-type alias | `type Handler = (req: Request) => Response` | `type Handler = (req: Request) => Response` (parameter labels required in named positions; documentation only — labels never affect assignability) |
 | Nested sums | `type ApiError = Network(NetworkError) \| NotFound` | nested discriminated union (compiler generates tags) |
 | Multi-depth match | `Network(Timeout(ms)) -> ...` | nested if/else with tag checks |
 | Type constructors | `User(name: "Ryan", email: e)` | `{ name: "Ryan", email: e }` (compiler adds tags for unions) |
@@ -641,9 +641,11 @@ type HttpMethod = OneOf<"GET", "POST", "PUT", "DELETE">
 // Structural intersection
 type AdminCard = Intersect<ButtonProps, { role: "admin" }>
 
-// Function-type alias — structural
-type Handler = (Request) -> Promise<Response>
-type Predicate<T> = (T) -> boolean
+// Function-type alias — structural. Parameter labels are required in
+// named positions (top-level alias, function-typed record field) and act
+// as documentation; they don't influence assignability.
+type Handler = (req: Request) -> Promise<Response>
+type Predicate<T> = (value: T) -> boolean
 
 // Sums can contain sums — nest as deep as you want
 type NetworkError =

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -66,13 +66,12 @@ Every type declaration starts with `type Name = ...`. The RHS picks the kind:
 - `{ ... }` — record
 - `Variant | Variant | ...` — nominal tagged sum (leading `|` optional)
 - `Name(T)` — newtype (single-value wrapper)
-- `(label: T, ...) -> Ret` — structural function-type alias (parameter labels required)
+- `(T, ...) -> Ret` or `(label: T, ...) -> Ret` — structural function-type alias; parameter labels are optional documentation that LSP hover surfaces and do not affect structural assignability
 - `OneOf<"a", "b">` / `Intersect<A, B>` — structural string-literal union / intersection
 - `Partial<T>` / `Pick<T, K>` / `Omit<T, K>` / `ReturnType<...>` / ... — TS utility aliases
 
 A bare `|` of string literals (e.g. `type M = "a" | "b"`) is **E201** — use `OneOf<"a", "b">` instead.
 An inline record in a function signature (e.g. `fn f(x: { a: T })`) is **E202** — name the type.
-A function-type alias or function-typed record field with unlabelled parameters (e.g. `type F = (Int) -> Int`) is **E203** — add labels (`type F = (x: Int) -> Int`). Labels are documentation only and do not affect structural assignability. Inline higher-order parameters (`let map(xs: Array<A>, f: (A) -> B) -> Array<B>`) keep labels optional.
 
 ```floe
 // Record type
@@ -147,9 +146,9 @@ type B = { y: string }
 type C = { ...A, ...B, z: boolean }
 
 // Function-type alias (structural — just a type). Labels on parameters
-// are required and act as documentation; they don't affect assignability.
+// are optional documentation and do not affect assignability.
 type Handler = (req: Request) -> Promise<Response>
-type Predicate<T> = (value: T) -> boolean
+type Predicate<T> = (T) -> boolean
 
 // Opaque types (only defining module can create/read)
 opaque type HashedPassword = HashedPassword(string)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -66,12 +66,13 @@ Every type declaration starts with `type Name = ...`. The RHS picks the kind:
 - `{ ... }` — record
 - `Variant | Variant | ...` — nominal tagged sum (leading `|` optional)
 - `Name(T)` — newtype (single-value wrapper)
-- `(Args) -> Ret` — structural function-type alias
+- `(label: T, ...) -> Ret` — structural function-type alias (parameter labels required)
 - `OneOf<"a", "b">` / `Intersect<A, B>` — structural string-literal union / intersection
 - `Partial<T>` / `Pick<T, K>` / `Omit<T, K>` / `ReturnType<...>` / ... — TS utility aliases
 
 A bare `|` of string literals (e.g. `type M = "a" | "b"`) is **E201** — use `OneOf<"a", "b">` instead.
 An inline record in a function signature (e.g. `fn f(x: { a: T })`) is **E202** — name the type.
+A function-type alias or function-typed record field with unlabelled parameters (e.g. `type F = (Int) -> Int`) is **E203** — add labels (`type F = (x: Int) -> Int`). Labels are documentation only and do not affect structural assignability. Inline higher-order parameters (`let map(xs: Array<A>, f: (A) -> B) -> Array<B>`) keep labels optional.
 
 ```floe
 // Record type
@@ -145,9 +146,10 @@ type A = { x: number }
 type B = { y: string }
 type C = { ...A, ...B, z: boolean }
 
-// Function-type alias (structural — just a type)
-type Handler = (Request) -> Promise<Response>
-type Predicate<T> = (T) -> boolean
+// Function-type alias (structural — just a type). Labels on parameters
+// are required and act as documentation; they don't affect assignability.
+type Handler = (req: Request) -> Promise<Response>
+type Predicate<T> = (value: T) -> boolean
 
 // Opaque types (only defining module can create/read)
 opaque type HashedPassword = HashedPassword(string)

--- a/docs/site/src/content/docs/docs/guide/types.md
+++ b/docs/site/src/content/docs/docs/guide/types.md
@@ -25,7 +25,7 @@ The RHS picks what kind of type you get:
 | `{ ... }` | Record |
 | `A \| B \| ...` | Tagged sum |
 | `Name(T)` | Newtype |
-| `(Args) => Ret` | Function-type alias |
+| `(label: T, ...) => Ret` | Function-type alias (parameter labels required) |
 | `OneOf<"a", "b">` | Structural string-literal union |
 | `Intersect<A, B>` | Structural intersection |
 
@@ -286,19 +286,26 @@ opaque type Email = Email(string)
 
 ## Function-Type Aliases
 
-Name a function type to use it in records or generics:
+Name a function type to use it in records or generics. **Parameter labels are required** at named positions (top-level aliases and function-typed record fields):
 
 ```floe
-type Handler = (Request) -> Promise<Response>
-type Predicate<T> = (T) -> boolean
+type Handler = (req: Request) -> Promise<Response>
+type Predicate<T> = (value: T) -> boolean
 
 type Button = {
   label: string,
   onClick: () -> (),
+  onSubmit: (form: FormData) -> (),
 }
 ```
 
-Function types use `=>`. The `->` arrow is reserved for match arms and the return type of an `fn` declaration.
+Labels are documentation only — they do not affect structural assignability. Inline higher-order parameters keep labels optional, since the name is usually noise:
+
+```floe
+let map(xs: Array<A>, f: (A) -> B) -> Array<B> = { xs |> Array.map(f) }
+```
+
+Omitting a label at a named position is a compile error (E203).
 
 ## Tuple Types
 

--- a/docs/site/src/content/docs/docs/guide/types.md
+++ b/docs/site/src/content/docs/docs/guide/types.md
@@ -25,7 +25,7 @@ The RHS picks what kind of type you get:
 | `{ ... }` | Record |
 | `A \| B \| ...` | Tagged sum |
 | `Name(T)` | Newtype |
-| `(label: T, ...) => Ret` | Function-type alias (parameter labels required) |
+| `(T, ...) => Ret` or `(label: T, ...) => Ret` | Function-type alias (parameter labels optional) |
 | `OneOf<"a", "b">` | Structural string-literal union |
 | `Intersect<A, B>` | Structural intersection |
 
@@ -286,11 +286,11 @@ opaque type Email = Email(string)
 
 ## Function-Type Aliases
 
-Name a function type to use it in records or generics. **Parameter labels are required** at named positions (top-level aliases and function-typed record fields):
+Name a function type to use it in records or generics. Parameter labels are optional documentation:
 
 ```floe
 type Handler = (req: Request) -> Promise<Response>
-type Predicate<T> = (value: T) -> boolean
+type Predicate<T> = (T) -> boolean
 
 type Button = {
   label: string,
@@ -299,13 +299,7 @@ type Button = {
 }
 ```
 
-Labels are documentation only — they do not affect structural assignability. Inline higher-order parameters keep labels optional, since the name is usually noise:
-
-```floe
-let map(xs: Array<A>, f: (A) -> B) -> Array<B> = { xs |> Array.map(f) }
-```
-
-Omitting a label at a named position is a compile error (E203).
+Labels never affect structural assignability — `(x: Int) -> Int`, `(y: Int) -> Int`, and `(Int) -> Int` are all the same type. Add labels when the name carries meaning (DDD-style workflow types, multi-param callbacks); skip them when the position is obvious.
 
 ## Tuple Types
 

--- a/docs/site/src/content/docs/docs/guide/typescript-interop.md
+++ b/docs/site/src/content/docs/docs/guide/typescript-interop.md
@@ -130,7 +130,7 @@ type CardProps = {
 
 ### Function-type aliases
 
-Use `->` for function types. Parameter labels are required in named positions:
+Use `->` for function types. Parameter labels are optional documentation:
 
 ```floe
 import { Request, Response } from "express"

--- a/docs/site/src/content/docs/docs/guide/typescript-interop.md
+++ b/docs/site/src/content/docs/docs/guide/typescript-interop.md
@@ -130,12 +130,12 @@ type CardProps = {
 
 ### Function-type aliases
 
-Use `=>` for function types:
+Use `->` for function types. Parameter labels are required in named positions:
 
 ```floe
 import { Request, Response } from "express"
 
-type Handler = (Request, Response) -> Promise<()>
+type Handler = (req: Request, res: Response) -> Promise<()>
 ```
 
 ## Nullable and optional type conversion

--- a/docs/site/src/content/docs/docs/reference/types.md
+++ b/docs/site/src/content/docs/docs/reference/types.md
@@ -32,7 +32,7 @@ Every type declaration starts with `type Name = RHS`. The shape of the RHS picks
 | `{ field: T, ... }` | Record |
 | `A \| B \| ...` (constructors) | Tagged sum (nominal — declares fresh constructors) |
 | `Name(T)` | Newtype (single-value wrapper) |
-| `(Args) => Ret` | Function-type alias (structural) |
+| `(label: T, ...) => Ret` | Function-type alias (structural; parameter labels required) |
 | `OneOf<"a", "b", ...>` | Structural string-literal union |
 | `Intersect<A, B, ...>` | Structural intersection |
 | `Partial<T>` / `Pick<T, K>` / `Omit<T, K>` / `ReturnType<...>` / ... | TS utility alias (pass-through) |
@@ -161,12 +161,20 @@ Only code in the module that defines `Email` can construct or destructure it. Ot
 
 ## Function-Type Aliases
 
-Structural function types. Use `=>` between the parameter list and return type:
+Structural function types. Use `->` between the parameter list and return type. **Parameter labels are required** in top-level type aliases and on function-typed record fields:
 
 ```floe
-type Handler = (Request) -> Promise<Response>
-type Predicate<T> = (T) -> boolean
-type Reducer<S, A> = (S, A) -> S
+type Handler = (req: Request) -> Promise<Response>
+type Predicate<T> = (value: T) -> boolean
+type Reducer<S, A> = (state: S, action: A) -> S
+```
+
+Labels are documentation only — they do not affect structural assignability, so `(x: Int) -> Int` is interchangeable with `(y: Int) -> Int`. Omitting labels at a named position is a compile error (**E203**).
+
+Inline function types used as higher-order parameters keep labels optional, since the name is usually noise:
+
+```floe
+let map(xs: Array<A>, f: (A) -> B) -> Array<B> = { xs |> Array.map(f) }
 ```
 
 ## Structural String-Literal Unions (`OneOf<>`)

--- a/docs/site/src/content/docs/docs/reference/types.md
+++ b/docs/site/src/content/docs/docs/reference/types.md
@@ -32,7 +32,7 @@ Every type declaration starts with `type Name = RHS`. The shape of the RHS picks
 | `{ field: T, ... }` | Record |
 | `A \| B \| ...` (constructors) | Tagged sum (nominal — declares fresh constructors) |
 | `Name(T)` | Newtype (single-value wrapper) |
-| `(label: T, ...) => Ret` | Function-type alias (structural; parameter labels required) |
+| `(T, ...) => Ret` or `(label: T, ...) => Ret` | Function-type alias (structural; parameter labels optional, documentation only) |
 | `OneOf<"a", "b", ...>` | Structural string-literal union |
 | `Intersect<A, B, ...>` | Structural intersection |
 | `Partial<T>` / `Pick<T, K>` / `Omit<T, K>` / `ReturnType<...>` / ... | TS utility alias (pass-through) |
@@ -161,21 +161,15 @@ Only code in the module that defines `Email` can construct or destructure it. Ot
 
 ## Function-Type Aliases
 
-Structural function types. Use `->` between the parameter list and return type. **Parameter labels are required** in top-level type aliases and on function-typed record fields:
+Structural function types. Use `->` between the parameter list and return type. Parameter labels are optional documentation:
 
 ```floe
 type Handler = (req: Request) -> Promise<Response>
-type Predicate<T> = (value: T) -> boolean
+type Predicate<T> = (T) -> boolean
 type Reducer<S, A> = (state: S, action: A) -> S
 ```
 
-Labels are documentation only — they do not affect structural assignability, so `(x: Int) -> Int` is interchangeable with `(y: Int) -> Int`. Omitting labels at a named position is a compile error (**E203**).
-
-Inline function types used as higher-order parameters keep labels optional, since the name is usually noise:
-
-```floe
-let map(xs: Array<A>, f: (A) -> B) -> Array<B> = { xs |> Array.map(f) }
-```
+Labels never affect structural assignability — `(x: Int) -> Int` is interchangeable with `(y: Int) -> Int` and with the unlabelled `(Int) -> Int`. Use them when the name carries meaning (DDD-style workflow types, multi-param callbacks); skip them when the position is obvious. LSP hover surfaces whichever form you wrote.
 
 ## Structural String-Literal Unions (`OneOf<>`)
 

--- a/editors/tree-sitter-floe/grammar.js
+++ b/editors/tree-sitter-floe/grammar.js
@@ -268,9 +268,15 @@ module.exports = grammar({
     function_type: ($) =>
       seq(
         "(",
-        commaSep($._type_expression),
+        commaSep($.function_type_param),
         ")",
         "->",
+        $._type_expression,
+      ),
+
+    function_type_param: ($) =>
+      choice(
+        seq(field("label", $.identifier), ":", $._type_expression),
         $._type_expression,
       ),
 

--- a/examples/store/src/pages/cart.fl
+++ b/examples/store/src/pages/cart.fl
@@ -6,8 +6,8 @@ import { for Array, formatPrice } from "../product"
 
 type CartItemRowProps = {
     item: CartItem,
-    onUpdateQty: (ProductId, number) -> (),
-    onRemove: (ProductId) -> (),
+    onUpdateQty: (id: ProductId, qty: number) -> (),
+    onRemove: (id: ProductId) -> (),
 }
 
 type OrderSummaryProps = {
@@ -18,8 +18,8 @@ type OrderSummaryProps = {
 
 type CartPageProps = {
     cart: Array<CartItem>,
-    onUpdateQty: (ProductId, number) -> (),
-    onRemove: (ProductId) -> (),
+    onUpdateQty: (id: ProductId, qty: number) -> (),
+    onRemove: (id: ProductId) -> (),
 }
 
 // ── Cart item row ──────────────────────────────────────

--- a/examples/store/src/pages/catalog.fl
+++ b/examples/store/src/pages/catalog.fl
@@ -11,26 +11,26 @@ import { fetchProducts, fetchCategories, CategoryResponse } from "../api"
 
 type ProductCardProps = {
     product: Product,
-    onAddToCart: (Product) -> (),
+    onAddToCart: (product: Product) -> (),
 }
 
 type FilterSidebarProps = {
     categories: Array<CategoryResponse>,
     selectedCategory: string,
-    onCategoryChange: (string) -> (),
+    onCategoryChange: (category: string) -> (),
     priceRange: PriceRange,
-    onPriceRangeChange: (PriceRange) -> (),
+    onPriceRangeChange: (range: PriceRange) -> (),
     sortOrder: SortOrder,
-    onSortChange: (SortOrder) -> (),
+    onSortChange: (order: SortOrder) -> (),
 }
 
 type CategoryListProps = {
     selectedCategory: string,
-    onCategoryChange: (string) -> (),
+    onCategoryChange: (category: string) -> (),
     priceRange: PriceRange,
-    onPriceRangeChange: (PriceRange) -> (),
+    onPriceRangeChange: (range: PriceRange) -> (),
     sortOrder: SortOrder,
-    onSortChange: (SortOrder) -> (),
+    onSortChange: (order: SortOrder) -> (),
 }
 
 type ProductGridProps = {
@@ -38,11 +38,11 @@ type ProductGridProps = {
     search: string,
     sortOrder: SortOrder,
     priceRange: PriceRange,
-    onAddToCart: (Product) -> (),
+    onAddToCart: (product: Product) -> (),
 }
 
 type CatalogPageProps = {
-    onAddToCart: (Product) -> (),
+    onAddToCart: (product: Product) -> (),
 }
 
 // ── Product card ───────────────────────────────────────

--- a/examples/store/src/pages/product-detail.fl
+++ b/examples/store/src/pages/product-detail.fl
@@ -18,7 +18,7 @@ type ReviewCardProps = {
 
 type ProductDetailProps = {
     productId: ProductId,
-    onAddToCart: (Product) -> (),
+    onAddToCart: (product: Product) -> (),
 }
 
 // ── Star rating display ────────────────────────────────


### PR DESCRIPTION
closes #1273

Add parser, AST, and codegen support for **optional parameter labels** in function-type aliases (`type Handler = (cmd: Cmd) -> Result<X, Y>`) and function-typed record fields. Labels are pure documentation — they surface in LSP hover and survive the formatter, but never affect structural assignability.

Both `(req: Request) -> Response` and `(Request) -> Response` are accepted at every position. The dominant functional-language convention (Haskell, Elm, F#, Gleam) is positional types with optional labels at definition or call sites; this PR aligns Floe with that convention while preserving the documentation affordance for DDD-style workflow types.

## Summary

- New `FN_TYPE_PARAM` CST kind and `FnTypeParam<T>` AST struct carrying optional `label`, `type_ann`, `span`.
- Codegen and tsgo probe generation use the label as the TypeScript parameter name when present, falling back to `_pN` otherwise.
- LSP hover renders labels in function types when authors write them.
- Tree-sitter grammar updated with `function_type_param` choice rule (label-optional).
- Migrated the store example app's prop types to add labels for readability.
- Updated `docs/llms.txt`, `docs/design.md`, `docs/site/.../guide/types.md`, `docs/site/.../guide/typescript-interop.md`, and `docs/site/.../reference/types.md`.

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] New checker tests: `fn_type_alias_accepts_labelled_and_unlabelled_params`, `fn_type_param_label_does_not_collide_with_call_site_arguments`
- [x] New parser tests: `fn_type_alias_with_labelled_params`, `fn_type_alias_without_labels_still_parses`
- [x] `floe fmt && floe check && floe build` on `examples/store/src/` and `examples/todo-app/src/`
- [x] LSP test suite passes (250/250)
- [x] `floe-doc-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)