### PR TITLE
fix: [#1286] thread `use` continuation into piped-into call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "floe"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ariadne",
  "bincode",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "floe-doc-check"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "floe-lsp"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "floe-core",
  "insta",
@@ -355,14 +355,14 @@ dependencies = [
 
 [[package]]
 name = "floe-test-helpers"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "floe-core",
 ]
 
 [[package]]
 name = "floe-wasm"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "floe-core",
  "serde",

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -9165,3 +9165,96 @@ export let id: OrderId = 42
         "nominal newtype must keep rejecting raw payload values"
     );
 }
+
+// ── `use x <- …` with piped RHS (regression: #1286) ──────────
+
+#[test]
+fn use_piped_into_result_guard_infers_ok_binding() {
+    // With the bug, `use body <- result |> Result.guard(err_fn)` desugared
+    // into `(result |> Result.guard(err_fn))(continuation)`, which stranded
+    // the continuation outside the hint-bearing call — the `body` param
+    // came back as `unknown` and the body couldn't use it as the Ok type.
+    //
+    // After the fix, the structure is `result |> Result.guard(err_fn, cont)`,
+    // so `body` inherits `Result.guard`'s on_ok param type.
+    let diags = check(
+        r#"
+let _run(r: Result<number, string>) -> number = {
+    use body <- r |> Result.guard((_) -> 0)
+    body + 1
+}
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::TypeMismatch),
+        "piped use-into Result.guard should infer the binding as the Ok type, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    assert!(
+        !has_warning_containing(&diags, "unknown type"),
+        "no unknown-type warning should fire for the `use` binding, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn use_piped_into_result_guard_rejects_wrong_body_type() {
+    // The flip side: if the binding is inferred, using it against the wrong
+    // type should still error. This proves the hint actually flows through
+    // (rather than the binding being silently typed as `unknown`).
+    let diags = check(
+        r#"
+let _run(r: Result<number, string>) -> string = {
+    use body <- r |> Result.guard((_) -> "err")
+    body
+}
+"#,
+    );
+    // If `body` is inferred as `number` (the Ok type), the function body
+    // evaluates to `number` and mismatches the declared `string` return.
+    // If `body` were `unknown`, no such error would fire.
+    assert!(
+        has_error_containing(&diags, "expected return type `string`, found `number`"),
+        "wrong use-body type should error once the binding is properly inferred, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn use_chained_pipe_preserves_binding_inference() {
+    // Chained pipes: the continuation must still reach the final call so the
+    // binding is hinted. `stepA` just re-exports the Result unchanged.
+    let diags = check(
+        r#"
+let stepA(r: Result<number, string>) -> Result<number, string> = { r }
+let _run(r: Result<number, string>) -> number = {
+    use body <- r |> stepA |> Result.guard((_) -> 0)
+    body + 1
+}
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::TypeMismatch),
+        "chained pipe into Result.guard should still infer binding, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn use_unpiped_call_still_works() {
+    // Regression guard: the non-pipe desugaring path must keep working
+    // exactly as before.
+    let diags = check(
+        r#"
+let _run(r: Result<number, string>) -> number = {
+    use body <- Result.guard(r, (_) -> 0)
+    body + 1
+}
+"#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::TypeMismatch),
+        "unpiped use-into Result.guard must still infer binding, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -9170,13 +9170,6 @@ export let id: OrderId = 42
 
 #[test]
 fn use_piped_into_result_guard_infers_ok_binding() {
-    // With the bug, `use body <- result |> Result.guard(err_fn)` desugared
-    // into `(result |> Result.guard(err_fn))(continuation)`, which stranded
-    // the continuation outside the hint-bearing call — the `body` param
-    // came back as `unknown` and the body couldn't use it as the Ok type.
-    //
-    // After the fix, the structure is `result |> Result.guard(err_fn, cont)`,
-    // so `body` inherits `Result.guard`'s on_ok param type.
     let diags = check(
         r#"
 let _run(r: Result<number, string>) -> number = {
@@ -9199,9 +9192,9 @@ let _run(r: Result<number, string>) -> number = {
 
 #[test]
 fn use_piped_into_result_guard_rejects_wrong_body_type() {
-    // The flip side: if the binding is inferred, using it against the wrong
-    // type should still error. This proves the hint actually flows through
-    // (rather than the binding being silently typed as `unknown`).
+    // Mismatched return type is the observable signal that `body` was
+    // inferred as `number` (not `unknown`) — without the fix the binding
+    // stays unknown and no such error fires.
     let diags = check(
         r#"
 let _run(r: Result<number, string>) -> string = {
@@ -9210,9 +9203,6 @@ let _run(r: Result<number, string>) -> string = {
 }
 "#,
     );
-    // If `body` is inferred as `number` (the Ok type), the function body
-    // evaluates to `number` and mismatches the declared `string` return.
-    // If `body` were `unknown`, no such error would fire.
     assert!(
         has_error_containing(&diags, "expected return type `string`, found `number`"),
         "wrong use-body type should error once the binding is properly inferred, got: {:?}",
@@ -9222,8 +9212,6 @@ let _run(r: Result<number, string>) -> string = {
 
 #[test]
 fn use_chained_pipe_preserves_binding_inference() {
-    // Chained pipes: the continuation must still reach the final call so the
-    // binding is hinted. `stepA` just re-exports the Result unchanged.
     let diags = check(
         r#"
 let stepA(r: Result<number, string>) -> Result<number, string> = { r }
@@ -9242,8 +9230,6 @@ let _run(r: Result<number, string>) -> number = {
 
 #[test]
 fn use_unpiped_call_still_works() {
-    // Regression guard: the non-pipe desugaring path must keep working
-    // exactly as before.
     let diags = check(
         r#"
 let _run(r: Result<number, string>) -> number = {

--- a/crates/floe-core/src/codegen/tests.rs
+++ b/crates/floe-core/src/codegen/tests.rs
@@ -2015,6 +2015,55 @@ fn use_chained() {
 }
 
 #[test]
+fn use_piped_call_appends_continuation_to_inner_call() {
+    // `use x <- a |> f(b)` must desugar so the continuation lands on the
+    // piped-into function, not outside the pipe. Codegen should produce
+    // `f(a, b, (x) => ...)`, matching the unpiped `use x <- f(a, b)` form.
+    let result = emit(
+        r#"let _test() -> number = {
+    use x <- 1 |> doSomething(42)
+    x
+}"#,
+    );
+    assert!(
+        result.contains("doSomething(1, 42, (x)"),
+        "piped use should expand into the piped-into call, got: {result}"
+    );
+}
+
+#[test]
+fn use_piped_bare_identifier_appends_continuation() {
+    // `use x <- a |> f` (bare identifier on the right) must become
+    // `f(a, (x) => ...)` — the continuation is the second arg to `f`.
+    let result = emit(
+        r#"let _test() -> number = {
+    use x <- 1 |> doSomething
+    x
+}"#,
+    );
+    assert!(
+        result.contains("doSomething(1, (x)"),
+        "piped-into bare identifier should receive the continuation, got: {result}"
+    );
+}
+
+#[test]
+fn use_chained_pipe_threads_continuation_to_final_call() {
+    // Chained pipes are left-associative. The continuation must land on the
+    // outermost (rightmost) piped-into call so earlier stages still chain.
+    let result = emit(
+        r#"let _test() -> number = {
+    use x <- 1 |> stepA |> stepB(42)
+    x
+}"#,
+    );
+    assert!(
+        result.contains("stepB(stepA(1), 42, (x)"),
+        "continuation should reach the final piped-into call, got: {result}"
+    );
+}
+
+#[test]
 fn use_callback_block_returns_last_expr() {
     let result = emit(
         r#"let _test() -> number = {

--- a/crates/floe-core/src/codegen/tests.rs
+++ b/crates/floe-core/src/codegen/tests.rs
@@ -2016,9 +2016,6 @@ fn use_chained() {
 
 #[test]
 fn use_piped_call_appends_continuation_to_inner_call() {
-    // `use x <- a |> f(b)` must desugar so the continuation lands on the
-    // piped-into function, not outside the pipe. Codegen should produce
-    // `f(a, b, (x) => ...)`, matching the unpiped `use x <- f(a, b)` form.
     let result = emit(
         r#"let _test() -> number = {
     use x <- 1 |> doSomething(42)
@@ -2033,8 +2030,6 @@ fn use_piped_call_appends_continuation_to_inner_call() {
 
 #[test]
 fn use_piped_bare_identifier_appends_continuation() {
-    // `use x <- a |> f` (bare identifier on the right) must become
-    // `f(a, (x) => ...)` — the continuation is the second arg to `f`.
     let result = emit(
         r#"let _test() -> number = {
     use x <- 1 |> doSomething
@@ -2049,8 +2044,6 @@ fn use_piped_bare_identifier_appends_continuation() {
 
 #[test]
 fn use_chained_pipe_threads_continuation_to_final_call() {
-    // Chained pipes are left-associative. The continuation must land on the
-    // outermost (rightmost) piped-into call so earlier stages still chain.
     let result = emit(
         r#"let _test() -> number = {
     use x <- 1 |> stepA |> stepB(42)

--- a/crates/floe-core/src/lower/expr.rs
+++ b/crates/floe-core/src/lower/expr.rs
@@ -915,6 +915,17 @@ impl<'src> Lowerer<'src> {
         );
 
         // Append the lambda as the last argument to the call
+        Some(self.append_use_continuation(call_expr, lambda, use_span))
+    }
+
+    /// Thread the `use`-generated continuation into the RHS of `<-`.
+    ///
+    /// For pipes, the continuation must land on the piped-into function so the
+    /// checker's lambda-param hints (derived from that function's signature)
+    /// flow into the continuation. Wrapping the whole pipe as a callee —
+    /// `(a |> f(x))(continuation)` — strands the continuation outside the
+    /// hint-bearing call and the parameter types come back as `unknown`.
+    fn append_use_continuation(&self, call_expr: Expr, lambda: Expr, use_span: Span) -> Expr {
         match call_expr.kind {
             ExprKind::Call {
                 callee,
@@ -922,24 +933,35 @@ impl<'src> Lowerer<'src> {
                 mut args,
             } => {
                 args.push(Arg::Positional(lambda));
-                Some(self.expr(
+                self.expr(
                     ExprKind::Call {
                         callee,
                         type_args,
                         args,
                     },
                     use_span,
-                ))
+                )
             }
-            // If it's not a call (e.g. just an identifier), wrap it as a call with the lambda
-            _ => Some(self.expr(
+            ExprKind::Pipe { left, right } => {
+                let pipe_span = call_expr.span;
+                let new_right = self.append_use_continuation(*right, lambda, use_span);
+                self.expr(
+                    ExprKind::Pipe {
+                        left,
+                        right: Box::new(new_right),
+                    },
+                    pipe_span,
+                )
+            }
+            // Bare identifier / member / other: wrap it as a call with the lambda.
+            _ => self.expr(
                 ExprKind::Call {
                     callee: Box::new(call_expr),
                     type_args: Vec::new(),
                     args: vec![Arg::Positional(lambda)],
                 },
                 use_span,
-            )),
+            ),
         }
     }
 


### PR DESCRIPTION
closes #1286

## Summary

`use x <- a |> f(b)` lost lambda-parameter hints because the desugaring wrapped the whole pipe as a callee — `(a |> f(b))(continuation)` — which stranded the continuation outside the hint-bearing call. The checker derives lambda-param hints from the piped-into function's signature, so `x` came back as \`unknown\` and W004 fired.

The fix: if the RHS of `<-` is a pipe, recurse into its rightmost stage and append the continuation to *that* call. For `a |> f(b)`, the result is `a |> f(b, continuation)` (codegens to `f(a, b, continuation)`), matching the unpiped `use x <- f(a, b)` form.

## Test plan

- [x] `cargo test -p floe-core` — all 1592 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] `floe fmt/check/build` on `examples/todo-app/` and `examples/store/` — clean
- [x] New regression tests:
  - `use_piped_into_result_guard_infers_ok_binding` — binding is typed, no W004
  - `use_piped_into_result_guard_rejects_wrong_body_type` — proves the hint flows through (a wrong annotation still errors)
  - `use_chained_pipe_preserves_binding_inference` — `a |> g |> h |> Result.guard(...)` case
  - `use_unpiped_call_still_works` — unpiped regression guard
  - codegen tests covering the emitted shape for piped Call, bare identifier, and chained pipes