### PR TITLE
fix: [#1294] format the RHS of use-declarations

### DIFF
--- a/crates/floe-core/src/formatter.rs
+++ b/crates/floe-core/src/formatter.rs
@@ -102,6 +102,7 @@ impl<'src> Formatter<'src> {
             SyntaxKind::REEXPORT_DECL => self.fmt_reexport(node),
             SyntaxKind::CONST_DECL => self.fmt_const(node),
             SyntaxKind::FUNCTION_DECL => self.fmt_function(node),
+            SyntaxKind::USE_DECL => self.fmt_use_decl(node),
             SyntaxKind::TYPE_DECL => self.fmt_type_decl(node),
             SyntaxKind::BLOCK_EXPR => self.fmt_block(node),
             SyntaxKind::PIPE_EXPR => self.fmt_pipe(node),

--- a/crates/floe-core/src/formatter/items.rs
+++ b/crates/floe-core/src/formatter/items.rs
@@ -294,6 +294,66 @@ impl Formatter<'_> {
         pretty::concat(parts)
     }
 
+    // ── Use declaration ─────────────────────────────────────────
+
+    pub(crate) fn fmt_use_decl(&mut self, node: &SyntaxNode) -> Document {
+        let binding = self.fmt_use_binding(node);
+        let mut parts = vec![pretty::str("use")];
+        if !binding.is_empty() {
+            parts.push(pretty::str(" "));
+            parts.push(pretty::str(binding));
+        }
+        parts.push(pretty::str(" <- "));
+        parts.push(self.fmt_use_rhs(node));
+        pretty::concat(parts)
+    }
+
+    fn fmt_use_binding(&self, node: &SyntaxNode) -> String {
+        let mut out = String::new();
+        for child in node.children_with_tokens() {
+            let Some(tok) = child.as_token() else {
+                continue;
+            };
+            match tok.kind() {
+                SyntaxKind::LEFT_ARROW => break,
+                SyntaxKind::KW_USE => {}
+                k if k.is_trivia() => {}
+                SyntaxKind::L_PAREN => out.push('('),
+                SyntaxKind::R_PAREN => out.push(')'),
+                SyntaxKind::L_BRACE => out.push_str("{ "),
+                SyntaxKind::R_BRACE => out.push_str(" }"),
+                SyntaxKind::COMMA => out.push_str(", "),
+                SyntaxKind::COLON => out.push_str(": "),
+                _ => out.push_str(tok.text()),
+            }
+        }
+        out
+    }
+
+    fn fmt_use_rhs(&mut self, node: &SyntaxNode) -> Document {
+        let mut past_arrow = false;
+        let mut parts = Vec::new();
+        for child in node.children_with_tokens() {
+            if !past_arrow {
+                if child
+                    .as_token()
+                    .is_some_and(|t| t.kind() == SyntaxKind::LEFT_ARROW)
+                {
+                    past_arrow = true;
+                }
+                continue;
+            }
+            match child {
+                rowan::NodeOrToken::Node(n) => parts.push(self.fmt_node(&n)),
+                rowan::NodeOrToken::Token(tok) if !tok.kind().is_trivia() => {
+                    parts.push(pretty::str(tok.text().to_string()));
+                }
+                _ => {}
+            }
+        }
+        pretty::concat(parts)
+    }
+
     fn fmt_type_params(&self, node: &SyntaxNode) -> Document {
         let mut in_angle = false;
         let mut started = false;

--- a/crates/floe-core/src/formatter/tests.rs
+++ b/crates/floe-core/src/formatter/tests.rs
@@ -1031,3 +1031,70 @@ fn idempotent_zero_arg_closure_with_alias() {
 fn idempotent_one_arg_closure_single_expression() {
     assert_idempotent("let f = (x) -> x + 1\n");
 }
+
+// ── use declarations ────────────────────────────────────────
+
+#[test]
+fn use_decl_reformats_pipe_rhs() {
+    // Input pipe is long enough to force a break; arms use three different
+    // source indentations (7, 8, 1 spaces) to prove they are all rewritten.
+    assert_fmt(
+        concat!(
+            "let f() = {\n",
+            "    use body <-\n",
+            "       c.req.json()\n",
+            "        |> await\n",
+            "        |> parse<CreateBody>\n",
+            " |> Result.guard((_) -> c.json({ error: \"invalid body\" }, 400))\n",
+            "    c.json(body, 200)\n",
+            "}",
+        ),
+        concat!(
+            "let f() = {\n",
+            "    use body <- c.req.json()\n",
+            "        |> await\n",
+            "        |> parse<CreateBody>\n",
+            "        |> Result.guard((_) -> c.json({ error: \"invalid body\" }, 400))\n",
+            "\n",
+            "    c.json(body, 200)\n",
+            "}",
+        ),
+    );
+}
+
+#[test]
+fn use_decl_single_ident_idempotent() {
+    assert_idempotent("let f() = {\n    use x <- Option.guard(a, b)\n\n    x\n}\n");
+}
+
+#[test]
+fn use_decl_paren_destructure() {
+    assert_fmt(
+        "let f() = {\n    use (a,b) <- pair\n    a\n}",
+        "let f() = {\n    use (a, b) <- pair\n\n    a\n}",
+    );
+}
+
+#[test]
+fn use_decl_brace_destructure() {
+    assert_fmt(
+        "let f() = {\n    use {a,b} <- record\n    a\n}",
+        "let f() = {\n    use { a, b } <- record\n\n    a\n}",
+    );
+}
+
+#[test]
+fn use_decl_brace_destructure_with_rename() {
+    assert_fmt(
+        "let f() = {\n    use {a:x,b} <- record\n    x\n}",
+        "let f() = {\n    use { a: x, b } <- record\n\n    x\n}",
+    );
+}
+
+#[test]
+fn use_decl_no_binding() {
+    assert_fmt(
+        "let f() = {\n    use <- wrap()\n    done\n}",
+        "let f() = {\n    use <- wrap()\n\n    done\n}",
+    );
+}


### PR DESCRIPTION
closes #1294

`fmt_node` had no arm for `SyntaxKind::USE_DECL`, so it fell through to `fmt_verbatim` — the entire `use <binding> <- <expr>` was copied byte-for-byte from source and any mis-indented pipe stayed mis-indented.

Added `fmt_use_decl` (with `fmt_use_binding` / `fmt_use_rhs` helpers). Binding is rebuilt from raw tokens since the CST stores it flat (`KW_USE`, optional ident/paren/brace, `LEFT_ARROW`); RHS is handed to `fmt_node`, which lets the pipe formatter wrap and indent it properly.

## Before

```floe
use body <-
   c.req.json()
    |> await
    |> parse<CreateBody>
 |> Result.guard((_) -> c.json({ error: "invalid body" }, 400))
```

## After

```floe
use body <- c.req.json()
    |> await
    |> parse<CreateBody>
    |> Result.guard((_) -> c.json({ error: "invalid body" }, 400))
```

## Test plan

- [x] `use_decl_reformats_pipe_rhs` — the repro from the issue is rewritten to canonical indentation
- [x] `use_decl_single_ident_idempotent` — single-ident binding
- [x] `use_decl_paren_destructure` — `use (a, b) <- pair`
- [x] `use_decl_brace_destructure` — `use { a, b } <- record`
- [x] `use_decl_brace_destructure_with_rename` — `use { a: x, b } <- record`
- [x] `use_decl_no_binding` — `use <- wrap()`
- [x] `cargo test -p floe-core` — 1539 passed, 0 failed
- [x] `cargo clippy -p floe-core --all-targets -- -D warnings` — clean
- [x] `floe fmt --check examples/todo-app/src/` and `examples/store/src/` — still formatted