### PR TITLE
feat: [#1281] per-function chain probes thread registration paths through handlers

### DIFF
--- a/crates/floe-core/src/checker.rs
+++ b/crates/floe-core/src/checker.rs
@@ -155,6 +155,12 @@ pub(crate) struct CheckContext {
     /// Expected type from surrounding context (const annotation, function return type, etc.).
     /// Used by Ok/Err for bidirectional inference to fill missing type parameters.
     pub expected_type: Option<Type>,
+    /// Name of the function currently being checked (top-level function
+    /// declarations only — lambdas and nested scopes leave this as `None`).
+    /// Used to look up per-function chain probes so `c.req.param(...)`
+    /// inside a handler registered at a specific route can narrow via
+    /// the path-threaded Context emitted by the probe generator.
+    pub current_function: Option<String>,
 }
 
 // ── Unused name tracking ────────────────────────────────────────

--- a/crates/floe-core/src/checker/expr.rs
+++ b/crates/floe-core/src/checker/expr.rs
@@ -2521,10 +2521,24 @@ impl Checker {
         field: &str,
     ) -> Option<Type> {
         let chain_key = extract_chain_key(object, field)?;
+        // Per-function scoped probe first — the probe generator emits a
+        // `__chain_{prefix}{fn}__{chain_key}` entry for handlers registered
+        // to a specific route, which threads the path into Context's P
+        // parameter and lets tsgo narrow `c.req.param("code")` to `string`.
+        if let Some(fn_name) = self.ctx.current_function.as_deref()
+            && let Some(ty) = self.lookup_dts_probe(&format!("{prefix}{fn_name}__{chain_key}"))
+        {
+            return Some(ty);
+        }
         if let Some(ty) = self.lookup_dts_probe(&format!("{prefix}{chain_key}")) {
             return Some(ty);
         }
         let type_key = self.chain_key_by_root_type(object, field)?;
+        if let Some(fn_name) = self.ctx.current_function.as_deref()
+            && let Some(ty) = self.lookup_dts_probe(&format!("{prefix}{fn_name}__{type_key}"))
+        {
+            return Some(ty);
+        }
         self.lookup_dts_probe(&format!("{prefix}{type_key}"))
     }
 

--- a/crates/floe-core/src/checker/items.rs
+++ b/crates/floe-core/src/checker/items.rs
@@ -511,6 +511,7 @@ impl Checker {
         // Set up scope for function body
         let prev_return_type = self.ctx.current_return_type.take();
         let prev_expected = self.ctx.expected_type.take();
+        let prev_function = self.ctx.current_function.replace(decl.name.clone());
         // For Promise<T> return types, unwrap so ? sees the inner type
         let effective_return = match &return_type {
             Type::Promise(inner) => inner.as_ref().clone(),
@@ -697,6 +698,7 @@ impl Checker {
         self.env.pop_scope();
         self.ctx.current_return_type = prev_return_type;
         self.ctx.expected_type = prev_expected;
+        self.ctx.current_function = prev_function;
         self.active_type_params = prev_type_params;
     }
 

--- a/crates/floe-core/src/interop/tsgo.rs
+++ b/crates/floe-core/src/interop/tsgo.rs
@@ -1367,6 +1367,40 @@ export let handler(c: Context<unknown>) -> string ={
     }
 
     #[test]
+    fn generate_probe_threads_registration_path_into_handler_context() {
+        // Regression for #1281. When a handler is registered via a pipe
+        // chain `|> get("/users/:id", handleUser)`, the probe must emit a
+        // per-function chain base with the path threaded into Context's
+        // P parameter — otherwise tsgo resolves `c.req.param("id")` via
+        // the default `any` param and returns `string | undefined` rather
+        // than the narrowed `string`.
+        let source = r#"import trusted { router, get, Context } from "hono"
+
+type Bindings = { DB: string }
+
+let handleUser(c: Context<{ Bindings: Bindings }>) -> string = {
+    c.req.param("id")
+}
+
+export let app = router<Bindings>()
+    |> get("/users/:id", handleUser)
+"#;
+        let program = Parser::new(source).parse_program().unwrap();
+        let probe = generate_probe(&program, &HashMap::new(), &HashMap::new());
+
+        assert!(
+            probe.contains("declare const __chain_base_handleUser__Context: Context<{ Bindings: Bindings }, \"/users/:id\">;"),
+            "per-function chain base must thread the registered path, got:\n{probe}"
+        );
+        assert!(
+            probe.contains(
+                "export let __chain_call_handleUser__Context$req$param = __chain_base_handleUser__Context.req.param(null! as any);"
+            ),
+            "per-function chain call probe missing for handler body, got:\n{probe}"
+        );
+    }
+
+    #[test]
     fn generate_probe_preserves_nested_generic_type_argument() {
         // Regression for #1276. Without the full type annotation in the probe,
         // `c.env.DB` on `Context<{ Bindings: Bindings }>` collapses to the

--- a/crates/floe-core/src/interop/tsgo/probe_gen.rs
+++ b/crates/floe-core/src/interop/tsgo/probe_gen.rs
@@ -1046,16 +1046,205 @@ pub(super) fn generate_probe(
 
     let has_jsx_probes = !collector.probes.is_empty() || !collector.children_probes.is_empty();
 
+    emit_per_handler_chain_probes(program, &imported_names, &mut lines);
+
     if probe_index == 0
         && member_accesses.is_empty()
         && !has_chain_probes
         && !has_type_probes
         && !has_jsx_probes
+        && !lines
+            .iter()
+            .any(|l| l.contains("__chain_base_") && l.contains("__"))
     {
         return String::new();
     }
 
     lines.join("\n") + "\n"
+}
+
+/// Emit per-handler scoped chain probes that thread the registration path
+/// (e.g. `get("/users/:id", handleGet)`) into the handler's parameter type.
+/// Without this, `c.req.param("id")` inside `handleGet` resolves against
+/// the default `P` of `Context` and falls back to `string | undefined`;
+/// with the path threaded, tsgo narrows to `string`.
+///
+/// Emits for each registered handler:
+///   declare const __chain_base_<fn>__<Base>: <Base><...args, "path">;
+///   export let __chain_<fn>__<Base>$f1$f2 = __chain_base_...f1.f2;
+///   export let __chain_call_<fn>__<Base>$f1$f2 = ...f1.f2(null! as any);
+///   export let __chain_await_<fn>__<Base>$f1$f2 = ...;
+///
+/// The checker's per-function chain lookup prefers these over the global
+/// `__chain_*` keys for expressions inside the named handler.
+fn emit_per_handler_chain_probes(
+    program: &Program,
+    imported_names: &HashMap<String, String>,
+    lines: &mut Vec<String>,
+) {
+    let handler_paths = collect_handler_paths(program);
+    if handler_paths.is_empty() {
+        return;
+    }
+
+    for item in &program.items {
+        let ItemKind::Function(decl) = &item.kind else {
+            continue;
+        };
+        let Some(path_literal) = handler_paths.get(decl.name.as_str()) else {
+            continue;
+        };
+
+        // Find the first imported-typed parameter (e.g. `c: Context<...>`)
+        // and render its annotation with the path threaded as an extra
+        // trailing type argument.
+        let Some((param_name, base_type, threaded_ann)) =
+            handler_param_with_path(decl, imported_names, path_literal)
+        else {
+            continue;
+        };
+
+        let chain_prefix = format!("{}__{}", decl.name, base_type);
+        let base_name = format!("__chain_base_{chain_prefix}");
+        lines.push(format!("declare const {base_name}: {threaded_ann};"));
+
+        // Walk the handler body for chain expressions rooted in `param_name`,
+        // then emit one probe per chain (plus `_call_` and `_await_` variants)
+        // using the per-function scoped base.
+        let chains = collect_param_rooted_chains(&decl.body, &param_name);
+        for (steps, is_call) in chains {
+            let chain_key = format!("{chain_prefix}${}", steps.join("$"));
+            let mut expr = base_name.clone();
+            for step in &steps {
+                expr = format!("{expr}.{step}");
+            }
+            lines.push(format!("export let __chain_{chain_key} = {expr};"));
+            if is_call {
+                lines.push(format!(
+                    "export let __chain_call_{chain_key} = {expr}(null! as any);"
+                ));
+            }
+            lines.push(format!("export let __chain_called_{chain_key} = {expr}();"));
+            let await_fn = format!("__chain_await_{chain_key}_fn");
+            lines.push(format!(
+                "declare function {await_fn}(): Awaited<typeof __chain_called_{chain_key}>;"
+            ));
+            lines.push(format!(
+                "export let __chain_await_{chain_key} = {await_fn}();"
+            ));
+        }
+    }
+}
+
+/// Scan pipe-chain method calls of the shape `router_method(path, handler)`
+/// and record `handler -> path`. Handlers registered by an inline lambda
+/// are skipped (no name to correlate with a function declaration).
+fn collect_handler_paths(program: &Program) -> HashMap<String, String> {
+    let mut out: HashMap<String, String> = HashMap::new();
+    crate::walk::walk_program(program, &mut |expr| {
+        let ExprKind::Call { args, .. } = &expr.kind else {
+            return;
+        };
+        // Two positional args: string literal path, then handler identifier.
+        if args.len() < 2 {
+            return;
+        }
+        let Arg::Positional(path_arg) = &args[0] else {
+            return;
+        };
+        let Arg::Positional(handler_arg) = &args[1] else {
+            return;
+        };
+        let ExprKind::String(path) = &path_arg.kind else {
+            return;
+        };
+        if !path.starts_with('/') {
+            return;
+        }
+        let ExprKind::Identifier(handler_name) = &handler_arg.kind else {
+            return;
+        };
+        out.entry(handler_name.clone())
+            .or_insert_with(|| path.clone());
+    });
+    out
+}
+
+/// For a function whose first parameter is `c: Import<...>`, render the
+/// TS annotation with `path_literal` appended as an additional type
+/// argument — e.g. `Context<{ Bindings: B }>` + `/users/:id` becomes
+/// `Context<{ Bindings: B }, "/users/:id">`. Returns the parameter name,
+/// the base type name (e.g. `"Context"`), and the rendered annotation.
+fn handler_param_with_path(
+    decl: &FunctionDecl,
+    imported_names: &HashMap<String, String>,
+    path_literal: &str,
+) -> Option<(String, String, String)> {
+    let param = decl.params.first()?;
+    let ann = param.type_ann.as_ref()?;
+    let TypeExprKind::Named {
+        name: base_type,
+        type_args,
+        ..
+    } = &ann.kind
+    else {
+        return None;
+    };
+    if !imported_names.contains_key(base_type) {
+        return None;
+    }
+    let mut args_str: Vec<String> = type_args.iter().map(type_expr_to_ts).collect();
+    args_str.push(format!("\"{path_literal}\""));
+    let threaded_ann = format!("{base_type}<{}>", args_str.join(", "));
+    Some((param.name.clone(), base_type.clone(), threaded_ann))
+}
+
+/// Walk `body` collecting chain expressions rooted in `param_name`. Each
+/// chain is returned once with a flag indicating whether any occurrence
+/// invoked the terminal step — that determines whether we emit the
+/// `__chain_call_` variant alongside the base `__chain_` probes.
+fn collect_param_rooted_chains(body: &Expr, param_name: &str) -> Vec<(Vec<String>, bool)> {
+    let mut by_key: HashMap<String, (Vec<String>, bool)> = HashMap::new();
+    crate::walk::walk_expr(body, &mut |expr| {
+        let (member_expr, is_call) = match &expr.kind {
+            ExprKind::Call { callee, .. } => (callee.as_ref(), true),
+            ExprKind::Member { .. } => (expr, false),
+            _ => return,
+        };
+        let Some(steps) = collect_member_chain(member_expr, param_name) else {
+            return;
+        };
+        if steps.len() < 2 {
+            return;
+        }
+        let key = steps.join("$");
+        by_key
+            .entry(key)
+            .and_modify(|(_, flag)| {
+                if is_call {
+                    *flag = true;
+                }
+            })
+            .or_insert((steps, is_call));
+    });
+    by_key.into_values().collect()
+}
+
+/// If `expr` is a Member chain rooted in `param_name`, return the field
+/// steps after the root (e.g. `c.req.param` → `vec!["req", "param"]`).
+fn collect_member_chain(expr: &Expr, param_name: &str) -> Option<Vec<String>> {
+    let ExprKind::Member { object, field } = &expr.kind else {
+        return None;
+    };
+    match &object.kind {
+        ExprKind::Identifier(name) if name == param_name => Some(vec![field.clone()]),
+        ExprKind::Member { .. } => {
+            let mut prior = collect_member_chain(object, param_name)?;
+            prior.push(field.clone());
+            Some(prior)
+        }
+        _ => None,
+    }
 }
 
 struct JsxCallbackProbe {

--- a/crates/floe-core/src/interop/tsgo/probe_gen.rs
+++ b/crates/floe-core/src/interop/tsgo/probe_gen.rs
@@ -1139,13 +1139,25 @@ fn emit_per_handler_chain_probes(
 /// Scan pipe-chain method calls of the shape `router_method(path, handler)`
 /// and record `handler -> path`. Handlers registered by an inline lambda
 /// are skipped (no name to correlate with a function declaration).
+///
+/// The shape match is heuristic — any call where arg 0 is a string
+/// starting with `/` and arg 1 is an identifier qualifies. False
+/// positives (e.g. `fs.readFile("/etc/hosts", cb)`) produce a bogus
+/// per-function probe block; tsgo emits `any` for mismatched
+/// instantiations and the checker's per-function chain lookup silently
+/// falls back to the global key. Harmless in practice, but a stricter
+/// check (verify the callee is actually a router method) could come
+/// later if false positives cause noise.
+///
+/// First registration per handler wins — if the same function is
+/// registered at multiple routes, only the first path is threaded into
+/// its chain base. Refining this requires per-registration bases.
 fn collect_handler_paths(program: &Program) -> HashMap<String, String> {
     let mut out: HashMap<String, String> = HashMap::new();
     crate::walk::walk_program(program, &mut |expr| {
         let ExprKind::Call { args, .. } = &expr.kind else {
             return;
         };
-        // Two positional args: string literal path, then handler identifier.
         if args.len() < 2 {
             return;
         }


### PR DESCRIPTION
closes #1281

## Summary

Handlers registered via pipe-chain router methods — \`|> get(\"/users/:id\", handleUser)\` — now have \`c.req.param(\"id\")\` **narrow to \`string\`** instead of the looser \`string | undefined\`. Matches TS Hono's behavior exactly.

Verified end-to-end: in a yeet-style \`routes.fl\`, \`let code: string = c.req.param(\"code\")\` now type-checks cleanly when \`handleGet\` is registered at \`/snippets/:code\`.

## The problem

The registration site (\`get(\"/users/:id\", handleUser)\`) and the handler definition (\`let handleUser(c: Context<...>) = { ... }\`) are on opposite sides of the program. A global \`__chain_base_Context\` can only thread one path, so it defaulted to the generic-default \`any\` for \`P extends string\` — tsgo resolved \`c.req.param(...)\` to \`string | undefined\`.

## The fix

\`probe_gen::emit_per_handler_chain_probes\` scans pipe chains for \`router_method(path_literal, handler_name)\` pairs, then for each registered handler emits a dedicated chain base:

\`\`\`ts
declare const __chain_base_handleUser__Context:
    Context<{ Bindings: Bindings }, \"/users/:id\">;
\`\`\`

Plus per-function chain exports for every member chain rooted in the handler's parameter.

The checker tracks the enclosing function via \`CheckContext::current_function\` (set/unset in \`check_function\`) and \`lookup_prefixed_chain_probe\` prefers the function-scoped key. When inside \`handleUser\`, lookup returns the narrowed \`string\`. Outside a handler, falls back to the global key — behavior unchanged.

Same \"hand TS more info and let it do the work\" pattern as #1276: no template-literal or conditional-type machinery in Floe, tsgo does the narrowing once the probe includes the registration path.

## Generality

Though motivated by Hono, the per-function chain infrastructure handles any framework where a named handler is specialized by its registration site — Express-style routers, tRPC procedures, ORMs with lifecycle hooks, React \`forwardRef\`, etc. Any pattern where TS narrows a handler parameter based on how it's registered benefits from this.

## Changes

- **\`checker.rs\`** — new \`CheckContext::current_function\` field.
- **\`checker/items.rs\`** — \`check_function\` push/pop's the current function name around body checking.
- **\`checker/expr.rs\`** — \`lookup_prefixed_chain_probe\` tries \`{prefix}{fn}__{key}\` before \`{prefix}{key}\`.
- **\`interop/tsgo/probe_gen.rs\`** — new \`emit_per_handler_chain_probes\` + helpers (\`collect_handler_paths\`, \`handler_param_with_path\`, \`collect_param_rooted_chains\`, \`collect_member_chain\`) called at the end of \`generate_probe\`.

## Test plan

- [x] New \`generate_probe_threads_registration_path_into_handler_context\` verifies the per-function chain base is emitted with the correct path-threaded annotation and the \`_call_\` variant for member chains.
- [x] Full \`cargo test -p floe-core --lib\`: 1519 passed.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`: clean.
- [x] Example apps: fmt + check + build on both \`examples/todo-app\` and \`examples/store\` succeed.
- [x] **End-to-end**: yeet's \`routes.fl\` with \`let code: string = c.req.param(\"code\")\` (no \`Option<>\` wrapper, no \`Option.guard\`) now type-checks — \`handleGet\` is registered at \`/snippets/:code\`, so \`\"code\"\` is a known path param and tsgo narrows.