### PR TITLE
fix: [#1310] type-check record-spread source fields against target fields

### DIFF
--- a/crates/floe-core/src/checker/expr.rs
+++ b/crates/floe-core/src/checker/expr.rs
@@ -1636,6 +1636,22 @@ impl Checker {
             }
         }
 
+        // Build field type map for type checking arguments and spread fields.
+        let field_type_map: Option<Vec<(String, Type)>> = if let Some(ref info) = type_info {
+            match &info.def {
+                TypeDef::Record(entries) => Some(
+                    entries
+                        .iter()
+                        .filter_map(|e| e.as_field())
+                        .map(|f| (f.name.clone(), self.resolve_type(&f.type_ann)))
+                        .collect(),
+                ),
+                _ => None,
+            }
+        } else {
+            None
+        };
+
         if let Some(spread_expr) = spread {
             let spread_type = self.check_expr(spread_expr);
 
@@ -1668,6 +1684,13 @@ impl Checker {
             if let Type::Record(spread_fields) = &spread_type {
                 let spread_keys: Vec<&str> =
                     spread_fields.iter().map(|(k, _)| k.as_str()).collect();
+                let explicit_labels: Vec<&str> = args
+                    .iter()
+                    .filter_map(|a| match a {
+                        Arg::Named { label, .. } => Some(label.as_str()),
+                        _ => None,
+                    })
+                    .collect();
                 for arg in args.iter() {
                     if let Arg::Named { label, .. } = arg
                         && spread_keys.contains(&label.as_str())
@@ -1682,33 +1705,18 @@ impl Checker {
                     }
                 }
 
-                // Type-check each spread source field against the target's
-                // field of the same name. Spread fields overwritten by an
-                // explicit arg are skipped — the explicit arg is checked
-                // below with its own span.
-                let explicit_labels: Vec<&str> = args
-                    .iter()
-                    .filter_map(|a| match a {
-                        Arg::Named { label, .. } => Some(label.as_str()),
-                        _ => None,
-                    })
-                    .collect();
-                if let Some(info) = &type_info
-                    && let TypeDef::Record(entries) = &info.def
-                {
+                // Spread fields overwritten by an explicit arg are skipped —
+                // the explicit arg is checked below with its own span.
+                if let Some(field_types) = &field_type_map {
                     for (src_name, src_ty) in spread_fields.iter() {
                         if explicit_labels.contains(&src_name.as_str()) {
                             continue;
                         }
-                        let Some(target_field) = entries
-                            .iter()
-                            .filter_map(|e| e.as_field())
-                            .find(|f| f.name == *src_name)
+                        let Some((_, target_ty)) = field_types.iter().find(|(n, _)| n == src_name)
                         else {
                             continue;
                         };
-                        let target_ty = self.resolve_type(&target_field.type_ann);
-                        if !self.types_compatible(&target_ty, src_ty) {
+                        if !self.types_compatible(target_ty, src_ty) {
                             self.emit_error(
                                 format!(
                                     "field `{src_name}` from spread: expected `{}`, found `{}`",
@@ -1723,22 +1731,6 @@ impl Checker {
                 }
             }
         }
-
-        // Build field type map for type checking arguments
-        let field_type_map: Option<Vec<(String, Type)>> = if let Some(ref info) = type_info {
-            match &info.def {
-                TypeDef::Record(entries) => Some(
-                    entries
-                        .iter()
-                        .filter_map(|e| e.as_field())
-                        .map(|f| (f.name.clone(), self.resolve_type(&f.type_ann)))
-                        .collect(),
-                ),
-                _ => None,
-            }
-        } else {
-            None
-        };
 
         // Build ordered field types for variant constructors (positional arg checking)
         let variant_field_types: Option<Vec<Type>> =

--- a/crates/floe-core/src/checker/expr.rs
+++ b/crates/floe-core/src/checker/expr.rs
@@ -1681,6 +1681,46 @@ impl Checker {
                         );
                     }
                 }
+
+                // Type-check each spread source field against the target's
+                // field of the same name. Spread fields overwritten by an
+                // explicit arg are skipped — the explicit arg is checked
+                // below with its own span.
+                let explicit_labels: Vec<&str> = args
+                    .iter()
+                    .filter_map(|a| match a {
+                        Arg::Named { label, .. } => Some(label.as_str()),
+                        _ => None,
+                    })
+                    .collect();
+                if let Some(info) = &type_info
+                    && let TypeDef::Record(entries) = &info.def
+                {
+                    for (src_name, src_ty) in spread_fields.iter() {
+                        if explicit_labels.contains(&src_name.as_str()) {
+                            continue;
+                        }
+                        let Some(target_field) = entries
+                            .iter()
+                            .filter_map(|e| e.as_field())
+                            .find(|f| f.name == *src_name)
+                        else {
+                            continue;
+                        };
+                        let target_ty = self.resolve_type(&target_field.type_ann);
+                        if !self.types_compatible(&target_ty, src_ty) {
+                            self.emit_error(
+                                format!(
+                                    "field `{src_name}` from spread: expected `{}`, found `{}`",
+                                    target_ty, src_ty
+                                ),
+                                spread_expr.span,
+                                ErrorCode::TypeMismatch,
+                                format!("expected `{}`", target_ty),
+                            );
+                        }
+                    }
+                }
             }
         }
 

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -5668,6 +5668,56 @@ fn option_rejected_at_non_option_function_argument() {
 }
 
 #[test]
+fn spread_source_field_type_mismatch_errors() {
+    let diags = check(
+        r#"
+        type SnippetId = SnippetId(number)
+        type Snippet = { id: SnippetId, name: string }
+        let row = { id: 1, name: "hi" }
+        let _s = Snippet(..row)
+    "#,
+    );
+    assert!(
+        has_error(&diags, ErrorCode::TypeMismatch),
+        "spread source field `id: number` into `id: SnippetId` must be rejected, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn spread_source_field_type_match_still_compiles() {
+    let diags = check(
+        r#"
+        type User = { id: number, name: string }
+        let row = { id: 1, name: "hi" }
+        let _u = User(..row)
+    "#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::TypeMismatch),
+        "matching spread source fields must compile, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn spread_source_overwritten_field_mismatch_is_silent() {
+    let diags = check(
+        r#"
+        type SnippetId = SnippetId(number)
+        type Snippet = { id: SnippetId, name: string }
+        let row = { id: 1, name: "hi" }
+        let _s = Snippet(..row, id: SnippetId(2))
+    "#,
+    );
+    assert!(
+        !has_error(&diags, ErrorCode::TypeMismatch),
+        "explicit override of mismatched spread field should suppress the spread error, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn option_rejected_as_record_spread_source() {
     let diags = check(
         r#"


### PR DESCRIPTION
closes #1310

The spread check in record/variant constructors only rejected wholly-incompatible wrappers (`Result`, `Option`) and warned on duplicate-field overwrites. It never verified that each spread source field's type matched the target field's type, so a bare \`number\` could land in a nominal newtype slot silently.

Concrete case: a Drizzle row with \`id: number\` spread into \`Snippet(..row)\` where \`Snippet.id: SnippetId = SnippetId(number)\` — compiles, then produces a snippet with a raw number in the newtype slot.

## Test plan

- [x] \`spread_source_field_type_mismatch_errors\` — \`{ id: number }\` spread into a record with \`id: SnippetId\` errors with E001.
- [x] \`spread_source_field_type_match_still_compiles\` — matching source/target spreads cleanly.
- [x] \`spread_source_overwritten_field_mismatch_is_silent\` — when the explicit arg overrides the mismatched spread field (\`Snippet(..row, id: SnippetId(2))\`), the spread mismatch is suppressed (the explicit arg carries its own type check).
- [x] Full \`cargo test -p floe-core\`: 1563 unit + 34 snapshot tests pass.
- [x] \`cargo clippy -p floe-core --all-targets -- -D warnings\` clean.
- [x] \`floe check examples/todo-app/src/\` and \`floe check examples/store/src/\` still clean.