### PR TITLE
fix: [#1296] wrap parse<T> in async IIFE when value contains await

### DIFF
--- a/crates/floe-core/src/codegen/tests.rs
+++ b/crates/floe-core/src/codegen/tests.rs
@@ -1965,6 +1965,33 @@ fn parse_in_pipe() {
     );
 }
 
+#[test]
+fn parse_with_awaited_value_emits_async_iife() {
+    let result =
+        emit_with_types("let f() -> Promise<unknown> = { fetchData() |> await |> parse<string> }");
+    assert!(
+        result.contains("await (async () => {"),
+        "parse with awaited value must wrap in async IIFE that is awaited, got: {result}"
+    );
+    assert!(
+        result.contains("await fetchData()"),
+        "should still emit the inner await, got: {result}"
+    );
+}
+
+#[test]
+fn parse_without_await_keeps_sync_iife() {
+    let result = emit("x |> parse<string>");
+    assert!(
+        result.contains("(() => {"),
+        "parse without await should stay sync, got: {result}"
+    );
+    assert!(
+        !result.contains("async () =>"),
+        "parse without await must not produce async IIFE, got: {result}"
+    );
+}
+
 // ── Use keyword (callback flattening) ────────────────────────
 
 #[test]

--- a/crates/floe-core/src/codegen/typescript/parse_mock.rs
+++ b/crates/floe-core/src/codegen/typescript/parse_mock.rs
@@ -2,6 +2,7 @@ use crate::parser::ast::*;
 use crate::pretty::{self, Document};
 use crate::type_layout::{ERROR_FIELD, OK_FIELD, TAG_FIELD, VALUE_FIELD};
 
+use super::expression::expr_contains_await;
 use super::generator::{THROW_MOCK_FUNCTION, TypeScriptGenerator};
 
 impl<'a> TypeScriptGenerator<'a> {
@@ -14,13 +15,19 @@ impl<'a> TypeScriptGenerator<'a> {
         let type_doc = self.emit_type_expr(type_arg);
         let type_str = Self::doc_to_string(&type_doc);
 
+        let (open, close) = if expr_contains_await(value) {
+            ("(await (async () => { const __v = ", "; })())")
+        } else {
+            ("(() => { const __v = ", "; })()")
+        };
+
         pretty::concat([
-            pretty::str("(() => { const __v = "),
+            pretty::str(open),
             value_doc,
             pretty::str("; "),
             pretty::str(checks),
             pretty::str(format!(
-                "return {{ {OK_FIELD}: true as const, {VALUE_FIELD}: __v as {type_str} }}; }})()"
+                "return {{ {OK_FIELD}: true as const, {VALUE_FIELD}: __v as {type_str} }}{close}"
             )),
         ])
     }


### PR DESCRIPTION
closes #1296

`emit_parse` always wrapped the value in a synchronous IIFE. When the piped value contained `|> await` (e.g. `c.req.json() |> await |> parse<CreateBody>`), the generated JS had `await` inside a non-async arrow, which esbuild/tsc reject.

Now detect await via the existing `expr_contains_await` helper and emit `(await (async () => { const __v = ...; return ...; })())` in that case. Sync IIFE is retained when no await is present.

## Test plan

- [x] `cargo test -p floe-core` — all 1541 tests pass, including two new cases:
  - `parse_with_awaited_value_emits_async_iife`
  - `parse_without_await_keeps_sync_iife`
- [x] End-to-end check: `floe build` on a minimal `.fl` with `x() |> await |> parse<T>` now produces TS that esbuild accepts
- [x] Existing examples (`examples/todo-app`, `examples/store`) still compile — the `|> Promise.await?` path is untouched
- [x] `cargo clippy -p floe-core --all-targets -- -D warnings` clean