### PR TITLE
fix: [#1303] parenthesize Promise.await template for correct member-access precedence

### DIFF
--- a/crates/floe-core/src/codegen/tests.rs
+++ b/crates/floe-core/src/codegen/tests.rs
@@ -967,6 +967,26 @@ fn nested_fn_with_bare_await_emits_async() {
 }
 
 #[test]
+fn await_before_member_access_is_parenthesized() {
+    let result = emit_with_types(
+        "type R = Ok(number) | Err(string)\n\
+         let f() -> Promise<number> = { match getResult() |> await { Ok(v) -> v, Err(_) -> 0 } }",
+    );
+    assert!(
+        result.contains("(await getResult())"),
+        "`await` feeding member access must parenthesize — JS parses `await X.Y` as `await (X.Y)` — got: {result}"
+    );
+    assert!(
+        !result.contains(" await getResult().tag"),
+        "`await X.tag` must not appear — JS would await the tag of the unawaited Promise, got: {result}"
+    );
+    assert!(
+        !result.contains(" await getResult().value"),
+        "`await X.value` must not appear — JS would await the value of the unawaited Promise, got: {result}"
+    );
+}
+
+#[test]
 fn match_on_comparison_wraps_subject_in_parens() {
     let result = emit("let _x = match 5 > 0 { true -> \"yes\", false -> \"no\" }");
     assert!(

--- a/crates/floe-core/src/stdlib/promise.rs
+++ b/crates/floe-core/src/stdlib/promise.rs
@@ -6,7 +6,7 @@ pub fn register(fns: &mut Vec<StdlibFn>) {
     let u = tv(1);
 
     fns.extend([
-        stdlib_fn!("Promise", "await", [promise_of(t.clone())], t.clone(), "await $0"),
+        stdlib_fn!("Promise", "await", [promise_of(t.clone())], t.clone(), "(await $0)"),
         stdlib_fn!("Promise", "all", [array_of(promise_of(t.clone()))], promise_of(array_of(t.clone())), "Promise.all($0)"),
         stdlib_fn!("Promise", "race", [array_of(promise_of(t.clone()))], promise_of(t.clone()), "Promise.race($0)"),
         stdlib_fn!("Promise", "any", [array_of(promise_of(t.clone()))], promise_of(t.clone()), "Promise.any($0)"),


### PR DESCRIPTION
closes #1303

The \`Promise.await\` stdlib template was \`\"await \$0\"\`, emitting bare \`await X\`. JavaScript parses \`await X.Y\` as \`await (X.Y)\` — awaiting the *unawaited* Promise's \`.Y\` property (\`undefined\`). Concrete impact: \`match fetch() |> await { Ok(v) -> ..., Err(e) -> ... }\` generates conditions like \`await fetch().ok === true\` which is \`undefined === true\` → every arm falls through to \`throw new Error(\"non-exhaustive match\")\` at runtime.

Change the template to \`\"(await \$0)\"\`. Parens are harmless in standalone contexts and correct in every other position.

## Test plan

- [x] New codegen test \`await_before_member_access_is_parenthesized\` asserts \`(await getResult())\` appears and bare \`await X.tag\` / \`await X.value\` do not
- [x] All 1553 existing tests pass (the existing \`bare_await_shorthand_pipe\` / \`promise_await_pipe\` assertions still hold — \`(await fetchData())\` contains the substring \`await fetchData()\`)
- [x] \`cargo clippy -p floe-core --all-targets -- -D warnings\` clean
- [x] End-to-end verified locally against a Floe Cloudflare Worker: \`match getSnippet(repo, code) |> await { Ok(Some(x)) -> ..., Ok(None) -> ..., Err(e) -> ... }\` no longer throws \`non-exhaustive match\` at runtime