### PR TITLE
feat: [#1302] member completion on imported generic types

### DIFF
--- a/crates/floe-core/src/checker/items.rs
+++ b/crates/floe-core/src/checker/items.rs
@@ -649,6 +649,11 @@ impl Checker {
                 self.check_no_redefinition(&param.name, span);
             }
             self.env.define(&param.name, ty.clone());
+            // Persist param type for LSP hover / dot-completion. Function
+            // scopes are popped after body-checking, so the later name_types
+            // scope-merge never reaches them. Matches the equivalent insert
+            // for lambda params in `check_arrow`.
+            self.name_types.insert(param.name.clone(), ty.to_string());
 
             // For destructured params, define the individual field names in scope
             if let Some(ref destructure) = param.destructure {
@@ -924,6 +929,7 @@ impl Checker {
 
             for (param, ty) in func.params.iter().zip(param_types.iter()) {
                 self.env.define(&param.name, ty.clone());
+                self.name_types.insert(param.name.clone(), ty.to_string());
             }
 
             // Type-check default parameter values

--- a/crates/floe-core/src/interop/dts.rs
+++ b/crates/floe-core/src/interop/dts.rs
@@ -41,6 +41,10 @@ pub struct GenericParamInfo {
 /// - `declare namespace X { ... }` blocks (when combined with `export = X`)
 /// - `export = X` re-export patterns
 /// - `export * from "./X"` re-exports (follows relative paths)
+/// - `export { X } from "./y"` / `export type { X as Y } from "./y"`
+///   (recursively resolves the local declaration in `./y` and rebinds it
+///   under the re-exported name, so barrel files like hono's `index.d.ts`
+///   surface the full interface bodies their consumers need)
 /// - Overloaded function declarations (uses first signature)
 pub fn parse_dts_exports(dts_path: &Path) -> Result<Vec<DtsExport>, String> {
     let mut visited = HashSet::new();
@@ -85,11 +89,11 @@ fn parse_dts_exports_recursive(
     // a curation of named re-exports (`export type { Context } from './context'`)
     // expose only the export name to callers, with no field info — breaking
     // boundary wrap, dot-completion, and Foreign field lookup downstream.
-    for (exported_name, local_name, source) in &result.named_reexports {
-        if seen_names.contains(exported_name) {
+    for reexport in &result.named_reexports {
+        if seen_names.contains(&reexport.exported_name) {
             continue;
         }
-        let Some(resolved) = resolve_dts_source(parent_dir, source) else {
+        let Some(resolved) = resolve_dts_source(parent_dir, &reexport.source) else {
             continue;
         };
         // Recurse: `visited` already prevents infinite loops on mutual
@@ -100,12 +104,15 @@ fn parse_dts_exports_recursive(
         let Ok(reexported) = parse_dts_exports_recursive(&resolved, &mut branch_visited) else {
             continue;
         };
-        if let Some(target) = reexported.into_iter().find(|e| &e.name == local_name) {
+        if let Some(target) = reexported
+            .into_iter()
+            .find(|e| e.name == reexport.local_name)
+        {
             exports.push(DtsExport {
-                name: exported_name.clone(),
+                name: reexport.exported_name.clone(),
                 ts_type: target.ts_type,
             });
-            seen_names.insert(exported_name.clone());
+            seen_names.insert(reexport.exported_name.clone());
         }
     }
 
@@ -162,18 +169,23 @@ fn resolve_dts_source(parent_dir: &Path, source: &str) -> Option<PathBuf> {
     None
 }
 
+/// A `export { local as exported } from 'source'` / `export type { X } from './y'`
+/// mapping. The recursive loader pulls `local_name`'s declaration out of
+/// `source` and rebinds it as `exported_name` in the current module, so
+/// hono's `export type { Context } from './context'` makes Context's full
+/// interface body available at the package boundary.
+#[derive(Debug, Clone)]
+struct NamedReexport {
+    exported_name: String,
+    local_name: String,
+    source: String,
+}
+
 /// Internal parse result including re-export sources.
 struct ParseResult {
     exports: Vec<DtsExport>,
     reexport_sources: Vec<String>,
-    /// Named re-exports with a source path — `export { X } from './y'` and
-    /// `export type { X as Y } from './y'`. Each entry is
-    /// `(exported_name, local_name, source)`. The recursive loader pulls
-    /// the local_name's declaration out of `source` and rebinds it as
-    /// `exported_name` in the current module, so hono's
-    /// `export type { Context } from './context'` makes Context's full
-    /// interface body available at the package boundary.
-    named_reexports: Vec<(String, String, String)>,
+    named_reexports: Vec<NamedReexport>,
 }
 
 fn parse_dts_content(content: &str) -> Result<ParseResult, String> {
@@ -196,7 +208,7 @@ fn parse_dts_content(content: &str) -> Result<ParseResult, String> {
     // `export { X as Y }`, and `typeof X` against the declared types.
     let mut local_types: HashMap<String, TsType> = HashMap::new();
     let mut aliased_reexports: Vec<(String, String)> = Vec::new();
-    let mut named_reexports: Vec<(String, String, String)> = Vec::new();
+    let mut named_reexports: Vec<NamedReexport> = Vec::new();
     let mut default_export_target: Option<String> = None;
 
     for stmt in &ret.program.body {
@@ -225,11 +237,11 @@ fn parse_dts_content(content: &str) -> Result<ParseResult, String> {
                         continue;
                     }
                     if let Some(ref src) = source_path {
-                        named_reexports.push((
-                            exported_name.clone(),
-                            local_name.clone(),
-                            src.clone(),
-                        ));
+                        named_reexports.push(NamedReexport {
+                            exported_name: exported_name.clone(),
+                            local_name: local_name.clone(),
+                            source: src.clone(),
+                        });
                     } else if exported_name != local_name {
                         aliased_reexports.push((exported_name, local_name));
                     }

--- a/crates/floe-core/src/interop/dts.rs
+++ b/crates/floe-core/src/interop/dts.rs
@@ -79,6 +79,36 @@ fn parse_dts_exports_recursive(
         }
     }
 
+    // Follow named re-exports: `export type { X } from './y'` pulls X's full
+    // declaration out of ./y.d.ts and binds it (optionally renamed) in the
+    // current module. Without this, packages like hono whose entrypoint is
+    // a curation of named re-exports (`export type { Context } from './context'`)
+    // expose only the export name to callers, with no field info — breaking
+    // boundary wrap, dot-completion, and Foreign field lookup downstream.
+    for (exported_name, local_name, source) in &result.named_reexports {
+        if seen_names.contains(exported_name) {
+            continue;
+        }
+        let Some(resolved) = resolve_dts_source(parent_dir, source) else {
+            continue;
+        };
+        // Recurse: `visited` already prevents infinite loops on mutual
+        // re-exports. We clone it for each branch so one branch's visit
+        // doesn't hide a target for another branch that hasn't walked
+        // that file yet.
+        let mut branch_visited = visited.clone();
+        let Ok(reexported) = parse_dts_exports_recursive(&resolved, &mut branch_visited) else {
+            continue;
+        };
+        if let Some(target) = reexported.into_iter().find(|e| &e.name == local_name) {
+            exports.push(DtsExport {
+                name: exported_name.clone(),
+                ts_type: target.ts_type,
+            });
+            seen_names.insert(exported_name.clone());
+        }
+    }
+
     Ok(exports)
 }
 
@@ -136,6 +166,14 @@ fn resolve_dts_source(parent_dir: &Path, source: &str) -> Option<PathBuf> {
 struct ParseResult {
     exports: Vec<DtsExport>,
     reexport_sources: Vec<String>,
+    /// Named re-exports with a source path — `export { X } from './y'` and
+    /// `export type { X as Y } from './y'`. Each entry is
+    /// `(exported_name, local_name, source)`. The recursive loader pulls
+    /// the local_name's declaration out of `source` and rebinds it as
+    /// `exported_name` in the current module, so hono's
+    /// `export type { Context } from './context'` makes Context's full
+    /// interface body available at the package boundary.
+    named_reexports: Vec<(String, String, String)>,
 }
 
 fn parse_dts_content(content: &str) -> Result<ParseResult, String> {
@@ -158,6 +196,7 @@ fn parse_dts_content(content: &str) -> Result<ParseResult, String> {
     // `export { X as Y }`, and `typeof X` against the declared types.
     let mut local_types: HashMap<String, TsType> = HashMap::new();
     let mut aliased_reexports: Vec<(String, String)> = Vec::new();
+    let mut named_reexports: Vec<(String, String, String)> = Vec::new();
     let mut default_export_target: Option<String> = None;
 
     for stmt in &ret.program.body {
@@ -174,16 +213,24 @@ fn parse_dts_content(content: &str) -> Result<ParseResult, String> {
                 record_local_type(decl, &mut local_types);
             }
 
-            // `export { X as Y }` without a declaration — collected here,
-            // resolved against local_types once the full file is scanned.
+            // `export { X as Y }` / `export type { Context } from './ctx'` —
+            // collected here, resolved against local_types (same file) or
+            // recursively from the source path (cross-file).
             if export_decl.declaration.is_none() {
+                let source_path = export_decl.source.as_ref().map(|s| s.value.to_string());
                 for spec in &export_decl.specifiers {
                     let exported_name = spec.exported.name().to_string();
                     let local_name = spec.local.name().to_string();
-                    if !exported_name.is_empty()
-                        && !local_name.is_empty()
-                        && exported_name != local_name
-                    {
+                    if exported_name.is_empty() || local_name.is_empty() {
+                        continue;
+                    }
+                    if let Some(ref src) = source_path {
+                        named_reexports.push((
+                            exported_name.clone(),
+                            local_name.clone(),
+                            src.clone(),
+                        ));
+                    } else if exported_name != local_name {
                         aliased_reexports.push((exported_name, local_name));
                     }
                 }
@@ -358,6 +405,7 @@ fn parse_dts_content(content: &str) -> Result<ParseResult, String> {
     Ok(ParseResult {
         exports,
         reexport_sources,
+        named_reexports,
     })
 }
 

--- a/crates/floe-core/src/interop/tests.rs
+++ b/crates/floe-core/src/interop/tests.rs
@@ -1166,3 +1166,53 @@ fn wrap_indexed_access_concrete_returns_field_type() {
     };
     assert_eq!(wrap_boundary_type(&ty), Type::String);
 }
+
+#[test]
+fn named_reexport_pulls_in_full_interface_body() {
+    // Regression for #1302. Packages like hono expose their entry point
+    // as a curation of named re-exports:
+    //     export type { Context } from './context'
+    // The parser must follow the `from './context'` into the target file
+    // and attach Context's full interface body under the re-exported
+    // name. Without this, dts_cache["hono"]["Context"] is absent (or a
+    // bare Named alias) and downstream stages — dot-completion,
+    // __field_Context_* entries, boundary field lookup — all come up
+    // empty.
+    use super::dts::parse_dts_exports;
+    use tempfile::TempDir;
+
+    let dir = TempDir::new().unwrap();
+    std::fs::write(
+        dir.path().join("context.d.ts"),
+        r#"
+export interface Context {
+    env: unknown;
+    json(body: unknown): Response;
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("index.d.ts"),
+        r#"
+export type { Context } from './context';
+"#,
+    )
+    .unwrap();
+
+    let exports = parse_dts_exports(&dir.path().join("index.d.ts")).expect("parse");
+    let context = exports
+        .iter()
+        .find(|e| e.name == "Context")
+        .expect("Context should be re-exported with its body");
+    match &context.ts_type {
+        TsType::Object(fields) => {
+            let names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
+            assert!(
+                names.contains(&"env") && names.contains(&"json"),
+                "expected Context fields env + json, got {names:?}"
+            );
+        }
+        other => panic!("expected TsType::Object for re-exported Context, got {other:?}"),
+    }
+}

--- a/crates/floe-lsp/src/completion.rs
+++ b/crates/floe-lsp/src/completion.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use tower_lsp::lsp_types::*;
 
 use floe_core::checker::Type;
+use floe_core::interop::{DtsExport, TsType, ts_type_to_string};
 
 use super::index::SymbolIndex;
 
@@ -239,6 +240,7 @@ pub(super) fn dot_access_completions(
     prefix: &str,
     type_map: &HashMap<String, String>,
     index: &SymbolIndex,
+    dts_imports: &HashMap<String, Vec<DtsExport>>,
 ) -> Vec<CompletionItem> {
     let mut items = Vec::new();
 
@@ -303,6 +305,50 @@ pub(super) fn dot_access_completions(
                         ..Default::default()
                     });
                 }
+            }
+        }
+    }
+
+    // Strategy 4: imported type from a .d.ts module (e.g. `Context<...>` from
+    // Hono). The obj_type's base name is looked up across every cached dts
+    // import; if one exports an interface/type-alias whose resolved shape is
+    // an `Object`, enumerate its fields. Lets `c.` pop up `env`, `req`, `res`,
+    // `json`, ... on a parameter typed as an imported generic.
+    if items.is_empty() {
+        let base = base_type_name(obj_type);
+        for exports in dts_imports.values() {
+            let Some(export) = exports.iter().find(|e| e.name == base) else {
+                continue;
+            };
+            let TsType::Object(fields) = &export.ts_type else {
+                continue;
+            };
+            for field in fields {
+                if !prefix.is_empty() && !field.name.starts_with(prefix) {
+                    continue;
+                }
+                if items.iter().any(|i: &CompletionItem| i.label == field.name) {
+                    continue;
+                }
+                let rendered = ts_type_to_string(&field.ty);
+                let kind = if matches!(&field.ty, TsType::Function { .. }) {
+                    CompletionItemKind::METHOD
+                } else {
+                    CompletionItemKind::PROPERTY
+                };
+                items.push(CompletionItem {
+                    label: field.name.clone(),
+                    kind: Some(kind),
+                    detail: Some(format!("(property) {}: {}", field.name, rendered)),
+                    insert_text: Some(field.name.clone()),
+                    insert_text_format: Some(InsertTextFormat::PLAIN_TEXT),
+                    ..Default::default()
+                });
+            }
+            // First matching module wins — prevents duplicate items when the
+            // same name is re-exported across related packages.
+            if !items.is_empty() {
+                break;
             }
         }
     }

--- a/crates/floe-lsp/src/completions.rs
+++ b/crates/floe-lsp/src/completions.rs
@@ -63,7 +63,9 @@ impl FloeLsp {
         if let Some(obj_name) = identifier_before_dot(&doc.content, offset)
             && !registry.is_module(obj_name)
         {
-            let items = dot_access_completions(obj_name, &prefix, &doc.type_map, &doc.index);
+            let dts_cache = self.dts_cache.read().await;
+            let items =
+                dot_access_completions(obj_name, &prefix, &doc.type_map, &doc.index, &dts_cache);
             // Always return here — never fall through to global completions in dot context.
             // If we can't resolve fields, returning empty is better than dumping every symbol.
             return Ok(Some(CompletionResponse::Array(items)));

--- a/crates/floe-lsp/src/tests.rs
+++ b/crates/floe-lsp/src/tests.rs
@@ -1081,7 +1081,8 @@ type User = { name: string, age: number }
 let u = User(name: "a", age: 1)
 "#;
     let (index, type_map) = build_index_and_types(source);
-    let items = dot_access_completions("u", "", &type_map, &index);
+    let dts = HashMap::new();
+    let items = dot_access_completions("u", "", &type_map, &index, &dts);
     let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
     assert!(
         labels.contains(&"name"),
@@ -1091,6 +1092,68 @@ let u = User(name: "a", age: 1)
         labels.contains(&"age"),
         "should suggest 'age', got: {labels:?}"
     );
+}
+
+#[test]
+fn dot_access_completions_for_imported_generic_type() {
+    // Regression for #1302. When a parameter is typed as an imported
+    // generic (e.g. `c: Context<{ Bindings: B }>` from Hono), typing `c.`
+    // should suggest Context's declared fields. Previously typing nothing
+    // came back because `Context<...>` isn't a Floe record and none of
+    // Strategies 1–3 could enumerate its shape.
+    use floe_core::interop::{DtsExport, ObjectField, TsType};
+
+    // Simulate an imported `Context` with the Hono-shaped fields.
+    let context_export = DtsExport {
+        name: "Context".to_string(),
+        ts_type: TsType::Object(vec![
+            ObjectField {
+                name: "env".to_string(),
+                ty: TsType::Any,
+                optional: false,
+            },
+            ObjectField {
+                name: "req".to_string(),
+                ty: TsType::Any,
+                optional: false,
+            },
+            ObjectField {
+                name: "json".to_string(),
+                ty: TsType::Function {
+                    params: vec![],
+                    return_type: Box::new(TsType::Any),
+                },
+                optional: false,
+            },
+        ]),
+    };
+    let mut dts = HashMap::new();
+    dts.insert("hono".to_string(), vec![context_export]);
+
+    let mut type_map = HashMap::new();
+    type_map.insert(
+        "c".to_string(),
+        "Context<{ Bindings: Bindings }>".to_string(),
+    );
+    let index = SymbolIndex::default();
+
+    let items = dot_access_completions("c", "", &type_map, &index, &dts);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+    assert!(
+        labels.contains(&"env"),
+        "should suggest 'env', got: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"req"),
+        "should suggest 'req', got: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"json"),
+        "should suggest 'json', got: {labels:?}"
+    );
+    // Function fields render as METHOD, plain fields as PROPERTY.
+    let json_item = items.iter().find(|i| i.label == "json").unwrap();
+    assert_eq!(json_item.kind, Some(CompletionItemKind::METHOD));
 }
 
 // ── Formatting range helper ──────────────────────────────────────


### PR DESCRIPTION
closes #1302

## Summary

Typing \`c.\` on a parameter typed as an imported generic (e.g. \`c: Context<{ Bindings: Bindings }>\` from Hono) now pops up the imported type's fields — \`env\`, \`req\`, \`res\`, \`json\`, … — in completion. Previously there were **zero** items for imported types.

## Fix

\`dot_access_completions\` gains a fourth strategy (after Floe records, \`__field_*\` entries, and inline record literals): look up the object's base type name across cached \`dts_imports\`. When an exported interface resolves to \`TsType::Object\`, enumerate its fields as completion items. Function-shaped fields render as \`METHOD\`, the rest as \`PROPERTY\`.

Threaded \`dts_cache\` down through \`handle_completion\` → \`dot_access_completions\` so the full import registry is available during completion.

## Test plan

- [x] New \`dot_access_completions_for_imported_generic_type\` verifies \`env\`, \`req\`, \`json\` appear and that \`json\` (function-shaped) is tagged as \`METHOD\`.
- [x] Existing \`dot_access_completions_for_record_type\` still passes with the new \`dts_imports\` param.
- [x] Full LSP unit suite: 105 passed.
- [x] Full Python LSP integration suite: 260 passed.
- [x] \`cargo test --workspace\`: all crates green (1556 core tests).
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`: clean.
- [x] Example apps: fmt + check + build on both \`examples/todo-app\` and \`examples/store\` succeed.

## Follow-ups

- Per-instantiation field narrowing (resolve \`c.env\` to the user's \`Bindings\` keys, not just \`any\`) — tracked separately; requires wiring the chain-probe results in addition to the declared interface fields.
- Method completion with overload-resolved signatures — same direction; today's display uses \`ts_type_to_string\` which gives the declared type, not the overload picked at call-site.