### PR TITLE
feat: [#1287] warn when let annotation widens value via Option wrapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "floe"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ariadne",
  "bincode",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "floe-doc-check"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "floe-lsp"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "floe-core",
  "insta",
@@ -355,14 +355,14 @@ dependencies = [
 
 [[package]]
 name = "floe-test-helpers"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "floe-core",
 ]
 
 [[package]]
 name = "floe-wasm"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "floe-core",
  "serde",

--- a/crates/floe-core/src/checker/error_codes.rs
+++ b/crates/floe-core/src/checker/error_codes.rs
@@ -137,6 +137,8 @@ pub enum ErrorCode {
     BareStringLiteralUnion,
     /// Inline record type in function signature — declare a named type first.
     InlineRecordTypeInSignature,
+    /// `let` annotation widens the value via implicit Option/Some wrapping.
+    WideningAnnotation,
 }
 
 impl ErrorCode {
@@ -199,6 +201,7 @@ impl ErrorCode {
             Self::TraitImportWithoutFor => "E053",
             Self::BareStringLiteralUnion => "E201",
             Self::InlineRecordTypeInSignature => "E202",
+            Self::WideningAnnotation => "W008",
         }
     }
 }

--- a/crates/floe-core/src/checker/items.rs
+++ b/crates/floe-core/src/checker/items.rs
@@ -80,6 +80,12 @@ impl Checker {
                 ty
             }
         });
+        if let (Some(type_ann), Some(declared)) = (decl.type_ann.as_ref(), declared_type.as_ref())
+            && tsgo_type.is_none()
+        {
+            self.warn_if_annotation_widens(type_ann.span, declared, &value_type);
+        }
+
         let mut final_type = self.resolve_const_type(
             value_type.clone(),
             declared_type,
@@ -173,6 +179,44 @@ impl Checker {
     fn find_per_field_probe(&mut self, field_name: &str) -> Option<Type> {
         let prefix = format!("__probe_{field_name}_");
         self.consume_probe(|name| name.starts_with(&prefix), true)
+    }
+
+    /// Warn when a `let` annotation widens the RHS via implicit Some wrapping
+    /// (e.g. `let x: Option<string> = "hi"`). The widening keeps compiling, but
+    /// it hides stale annotations — if the RHS tightened after an upgrade, the
+    /// user would never notice without hovering.
+    fn warn_if_annotation_widens(&mut self, ann_span: Span, declared: &Type, value: &Type) {
+        if !declared.is_option() || value.is_option() {
+            return;
+        }
+        if matches!(
+            value,
+            Type::Unknown | Type::Error | Type::Never | Type::Var(_)
+        ) {
+            return;
+        }
+        let Some(inner) = declared.option_inner() else {
+            return;
+        };
+        if matches!(inner, Type::Var(_) | Type::Unknown) {
+            return;
+        }
+        if !self.types_compatible(inner, value) {
+            return;
+        }
+        self.emit_warning_with_help(
+            format!(
+                "annotation `{}` is wider than the value type `{}`",
+                declared, value
+            ),
+            ann_span,
+            ErrorCode::WideningAnnotation,
+            format!("value has type `{}`", value),
+            format!(
+                "change the annotation to `{}`, or wrap the value with `Some(...)` if the `Option` is intentional",
+                value
+            ),
+        );
     }
 
     /// Determine the final type for a const binding given value type, declared type, and tsgo probe.

--- a/crates/floe-core/src/checker/items.rs
+++ b/crates/floe-core/src/checker/items.rs
@@ -189,16 +189,14 @@ impl Checker {
         if !declared.is_option() || value.is_option() {
             return;
         }
-        if matches!(
-            value,
-            Type::Unknown | Type::Error | Type::Never | Type::Var(_)
-        ) {
-            return;
-        }
         let Some(inner) = declared.option_inner() else {
             return;
         };
-        if matches!(inner, Type::Var(_) | Type::Unknown) {
+        if matches!(
+            value,
+            Type::Unknown | Type::Error | Type::Never | Type::Var(_)
+        ) || matches!(inner, Type::Unknown | Type::Var(_))
+        {
             return;
         }
         if !self.types_compatible(inner, value) {

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -5661,6 +5661,99 @@ fn array_assignable_to_option_array() {
     );
 }
 
+// ── Widening annotations (W008) ──────────────────────────
+
+#[test]
+fn widening_annotation_warns_on_bare_literal() {
+    let diags = check(r#"let x: Option<string> = "hi""#);
+    assert!(
+        has_error(&diags, ErrorCode::WideningAnnotation),
+        "expected W008, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    assert!(!has_error(&diags, ErrorCode::TypeMismatch));
+}
+
+#[test]
+fn widening_annotation_warns_on_narrowed_call_result() {
+    // Simulates the motivating example: a function that returns a narrowed `string`
+    // being bound under a wider `Option<string>` annotation.
+    let diags = check(
+        r#"
+        let narrow() -> string = { "hi" }
+        let x: Option<string> = narrow()
+    "#,
+    );
+    assert!(
+        has_error(&diags, ErrorCode::WideningAnnotation),
+        "expected W008 on leftover Option annotation, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn widening_annotation_does_not_warn_when_rhs_is_option() {
+    let diags = check(
+        r#"
+        let maybe() -> Option<string> = { Some("hi") }
+        let x: Option<string> = maybe()
+    "#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::WideningAnnotation),
+        "should not warn when RHS is already Option<T>, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn widening_annotation_does_not_warn_on_none() {
+    let diags = check("let x: Option<string> = None");
+    assert!(
+        !has_error(&diags, ErrorCode::WideningAnnotation),
+        "should not warn on None — it is already an Option, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn widening_annotation_does_not_warn_on_some_wrapping() {
+    let diags = check(r#"let x: Option<string> = Some("hi")"#);
+    assert!(
+        !has_error(&diags, ErrorCode::WideningAnnotation),
+        "should not warn when user already wrote Some(...), got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn widening_annotation_does_not_warn_on_bare_binding() {
+    // Without an annotation there is nothing to widen.
+    let diags = check(r#"let x = "hi""#);
+    assert!(
+        !has_error(&diags, ErrorCode::WideningAnnotation),
+        "no annotation means nothing to warn about, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn widening_annotation_does_not_warn_on_function_return_type() {
+    // Scope: the rule intentionally only fires on `let` annotations, not
+    // function return types — widening a return type can be deliberate for
+    // API compatibility.
+    let diags = check(
+        r#"
+        let wrap() -> Option<string> = { "hi" }
+    "#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::WideningAnnotation),
+        "function return widening should not warn, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
 // ── intersection types ─────────────────────────────────────
 
 #[test]

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -5728,7 +5728,6 @@ fn widening_annotation_does_not_warn_on_some_wrapping() {
 
 #[test]
 fn widening_annotation_does_not_warn_on_bare_binding() {
-    // Without an annotation there is nothing to widen.
     let diags = check(r#"let x = "hi""#);
     assert!(
         !has_error(&diags, ErrorCode::WideningAnnotation),


### PR DESCRIPTION
closes #1287

## Summary

Emit a new **W008** warning when `let x: Option<T> = ...` silently wraps a bare `T` via implicit `Some` wrapping. The widening still compiles, but it hides stale annotations — after an upgrade narrows an RHS (e.g. path params narrowing to `string` via per-route probes), the user would never notice their `Option<string>` is now over-broad short of hovering.

**Scope (deliberately narrow):**
- Only fires on `let` bindings, not function return types (widening a return type is sometimes intentional for API compat).
- Only fires when the RHS is a concrete value, not already an `Option<_>`, and not `unknown`/`never`/type-variable.
- `Result<T, _>` is not included: Floe has no implicit `Ok` wrapping — `type_compat.rs` rejects bare-`T`-to-`Result<T, _>` — so there is nothing to detect for Result.

## Test plan

- [x] `let x: Option<string> = "hi"` — warns
- [x] `let x: Option<string> = maybeString()` where callee returns `Option<string>` — no warning
- [x] `let x: Option<string> = narrow()` where callee returns `string` — warns (motivating case)
- [x] `let x: Option<string> = None` — no warning
- [x] `let x: Option<string> = Some("hi")` — no warning
- [x] `let x = "hi"` (no annotation) — no warning
- [x] `let wrap() -> Option<string> = { "hi" }` (function return) — no warning
- [x] Existing `value_assignable_to_option` / `array_assignable_to_option_array` still compile cleanly
- [x] `cargo test --workspace` passes (1530 checker tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `floe check` passes on `examples/todo-app` and `examples/store`

🤖 Generated with [Claude Code](https://claude.com/claude-code)