### PR TITLE
fix: [#1305] codegen: cross-file trait dispatch and __make factory

### DIFF
--- a/crates/floe-core/src/codegen.rs
+++ b/crates/floe-core/src/codegen.rs
@@ -27,6 +27,16 @@ pub fn for_block_fn_name<T>(type_expr: &TypeExpr<T>, fn_name: &str) -> String {
     format!("{type_prefix}__{fn_name}")
 }
 
+/// Base type name of a for-block (`for User: Display { ... }` -> `Some("User")`).
+/// Returns `None` for structural type expressions that can't be targeted
+/// by a nominal `T__make` factory (e.g. arrays, tuples).
+pub(crate) fn for_block_base_type_name<T>(type_expr: &TypeExpr<T>) -> Option<&str> {
+    match &type_expr.kind {
+        TypeExprKind::Named { name, .. } => Some(name),
+        _ => None,
+    }
+}
+
 /// Mangle a type expression into a valid identifier fragment.
 fn mangle_type_name<T>(type_expr: &TypeExpr<T>) -> String {
     match &type_expr.kind {

--- a/crates/floe-core/src/codegen/typescript/generator.rs
+++ b/crates/floe-core/src/codegen/typescript/generator.rs
@@ -8,7 +8,7 @@ use crate::type_layout;
 
 use super::super::{
     CodegenOutput, DEEP_EQUAL_FN, collect_constructor_names, collect_value_used_names,
-    for_block_fn_name,
+    for_block_base_type_name, for_block_fn_name,
 };
 
 // ── Runtime codegen constants ───────────────────────────────────
@@ -131,10 +131,10 @@ impl TypeContext {
                         for block in &resolved.for_blocks {
                             ctx.register_for_block_fns(block);
                             if let Some(trait_name) = &block.trait_name
-                                && let TypeExprKind::Named { name, .. } = &block.type_name.kind
+                                && let Some(name) = for_block_base_type_name(&block.type_name)
                             {
                                 ctx.type_trait_impls
-                                    .entry(name.clone())
+                                    .entry(name.to_string())
                                     .or_default()
                                     .push(trait_name.clone());
                             }
@@ -151,14 +151,14 @@ impl TypeContext {
                         ctx.local_names.insert(func.name.clone());
                     }
                     if let Some(trait_name) = &block.trait_name
-                        && let TypeExprKind::Named { name, .. } = &block.type_name.kind
+                        && let Some(name) = for_block_base_type_name(&block.type_name)
                     {
                         ctx.type_trait_impls
-                            .entry(name.clone())
+                            .entry(name.to_string())
                             .or_default()
                             .push(trait_name.clone());
                         ctx.trait_impl_blocks
-                            .entry(name.clone())
+                            .entry(name.to_string())
                             .or_default()
                             .push(block.clone());
                     }
@@ -196,9 +196,8 @@ impl TypeContext {
     }
 
     pub(super) fn register_for_block_fns<T>(&mut self, block: &ForBlock<T>) {
-        let type_name = match &block.type_name.kind {
-            TypeExprKind::Named { name, .. } => name.clone(),
-            _ => return,
+        let Some(type_name) = for_block_base_type_name(&block.type_name).map(str::to_string) else {
+            return;
         };
         self.for_block_type_names.insert(type_name.clone());
         for func in &block.functions {

--- a/crates/floe-core/src/codegen/typescript/generator.rs
+++ b/crates/floe-core/src/codegen/typescript/generator.rs
@@ -54,6 +54,11 @@ pub(crate) struct TypeContext {
     pub trait_decls: HashMap<String, TypedTraitDecl>,
     pub type_trait_impls: HashMap<String, Vec<String>>,
     pub traits_needing_interface: HashSet<String>,
+    /// All local `for T: Trait { ... }` blocks grouped by the implementing
+    /// type name. Used to emit a single `T__make` factory per type that
+    /// wires up every trait method, rather than one factory per for-block
+    /// (which would collide when a type has multiple trait impls).
+    pub trait_impl_blocks: HashMap<String, Vec<TypedForBlock>>,
 }
 
 impl TypeContext {
@@ -80,6 +85,7 @@ impl TypeContext {
             trait_decls: HashMap::new(),
             type_trait_impls: HashMap::new(),
             traits_needing_interface: HashSet::new(),
+            trait_impl_blocks: HashMap::new(),
         };
 
         // Pre-register union variant info and type defs from imported types.
@@ -124,6 +130,18 @@ impl TypeContext {
                     if let Some(resolved) = ctx.resolved_imports.get(&decl.source).cloned() {
                         for block in &resolved.for_blocks {
                             ctx.register_for_block_fns(block);
+                            if let Some(trait_name) = &block.trait_name
+                                && let TypeExprKind::Named { name, .. } = &block.type_name.kind
+                            {
+                                ctx.type_trait_impls
+                                    .entry(name.clone())
+                                    .or_default()
+                                    .push(trait_name.clone());
+                            }
+                        }
+                        for decl in &resolved.trait_decls {
+                            let typed = crate::checker::attach_trait_decl_shallow(decl);
+                            ctx.trait_decls.entry(typed.name.clone()).or_insert(typed);
                         }
                     }
                 }
@@ -139,6 +157,10 @@ impl TypeContext {
                             .entry(name.clone())
                             .or_default()
                             .push(trait_name.clone());
+                        ctx.trait_impl_blocks
+                            .entry(name.clone())
+                            .or_default()
+                            .push(block.clone());
                     }
                 }
                 ItemKind::TraitDecl(decl) => {
@@ -222,6 +244,9 @@ pub(crate) struct TypeScriptGenerator<'a> {
     pub(super) needs_deep_equal: bool,
     pub(super) has_jsx: bool,
     pub(super) unwrap_counter: usize,
+    /// Types whose `{T}__make` factory has already been emitted, so
+    /// subsequent trait-impl for-blocks for the same type don't re-emit it.
+    pub(super) emitted_factories: HashSet<String>,
 }
 
 impl<'a> TypeScriptGenerator<'a> {
@@ -233,6 +258,7 @@ impl<'a> TypeScriptGenerator<'a> {
             needs_deep_equal: false,
             has_jsx: false,
             unwrap_counter: 0,
+            emitted_factories: HashSet::new(),
         }
     }
 

--- a/crates/floe-core/src/codegen/typescript/statement.rs
+++ b/crates/floe-core/src/codegen/typescript/statement.rs
@@ -142,6 +142,13 @@ impl<'a> TypeScriptGenerator<'a> {
             first = false;
             s.push_str(name);
         }
+        for factory_name in self.resolve_factory_import_names(decl) {
+            if !first {
+                s.push_str(", ");
+            }
+            first = false;
+            s.push_str(&factory_name);
+        }
         s.push_str(&format!(" }} from \"{}\";", decl.source));
         pretty::str(s)
     }
@@ -431,32 +438,26 @@ impl<'a> TypeScriptGenerator<'a> {
             }
             docs.push(self.emit_for_block_function(func, &block.type_name));
         }
-        if let Some(trait_name) = &block.trait_name
-            && self
-                .ctx
-                .traits_needing_interface
-                .contains(trait_name.as_str())
+        if block.trait_name.is_some()
+            && let TypeExprKind::Named { name, .. } = &block.type_name.kind
+            && !self.emitted_factories.contains(name)
         {
+            self.emitted_factories.insert(name.clone());
             docs.push(pretty::str("\n"));
-            docs.push(self.emit_trait_impl_factory(block));
+            docs.push(self.emit_trait_impl_factory(name, &block.type_name));
         }
         pretty::concat(docs)
     }
 
-    fn emit_trait_impl_factory(&mut self, block: &TypedForBlock) -> Document {
-        let type_name = match &block.type_name.kind {
-            TypeExprKind::Named { name, .. } => name.clone(),
-            _ => return pretty::nil(),
-        };
-
+    fn emit_trait_impl_factory(&mut self, type_name: &str, type_expr: &TypedTypeExpr) -> Document {
         let factory_name = format!("{type_name}__make");
         let mut docs = vec![
-            pretty::str("function "),
+            pretty::str("export function "),
             pretty::str(&factory_name),
             pretty::str("(__data: "),
-            self.emit_type_expr(&block.type_name),
+            self.emit_type_expr(type_expr),
             pretty::str("): "),
-            self.emit_type_expr(&block.type_name),
+            self.emit_type_expr(type_expr),
             pretty::str(" {"),
         ];
 
@@ -466,38 +467,44 @@ impl<'a> TypeScriptGenerator<'a> {
         return_inner.push(pretty::line());
         return_inner.push(pretty::str("...__data,"));
 
-        for func in &block.functions {
-            let non_self_params: Vec<&TypedParam> =
-                func.params.iter().filter(|p| p.name != "self").collect();
-            let mangled = for_block_fn_name(&block.type_name, &func.name);
+        let Some(blocks) = self.ctx.trait_impl_blocks.get(type_name).cloned() else {
+            return pretty::nil();
+        };
+        for block in &blocks {
+            for func in &block.functions {
+                let non_self_params: Vec<&TypedParam> =
+                    func.params.iter().filter(|p| p.name != "self").collect();
+                let mangled = for_block_fn_name(&block.type_name, &func.name);
 
-            return_inner.push(pretty::line());
-            let mut param_parts = Vec::new();
-            for (i, param) in non_self_params.iter().enumerate() {
-                if i > 0 {
-                    param_parts.push(", ".to_string());
+                return_inner.push(pretty::line());
+                let mut param_parts = Vec::new();
+                for (i, param) in non_self_params.iter().enumerate() {
+                    if i > 0 {
+                        param_parts.push(", ".to_string());
+                    }
+                    let mut p = param.name.clone();
+                    if let Some(ta) = &param.type_ann {
+                        p.push_str(": ");
+                        let type_doc = self.emit_type_expr(ta);
+                        p.push_str(&Self::doc_to_string(&type_doc));
+                    }
+                    param_parts.push(p);
                 }
-                let mut p = param.name.clone();
-                if let Some(ta) = &param.type_ann {
-                    p.push_str(": ");
-                    let type_doc = self.emit_type_expr(ta);
-                    p.push_str(&Self::doc_to_string(&type_doc));
-                }
-                param_parts.push(p);
+                let params_str = param_parts.join("");
+
+                let call_args: Vec<String> =
+                    non_self_params.iter().map(|p| p.name.clone()).collect();
+                let call_args_str = if call_args.is_empty() {
+                    String::new()
+                } else {
+                    format!(", {}", call_args.join(", "))
+                };
+
+                return_inner.push(pretty::str(format!(
+                    "{}: ({params_str}) => {mangled}(__data{call_args_str}),",
+                    func.name
+                )));
             }
-            let params_str = param_parts.join("");
-
-            let call_args: Vec<String> = non_self_params.iter().map(|p| p.name.clone()).collect();
-            let call_args_str = if call_args.is_empty() {
-                String::new()
-            } else {
-                format!(", {}", call_args.join(", "))
-            };
-
-            return_inner.push(pretty::str(format!(
-                "{}: ({params_str}) => {mangled}(__data{call_args_str}),",
-                func.name
-            )));
         }
 
         inner.push(pretty::nest(2, pretty::concat(return_inner)));
@@ -853,6 +860,31 @@ impl<'a> TypeScriptGenerator<'a> {
                         }
                     }
                 }
+            }
+        }
+        names
+    }
+
+    /// Factory `__make` functions for imported types that have a trait impl.
+    /// The factory lives in the impl module and wraps the data with bound
+    /// methods; consumers need it in scope when they construct the type
+    /// (via `T(field: value)` syntax) so the returned object carries the
+    /// trait methods.
+    pub(super) fn resolve_factory_import_names(&self, decl: &ImportDecl) -> Vec<String> {
+        let Some(resolved) = self.ctx.resolved_imports.get(&decl.source) else {
+            return Vec::new();
+        };
+        let mut names = Vec::new();
+        for spec in &decl.specifiers {
+            let has_trait_impl = resolved.for_blocks.iter().any(|block| {
+                block.trait_name.is_some()
+                    && matches!(
+                        &block.type_name.kind,
+                        TypeExprKind::Named { name, .. } if name == &spec.name
+                    )
+            });
+            if has_trait_impl {
+                names.push(format!("{}__make", spec.name));
             }
         }
         names

--- a/crates/floe-core/src/codegen/typescript/statement.rs
+++ b/crates/floe-core/src/codegen/typescript/statement.rs
@@ -3,7 +3,7 @@ use crate::pretty::{self, Document};
 use crate::type_layout;
 use crate::type_layout::TAG_FIELD;
 
-use super::super::{escape_string, for_block_fn_name};
+use super::super::{escape_string, for_block_base_type_name, for_block_fn_name};
 use super::generator::TypeScriptGenerator;
 
 impl<'a> TypeScriptGenerator<'a> {
@@ -439,10 +439,10 @@ impl<'a> TypeScriptGenerator<'a> {
             docs.push(self.emit_for_block_function(func, &block.type_name));
         }
         if block.trait_name.is_some()
-            && let TypeExprKind::Named { name, .. } = &block.type_name.kind
+            && let Some(name) = for_block_base_type_name(&block.type_name)
             && !self.emitted_factories.contains(name)
         {
-            self.emitted_factories.insert(name.clone());
+            self.emitted_factories.insert(name.to_string());
             docs.push(pretty::str("\n"));
             docs.push(self.emit_trait_impl_factory(name, &block.type_name));
         }
@@ -450,6 +450,17 @@ impl<'a> TypeScriptGenerator<'a> {
     }
 
     fn emit_trait_impl_factory(&mut self, type_name: &str, type_expr: &TypedTypeExpr) -> Document {
+        // Invariant: the caller only invokes this for type names that were
+        // registered in `ctx.trait_impl_blocks` during context construction.
+        let blocks = self
+            .ctx
+            .trait_impl_blocks
+            .get(type_name)
+            .cloned()
+            .unwrap_or_else(|| {
+                panic!("emit_trait_impl_factory called for unregistered type {type_name}")
+            });
+
         let factory_name = format!("{type_name}__make");
         let mut docs = vec![
             pretty::str("export function "),
@@ -467,9 +478,6 @@ impl<'a> TypeScriptGenerator<'a> {
         return_inner.push(pretty::line());
         return_inner.push(pretty::str("...__data,"));
 
-        let Some(blocks) = self.ctx.trait_impl_blocks.get(type_name).cloned() else {
-            return pretty::nil();
-        };
         for block in &blocks {
             for func in &block.functions {
                 let non_self_params: Vec<&TypedParam> =
@@ -878,10 +886,7 @@ impl<'a> TypeScriptGenerator<'a> {
         for spec in &decl.specifiers {
             let has_trait_impl = resolved.for_blocks.iter().any(|block| {
                 block.trait_name.is_some()
-                    && matches!(
-                        &block.type_name.kind,
-                        TypeExprKind::Named { name, .. } if name == &spec.name
-                    )
+                    && for_block_base_type_name(&block.type_name) == Some(spec.name.as_str())
             });
             if has_trait_impl {
                 names.push(format!("{}__make", spec.name));

--- a/crates/floe-core/tests/snapshot_codegen.rs
+++ b/crates/floe-core/tests/snapshot_codegen.rs
@@ -7,6 +7,8 @@ use floe_core::checker::{self, Checker};
 use floe_core::codegen::Codegen;
 use floe_core::desugar;
 use floe_core::parser::Parser;
+use floe_core::resolve::{ResolvedImports, TsconfigPaths};
+use std::collections::HashMap;
 
 fn compile(source: &str) -> String {
     let mut program = Parser::new(source)
@@ -16,6 +18,31 @@ fn compile(source: &str) -> String {
     desugar::desugar_program(&mut program, &std::collections::HashMap::new());
     let typed = checker::attach_types(program, &expr_types, &std::collections::HashSet::new());
     Codegen::new().generate(&typed).code
+}
+
+/// Compile `consumer` in a temp directory that also contains the named
+/// sibling `.fl` files (for cross-file `import { ... } from "./name"`).
+/// Returns the consumer's TypeScript output.
+fn compile_cross_file(consumer: &str, siblings: &[(&str, &str)]) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    for (name, source) in siblings {
+        std::fs::write(root.join(format!("{name}.fl")), source).expect("write sibling");
+    }
+    let consumer_path = root.join("use.fl");
+    std::fs::write(&consumer_path, consumer).expect("write consumer");
+
+    let mut program = Parser::new(consumer)
+        .parse_program()
+        .expect("consumer should parse");
+    let tsconfig = TsconfigPaths::default();
+    let resolved: HashMap<String, ResolvedImports> =
+        floe_core::resolve::resolve_imports(&consumer_path, &program, &tsconfig);
+
+    let (_, expr_types, _) = Checker::with_imports(resolved.clone()).check_full(&program);
+    desugar::desugar_program(&mut program, &std::collections::HashMap::new());
+    let typed = checker::attach_types(program, &expr_types, &std::collections::HashSet::new());
+    Codegen::with_imports(&resolved).generate(&typed).code
 }
 
 fn compile_fixture(name: &str) -> String {
@@ -160,6 +187,49 @@ fn snapshot_trusted_import() {
 #[test]
 fn snapshot_traits() {
     let output = compile_fixture("traits");
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn snapshot_trait_constrained_generics_cross_file() {
+    let output = compile_cross_file(
+        r#"
+import { for Repo } from "./repo"
+import { DrizzleRepo } from "./impl"
+
+let doWork<R: Repo>(repo: R, id: number) -> string = {
+    repo |> findById(id)
+}
+
+export let run() -> string = {
+    let repo = DrizzleRepo(db: "x")
+    doWork(repo, 1)
+}
+"#,
+        &[
+            (
+                "repo",
+                r#"
+export trait Repo {
+    let findById(self, id: number) -> string
+}
+"#,
+            ),
+            (
+                "impl",
+                r#"
+import { for Repo } from "./repo"
+export type DrizzleRepo = { db: string }
+
+for DrizzleRepo: Repo {
+    export let findById(self, id: number) -> string = {
+        "found"
+    }
+}
+"#,
+            ),
+        ],
+    );
     insta::assert_snapshot!(output);
 }
 

--- a/crates/floe-core/tests/snapshots/snapshot_codegen__snapshot_trait_constrained_generics.snap
+++ b/crates/floe-core/tests/snapshots/snapshot_codegen__snapshot_trait_constrained_generics.snap
@@ -16,7 +16,7 @@ export function DrizzleRepo__create(self: DrizzleRepo, input: string): string {
 export function DrizzleRepo__findById(self: DrizzleRepo, id: number): string {
   return "found";
 }
-function DrizzleRepo__make(__data: DrizzleRepo): DrizzleRepo {
+export function DrizzleRepo__make(__data: DrizzleRepo): DrizzleRepo {
   return {
     ...__data,
     create: (input: string) => DrizzleRepo__create(__data, input),

--- a/crates/floe-core/tests/snapshots/snapshot_codegen__snapshot_trait_constrained_generics_cross_file.snap
+++ b/crates/floe-core/tests/snapshots/snapshot_codegen__snapshot_trait_constrained_generics_cross_file.snap
@@ -1,0 +1,20 @@
+---
+source: crates/floe-core/tests/snapshot_codegen.rs
+assertion_line: 233
+expression: output
+---
+interface Repo {
+  findById(id: number): string;
+}
+import {  } from "./repo";
+
+import { type DrizzleRepo, DrizzleRepo__make } from "./impl";
+
+function doWork<R extends Repo>(repo: R, id: number): string {
+  return repo.findById(id);
+}
+
+export function run(): string {
+  const repo = DrizzleRepo__make({ db: "x" });
+  return doWork(repo, 1);
+}

--- a/crates/floe-core/tests/snapshots/snapshot_codegen__snapshot_traits.snap
+++ b/crates/floe-core/tests/snapshots/snapshot_codegen__snapshot_traits.snap
@@ -21,6 +21,13 @@ type User = { name: string; age: number };
 function User__display(self: User): string {
   return `${self.name} (${self.age})`;
 }
+export function User__make(__data: User): User {
+  return {
+    ...__data,
+    display: () => User__display(__data),
+    eq: (other: string) => User__eq(__data, other),
+  };
+}
 
 function User__eq(self: User, other: string): boolean {
   return __floeEq(self.name, other);


### PR DESCRIPTION
closes #1305

A generic function constrained by a trait (`fn doWork<R: Repo>(...)`) whose trait lives in one file, whose impl lives in a second file, and whose consumer is in a third could never dispatch at runtime. Three separate gaps in codegen:

1. **`{Type}__make` factory was never exported.** Consumers that imported the type couldn't call `Type__make(...)`, so constructor syntax `DrizzleRepo(db: "x")` silently lowered to a plain `{ db: "x" }` with no bound methods.
2. **The consumer didn't know an imported type had trait impls.** `type_trait_impls` and `trait_decls` were only populated from local items, so the constructor path skipped `__make` and trait-bounded pipe dispatch (`repo |> findByCode(code)`) fell back to a bare `findByCode(repo, code)` instead of `repo.findByCode(code)`.
3. **`__make` was emitted per for-block.** A type with multiple trait impls (`for User: Display`, `for User: Eq`) produced two colliding `User__make` definitions.

Fix:
- Registering imported trait decls (via `attach_trait_decl_shallow`) and imported `for T: Trait` blocks into the codegen context on any `ItemKind::Import`.
- Adding `{Type}__make` to the emitted import list when the spec matches an imported type with a trait impl (`resolve_factory_import_names`).
- Emitting `__make` once per type, combining methods from every `for T: *` block (`trait_impl_blocks` grouping in `TypeContext`, `emitted_factories` guard on the generator).
- Always `export` the factory.

## Test plan

- [x] New `snapshot_trait_constrained_generics_cross_file` — three files, consumer calls generic `doWork<R: Repo>`; output shows `interface Repo`, `import { type DrizzleRepo, DrizzleRepo__make }`, `repo.findById(id)`, and `DrizzleRepo__make({ db: "x" })`.
- [x] Existing `snapshot_trait_constrained_generics` and `snapshot_traits` updated — factory is now exported, and only one factory is emitted for a type with two trait impls (methods combined).
- [x] Full `cargo test -p floe-core`: 1556 unit + 34 snapshot tests pass.
- [x] `cargo clippy -p floe-core --all-targets -- -D warnings` clean.
- [x] End-to-end against a real Floe Cloudflare Worker with domain/application/infrastructure split: `getSnippet → repo.findByCode → DrizzleSnippetRepository__findByCode → Drizzle` now dispatches correctly at runtime. (Previous behaviour: `ReferenceError: findByCode is not defined`.)