### PR TITLE
feat!: [#1312] record spread must come last (Rust/Gleam semantics)

### DIFF
--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -604,7 +604,7 @@ type Todo = {
     done: bool,
 }
 let original = Todo(id: "1", text: "hello", done: false)
-let _t = Todo(..original, text: "updated")
+let _t = Todo(text: "updated", ..original)
 "#,
     );
     assert!(!has_error(&diags, ErrorCode::DuplicateDefinition));
@@ -5707,7 +5707,7 @@ fn spread_source_overwritten_field_mismatch_is_silent() {
         type SnippetId = SnippetId(number)
         type Snippet = { id: SnippetId, name: string }
         let row = { id: 1, name: "hi" }
-        let _s = Snippet(..row, id: SnippetId(2))
+        let _s = Snippet(id: SnippetId(2), ..row)
     "#,
     );
     assert!(
@@ -5723,7 +5723,7 @@ fn option_rejected_as_record_spread_source() {
         r#"
         type User = { id: number, name: string }
         let maybe: Option<User> = Some(User(id: 1, name: "a"))
-        let _u = User(..maybe, name: "b")
+        let _u = User(name: "b", ..maybe)
     "#,
     );
     assert!(

--- a/crates/floe-core/src/codegen/tests.rs
+++ b/crates/floe-core/src/codegen/tests.rs
@@ -535,7 +535,7 @@ fn constructor_named() {
 #[test]
 fn constructor_with_spread() {
     assert_eq!(
-        emit(r#"User(..user, name: "New")"#),
+        emit(r#"User(name: "New", ..user)"#),
         r#"{ ...user, name: "New" };"#
     );
 }

--- a/crates/floe-core/src/cst/exprs.rs
+++ b/crates/floe-core/src/cst/exprs.rs
@@ -426,25 +426,7 @@ impl<'src> CstParser<'src> {
                     if has_args {
                         self.expect(TokenKind::LeftParen);
                         self.eat_trivia();
-
-                        // Check for spread
-                        if self.at(TokenKind::DotDot) {
-                            self.builder.start_node(SyntaxKind::SPREAD_EXPR.into());
-                            self.bump();
-                            self.eat_trivia();
-                            self.parse_expr();
-                            self.builder.finish_node();
-                            self.eat_trivia();
-                            if self.at(TokenKind::Comma) {
-                                self.bump();
-                                self.eat_trivia();
-                            }
-                        }
-
-                        if !self.at(TokenKind::RightParen) {
-                            self.parse_comma_separated(Self::parse_call_arg, TokenKind::RightParen);
-                        }
-
+                        self.parse_constructor_args();
                         self.expect(TokenKind::RightParen);
                     }
 
@@ -492,26 +474,58 @@ impl<'src> CstParser<'src> {
         self.expect(TokenKind::LeftParen);
         self.eat_trivia();
 
-        // Check for spread: `..expr`
-        if self.at(TokenKind::DotDot) {
-            self.builder.start_node(SyntaxKind::SPREAD_EXPR.into());
-            self.bump();
-            self.eat_trivia();
-            self.parse_expr();
-            self.builder.finish_node();
+        self.parse_constructor_args();
+
+        self.expect(TokenKind::RightParen);
+        self.builder.finish_node();
+    }
+
+    /// Parse a comma-separated list of constructor arguments. Accepts named
+    /// fields interspersed with at most one trailing `..base` spread. A
+    /// spread that appears before an explicit field is rejected with a
+    /// diagnostic pointing at the bad position.
+    fn parse_constructor_args(&mut self) {
+        let mut saw_spread = false;
+        while !self.at(TokenKind::RightParen) && !self.at_end() {
+            if self.at(TokenKind::DotDot) {
+                if saw_spread {
+                    self.builder.start_node(SyntaxKind::ERROR.into());
+                    self.error(
+                        "only one spread `..base` is allowed per constructor",
+                    );
+                    self.bump();
+                    self.eat_trivia();
+                    self.parse_expr();
+                    self.builder.finish_node();
+                } else {
+                    self.builder.start_node(SyntaxKind::SPREAD_EXPR.into());
+                    self.bump();
+                    self.eat_trivia();
+                    self.parse_expr();
+                    self.builder.finish_node();
+                    saw_spread = true;
+                }
+            } else {
+                if saw_spread {
+                    // Explicit arg after spread — the old spread-first syntax.
+                    self.builder.start_node(SyntaxKind::ERROR.into());
+                    self.error(
+                        "spread `..base` must come last — write explicit fields first, then `..base`",
+                    );
+                    self.parse_call_arg();
+                    self.builder.finish_node();
+                } else {
+                    self.parse_call_arg();
+                }
+            }
             self.eat_trivia();
             if self.at(TokenKind::Comma) {
                 self.bump();
                 self.eat_trivia();
+            } else {
+                break;
             }
         }
-
-        if !self.at(TokenKind::RightParen) {
-            self.parse_comma_separated(Self::parse_call_arg, TokenKind::RightParen);
-        }
-
-        self.expect(TokenKind::RightParen);
-        self.builder.finish_node();
     }
 
     // ── Call Arguments ───────────────────────────────────────────

--- a/crates/floe-core/src/cst/exprs.rs
+++ b/crates/floe-core/src/cst/exprs.rs
@@ -490,9 +490,7 @@ impl<'src> CstParser<'src> {
             if self.at(TokenKind::DotDot) {
                 if saw_spread {
                     self.builder.start_node(SyntaxKind::ERROR.into());
-                    self.error(
-                        "only one spread `..base` is allowed per constructor",
-                    );
+                    self.error("only one spread `..base` is allowed per constructor");
                     self.bump();
                     self.eat_trivia();
                     self.parse_expr();

--- a/crates/floe-core/src/formatter/expr.rs
+++ b/crates/floe-core/src/formatter/expr.rs
@@ -874,11 +874,6 @@ impl Formatter<'_> {
         let mut inner = vec![pretty::break_("", "")];
         let mut first = true;
         let mut prev_end: Option<u32> = None;
-        if let Some(spread) = &spread {
-            inner.push(self.fmt_spread(spread));
-            prev_end = Some(spread.text_range().end().into());
-            first = false;
-        }
         for arg in &args {
             let arg_start: u32 = arg.text_range().start().into();
             if !first {
@@ -894,6 +889,20 @@ impl Formatter<'_> {
             inner.push(self.fmt_arg(arg));
             prev_end = Some(arg.text_range().end().into());
             first = false;
+        }
+        if let Some(spread) = &spread {
+            if !first {
+                inner.push(pretty::break_(",", ", "));
+            }
+            if let Some(prev) = prev_end {
+                let spread_start: u32 = spread.text_range().start().into();
+                for c in self.pop_comments_in_range(prev, spread_start) {
+                    inner.push(pretty::str(c.text));
+                    inner.push(pretty::line());
+                    has_comment = true;
+                }
+            }
+            inner.push(self.fmt_spread(spread));
         }
 
         let mut group_parts = vec![pretty::str("(")];

--- a/crates/floe-core/src/formatter/tests.rs
+++ b/crates/floe-core/src/formatter/tests.rs
@@ -487,8 +487,8 @@ fn format_record_spread() {
 #[test]
 fn format_spread_in_construct() {
     assert_fmt(
-        "let x = Todo(..t, done: true)",
-        "let x = Todo(..t, done: true)",
+        "let x = Todo(done: true, ..t)",
+        "let x = Todo(done: true, ..t)",
     );
 }
 

--- a/crates/floe-core/src/parser/tests.rs
+++ b/crates/floe-core/src/parser/tests.rs
@@ -379,7 +379,7 @@ fn constructor() {
 
 #[test]
 fn constructor_with_spread() {
-    let expr = first_expr(r#"User(..user, name: "New")"#);
+    let expr = first_expr(r#"User(name: "New", ..user)"#);
     match expr {
         ExprKind::Construct { spread, args, .. } => {
             assert!(spread.is_some());
@@ -387,6 +387,19 @@ fn constructor_with_spread() {
         }
         _ => panic!("expected construct"),
     }
+}
+
+#[test]
+fn constructor_with_spread_first_errors() {
+    let diags = crate::parser::Parser::new(r#"let _ = User(..user, name: "New")"#)
+        .parse_program()
+        .err()
+        .unwrap_or_default();
+    assert!(
+        diags.iter().any(|d| d.message.contains("must come last")),
+        "spread-first should produce 'must come last' diagnostic, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
 }
 
 // ── Result/Option Constructors ───────────────────────────────

--- a/crates/floe-core/tests/fixtures/constructors.fl
+++ b/crates/floe-core/tests/fixtures/constructors.fl
@@ -4,7 +4,7 @@ type Point = {
 }
 
 let origin = Point(x: 0, y: 0)
-let moved = Point(..origin, x: 10)
+let moved = Point(x: 10, ..origin)
 
 let x = 5
 let y = 10

--- a/docs/design.md
+++ b/docs/design.md
@@ -225,7 +225,7 @@ todos |> Array.filter(.id != id)       // filter(todos, x -> x.id != id)
 todos |> Array.map(.text)              // map(todos, x -> x.text)
 
 // Closures — arrow syntax for when you need a named param
-todos |> Array.map((t) -> Todo(..t, done: true))
+todos |> Array.map((t) -> Todo(done: true, ..t))
 items |> Array.reduce((acc, x) -> acc + x.price, 0)
 
 // tap — call a function for side effects, pass value through
@@ -924,11 +924,13 @@ let user = User(
   nickname: None,
 )
 
-// Update with spread — ..existing then override
-let updated = User(..user, nickname: Some("Ry"))
-let updated = User(..user,
+// Update with spread — explicit fields first, `..base` last.
+// Explicit fields always win; `..base` only fills fields you didn't name.
+let updated = User(nickname: Some("Ry"), ..user)
+let updated = User(
   name: "Ryan Updated",
   nickname: Some("Ry"),
+  ..user,
 )
 // Compiles to: { ...user, name: "Ryan Updated", nickname: "Ry" }
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -200,8 +200,8 @@ let user = User("1", "Ryan", "r@test.com")
 // Named arguments (any order)
 let user = User(name: "Ryan", id: "1", email: "r@test.com")
 
-// Record spread with double dot
-let updated = User(..user, name: "New Name")
+// Record spread with double dot — explicit fields first, spread last
+let updated = User(name: "New Name", ..user)
 
 // Union variant construction
 let err = ApiError.Network(NetworkError.Timeout(ms: 3000))
@@ -761,7 +761,7 @@ export let App() -> JSX.Element = {
                     </span>
                     <button onClick={() -> setTodos(todos |> map((t) ->
                         match t.id == item.id {
-                            true -> Todo(..t, done: !t.done),
+                            true -> Todo(done: !t.done, ..t),
                             false -> t,
                         }
                     ))}>

--- a/docs/site/src/content/docs/docs/guide/pipes.md
+++ b/docs/site/src/content/docs/docs/guide/pipes.md
@@ -61,7 +61,7 @@ users |> Array.sortBy(.name)
 For anything more complex, use an arrow closure:
 
 ```floe
-todos |> Array.map((t) -> Todo(..t, done: !t.done))
+todos |> Array.map((t) -> Todo(done: !t.done, ..t))
 ```
 
 ## Method-Style Pipes

--- a/docs/site/src/content/docs/docs/guide/tour.md
+++ b/docs/site/src/content/docs/docs/guide/tour.md
@@ -55,7 +55,7 @@ type Shape = | Circle { radius: number }
     | Rectangle { width: number, height: number }
 
 let u = User(name: "Alice", id: "1", email: "a@t.com")
-let updated = User(..u, name: "Bob")
+let updated = User(name: "Bob", ..u)
 type UserId = UserId(string)   // newtype
 ```
 

--- a/docs/site/src/content/docs/docs/guide/type-driven-features.md
+++ b/docs/site/src/content/docs/docs/guide/type-driven-features.md
@@ -135,7 +135,7 @@ type Task = {
 }
 
 let toggleDone(task: Task) -> Task = {
-  Task(..task, done: !task.done)
+  Task(done: !task.done, ..task)
 }
 
 test "toggle flips done status" {

--- a/docs/site/src/content/docs/docs/guide/types.md
+++ b/docs/site/src/content/docs/docs/guide/types.md
@@ -45,10 +45,10 @@ Construct records with the type name:
 let user = User(name: "Alice", email: "a@b.com", age: 30)
 ```
 
-Update with spread:
+Update with spread — explicit fields first, `..base` last, explicit wins:
 
 ```floe
-let updated = User(..user, age: 31)
+let updated = User(age: 31, ..user)
 ```
 
 Two types with identical fields are NOT interchangeable. `User` is not `Product` even if both have `name: string`.

--- a/docs/site/src/content/docs/docs/reference/operators.md
+++ b/docs/site/src/content/docs/docs/reference/operators.md
@@ -70,7 +70,7 @@ The `?` operator unwraps `Ok(value)` or `Some(value)`, and returns early with `E
 
 | Operator | Context | Example |
 |----------|---------|---------|
-| `..` | Record spread in constructors | `User(..existing, name: "New")` |
+| `..` | Record spread in constructors (must be last) | `User(name: "New", ..existing)` |
 | `..` | Array rest in match patterns | `[first, ..rest]` |
 | `...` | Type spread in record definitions | `type B = { ...A, extra: string }` |
 | `1..10` | Range pattern in match | `match n { 1..10 -> "small" }` |

--- a/docs/site/src/content/docs/docs/reference/syntax.md
+++ b/docs/site/src/content/docs/docs/reference/syntax.md
@@ -223,7 +223,7 @@ f(a, b)
 f(name: value)                 // named argument
 f(a, b: 2, c: 3)               // positional first, then named
 Constructor(a: 1)              // record constructor
-Constructor(..existing, a: 2)  // spread + update
+Constructor(a: 2, ..existing)  // explicit fields first, spread last
 ```
 
 Call rules:

--- a/examples/store/src/checkout.fl
+++ b/examples/store/src/checkout.fl
@@ -45,7 +45,7 @@ export let validateCheckout(
             let phone = shipping.phone |> validatePhone?
             let _stock = cart |> validateStock?
 
-            ShippingInfo(..shipping, email: email, phone: phone)
+            ShippingInfo(email: email, phone: phone, ..shipping)
         },
     }
 }

--- a/examples/store/src/product.fl
+++ b/examples/store/src/product.fl
@@ -50,7 +50,7 @@ for Array<CartItem> {
         existing |> match {
             None -> self |> Array.append(CartItem(product:, quantity: qty)),
             Some(_) -> self |> Array.map((item) -> match item.product.id == product.id {
-                    true -> CartItem(..item, quantity: item.quantity + qty),
+                    true -> CartItem(quantity: item.quantity + qty, ..item),
                     false -> item,
                 }),
         }
@@ -64,7 +64,7 @@ for Array<CartItem> {
         qty |> match {
             0 -> self |> removeItem(productId),
             _ -> self |> Array.map((item) -> match item.product.id == productId {
-                    true -> CartItem(..item, quantity: qty),
+                    true -> CartItem(quantity: qty, ..item),
                     false -> item,
                 }),
         }

--- a/examples/todo-app/src/pages/home.fl
+++ b/examples/todo-app/src/pages/home.fl
@@ -28,7 +28,7 @@ export let HomePage() -> JSX.Element = {
 
     let handleToggle(id: string) = {
         setTodos(todos |> map((t) -> match t.id == id {
-                    true -> Todo(..t, done: !t.done),
+                    true -> Todo(done: !t.done, ..t),
                     false -> t,
                 }))
     }

--- a/tests/lsp/fixtures.py
+++ b/tests/lsp/fixtures.py
@@ -315,7 +315,7 @@ type User = {
 }
 
 let updateName(user: User, newName: string) -> User = {
-    User(..user, name: newName)
+    User(name: newName, ..user)
 }
 """
 


### PR DESCRIPTION
closes #1312

**Breaking change.** Record-spread in constructors flips from spread-first to spread-last.

### Before (old)

```floe
Snippet(..row, id: SnippetId(row.id))
```

Spread comes first. Later explicit fields override. TS/JS-style last-wins.

### After (new)

```floe
Snippet(id: SnippetId(row.id), ..row)
```

Explicit fields come first. \`..row\` fills **only fields not already named** — not "last wins." This is the Rust/Gleam semantics: you write the fields you care about; the spread is filler for the rest.

### Error on old syntax

Writing spread-first now produces:

\`\`\`
Error: spread \`..base\` must come last — write explicit fields first, then \`..base\`
  ╭─[ routes.fl:3:15 ]
  │
  │     User(..u, name: "New")
  │               ─┬──
  │                ╰─── spread \`..base\` must come last ...
  ╯
\`\`\`

A second spread triggers: \`only one spread \`..base\` is allowed per constructor\`.

### Migration

All internal fixtures, example apps, and documentation flipped. Files touched:
- Parser: consolidated the two spread-parsing call sites (regular constructor + qualified variant) into a shared \`parse_constructor_args\` helper.
- Formatter: emits args first, then spread, including correct comment handling for the new position.
- Tests: \`constructor_with_spread\`, \`constructor_spread_skips_missing_check\`, \`option_rejected_as_record_spread_source\`, \`spread_source_overwritten_field_mismatch_is_silent\`, \`format_spread_in_construct\`, fixture \`tests/fixtures/constructors.fl\` — all flipped.
- New test: \`constructor_with_spread_first_errors\` verifies the diagnostic fires.
- Examples: \`examples/todo-app/src/pages/home.fl\`, \`examples/store/src/checkout.fl\`, \`examples/store/src/product.fl\`.
- Docs: \`docs/design.md\`, \`docs/llms.txt\`, \`docs/site/src/content/docs/**\`.

## Test plan

- [x] \`cargo test -p floe-core\`: 1564 unit + 34 snapshot + 29 insta tests pass.
- [x] \`floe check examples/todo-app/src/\` clean.
- [x] \`floe check examples/store/src/\` clean.
- [x] \`cargo clippy -p floe-core --all-targets -- -D warnings\` clean.
- [x] End-to-end: hand-written \`.fl\` with old syntax produces the new diagnostic with correct span.

## Pre-1.0 note

\`feat!:\` prefix so release-please bumps pre-1.0 minor. Any downstream Floe code using spread needs the flip — not much in the wild yet, and the error message walks users through it.