### PR TITLE
fix: [#1300] wrap match IIFE in async when subject contains await

### DIFF
--- a/crates/floe-core/src/codegen/tests.rs
+++ b/crates/floe-core/src/codegen/tests.rs
@@ -984,6 +984,34 @@ fn match_arm_block_iife_returns_last_expr() {
     );
 }
 
+#[test]
+fn match_with_awaited_subject_and_bindings_emits_async_iife() {
+    let result = emit_with_types(
+        "type R = Ok(number) | Err(string)\n\
+         let f() -> Promise<number> = { match fetchResult() |> await { Ok(value) -> value, Err(message) -> 0 } }",
+    );
+    assert!(
+        result.contains("await (async () => {"),
+        "match arms with awaited subject must wrap bindings in async IIFE, got: {result}"
+    );
+}
+
+#[test]
+fn match_without_await_keeps_sync_iife() {
+    let result = emit_with_types(
+        "type R = Ok(number) | Err(string)\n\
+         let f() -> number = { match getResult() { Ok(value) -> value, Err(message) -> 0 } }",
+    );
+    assert!(
+        result.contains("(() => {"),
+        "match without await should stay sync, got: {result}"
+    );
+    assert!(
+        !result.contains("async () =>"),
+        "match without await must not produce async IIFE, got: {result}"
+    );
+}
+
 // ── Implicit Return ──────────────────────────────────────────
 
 #[test]

--- a/crates/floe-core/src/codegen/typescript/match_emit.rs
+++ b/crates/floe-core/src/codegen/typescript/match_emit.rs
@@ -350,7 +350,7 @@ impl<'a> TypeScriptGenerator<'a> {
         let bindings = collect_bindings(&subject_str, pattern, &self.ctx.variant_info);
         let needs_iife = !bindings.is_empty() || matches!(body.kind, ExprKind::Block(_));
         if needs_iife {
-            let has_await = expr_contains_await(body);
+            let has_await = expr_contains_await(subject) || expr_contains_await(body);
             let mut s = String::new();
             if has_await {
                 s.push_str("await (async () => { ");


### PR DESCRIPTION
closes #1300

`emit_match_body` only checked `expr_contains_await(body)` when deciding whether to make an arm IIFE async. But the subject is inlined into the bindings (`const e = await foo().error`), so a sync IIFE would contain `await` when the subject had one.

Extend the check to `expr_contains_await(subject) || expr_contains_await(body)`, mirroring the pattern used by `parse_mock` in #1296.

## Test plan

- [x] `cargo test -p floe-core` — 1555 tests pass, including two new ones:
  - `match_with_awaited_subject_and_bindings_emits_async_iife`
  - `match_without_await_keeps_sync_iife`
- [x] End-to-end: the yeet repro (`match createSnippet(repo, input) |> await { Ok(...) -> ..., Err(...) -> ... }`) now compiles through floe + esbuild
- [x] `cargo clippy -p floe-core --all-targets -- -D warnings` clean