### PR TITLE
feat!: [#1313] add `typealias` keyword for structural aliases

### DIFF
--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -3951,7 +3951,7 @@ type Route = | Home
 
 #[test]
 fn type_alias_without_ts_import_is_error() {
-    let diags = check("type Name = string");
+    let diags = check("typealias Name = string");
     {
         let errors: Vec<_> = diags
             .iter()
@@ -5551,7 +5551,7 @@ let _result = toModel(row)
 fn typeof_local_binding_is_ok() {
     let diags = check(
         "let greet(name: string) -> string = { `Hello, ${name}!` }
-type Greeter = typeof greet",
+typealias Greeter = typeof greet",
     );
     {
         let errors: Vec<_> = diags
@@ -5571,7 +5571,7 @@ fn typeof_local_record_binding_is_ok() {
     let diags = check(
         "type Config = { baseUrl: string, timeout: number }
 let config = Config(baseUrl: \"https://api.com\", timeout: 5000)
-type MyConfig = typeof config",
+typealias MyConfig = typeof config",
     );
     {
         let errors: Vec<_> = diags
@@ -5588,7 +5588,7 @@ type MyConfig = typeof config",
 
 #[test]
 fn typeof_undefined_binding() {
-    let diags = check("type T = typeof doesNotExist");
+    let diags = check("typealias T = typeof doesNotExist");
     assert!(
         has_error_containing(&diags, "undefined binding"),
         "should error on undefined binding: {diags:?}"
@@ -5600,7 +5600,7 @@ fn typeof_forward_reference_errors() {
     // typeof cannot forward-reference local functions (they aren't registered
     // until the second pass, after type registration)
     let diags = check(
-        "type Greeter = typeof greet
+        "typealias Greeter = typeof greet
 let greet(name: string) -> string = { `Hello, ${name}!` }",
     );
     assert!(
@@ -5803,7 +5803,7 @@ fn intersection_local_types_is_ok() {
     let diags = check(
         "type A = { x: number }
 type B = { y: string }
-type C = A & B",
+typealias C = A & B",
     );
     {
         let errors: Vec<_> = diags
@@ -5823,7 +5823,7 @@ fn intersection_three_local_types_is_ok() {
     let diags = check(
         "type A = { x: number }
 type B = { y: string }
-type D = A & B & { z: boolean }",
+typealias D = A & B & { z: boolean }",
     );
     {
         let errors: Vec<_> = diags
@@ -5843,7 +5843,7 @@ fn intersection_with_local_typeof_is_ok() {
     let diags = check(
         "type Config = { baseUrl: string }
 let config = Config(baseUrl: \"https://api.com\")
-type Extended = typeof config & { timeout: number }",
+typealias Extended = typeof config & { timeout: number }",
     );
     {
         let errors: Vec<_> = diags
@@ -5863,7 +5863,7 @@ fn intersection_local_generic_is_ok() {
     let diags = check(
         "type A = { x: number }
 type B = { y: string }
-type C = Array<A> & B",
+typealias C = Array<A> & B",
     );
     {
         let errors: Vec<_> = diags
@@ -5898,7 +5898,7 @@ let _test(b: B) -> number = { b.x }",
 fn alias_with_local_type_is_ok() {
     let diags = check(
         "type A = { x: number }
-type B = Array<\"div\">",
+typealias B = Array<\"div\">",
     );
     {
         let errors: Vec<_> = diags
@@ -5923,7 +5923,7 @@ fn alias_with_npm_import_is_ok() {
     let program = crate::parser::Parser::new(
         r#"
 import { ComponentProps } from "react"
-type DivProps = ComponentProps<"div">
+typealias DivProps = ComponentProps<"div">
 "#,
     )
     .parse_program()
@@ -5960,7 +5960,7 @@ fn intersection_with_npm_import_is_ok() {
     let program = crate::parser::Parser::new(
         r#"
 import { VariantProps } from "tailwind-variants"
-type CardProps = VariantProps & { className: string }
+typealias CardProps = VariantProps & { className: string }
 "#,
     )
     .parse_program()
@@ -6027,7 +6027,7 @@ fn assert_utility_type_accepted(src: &str) {
 fn alias_with_return_type_and_typeof_local_is_ok() {
     assert_utility_type_accepted(
         "let createDb(id: string) -> string = { id }
-type Database = ReturnType<typeof createDb>",
+typealias Database = ReturnType<typeof createDb>",
     );
 }
 
@@ -6035,7 +6035,7 @@ type Database = ReturnType<typeof createDb>",
 fn alias_with_parameters_is_ok() {
     assert_utility_type_accepted(
         "let createDb(id: string) -> string = { id }
-type DbArgs = Parameters<typeof createDb>",
+typealias DbArgs = Parameters<typeof createDb>",
     );
 }
 
@@ -6043,7 +6043,7 @@ type DbArgs = Parameters<typeof createDb>",
 fn alias_with_partial_over_local_record_is_ok() {
     assert_utility_type_accepted(
         "type User = { name: string, email: string, age: number }
-type PartialUser = Partial<User>",
+typealias PartialUser = Partial<User>",
     );
 }
 
@@ -6051,8 +6051,8 @@ type PartialUser = Partial<User>",
 fn alias_with_readonly_and_non_nullable_is_ok() {
     assert_utility_type_accepted(
         "type User = { name: string }
-type ReadOnlyUser = Readonly<User>
-type NonNullableUser = NonNullable<User>",
+typealias ReadOnlyUser = Readonly<User>
+typealias NonNullableUser = NonNullable<User>",
     );
 }
 
@@ -6060,7 +6060,7 @@ type NonNullableUser = NonNullable<User>",
 fn bare_typeof_local_still_errors() {
     let diags = check(
         "let createDb(id: string) -> string = { id }
-type Identity = typeof createDb",
+typealias Identity = typeof createDb",
     );
     {
         let errors: Vec<_> = diags
@@ -6079,7 +6079,7 @@ type Identity = typeof createDb",
 fn unknown_utility_like_name_still_errors() {
     let diags = check(
         "type User = { name: string }
-type Wat = MyCustomUtility<User>",
+typealias Wat = MyCustomUtility<User>",
     );
     assert!(has_error(&diags, ErrorCode::UndefinedName), "{diags:?}");
 }
@@ -6106,7 +6106,7 @@ type Props = {
 fn intersection_in_type_alias_is_ok() {
     let diags = check(
         r#"
-type Props = string & { extra: number }
+typealias Props = string & { extra: number }
 "#,
     );
     assert!(
@@ -9185,8 +9185,8 @@ fn fn_type_alias_accepts_labelled_and_unlabelled_params() {
     // Labels are documentation only — both forms parse and check cleanly.
     let diags = check(
         r#"
-type Handler = (req: number) -> number
-type Predicate = (number) -> boolean
+typealias Handler = (req: number) -> number
+typealias Predicate = (number) -> boolean
 let _h(f: Handler, x: number) -> number = { f(x) }
 let _p(f: Predicate, x: number) -> boolean = { f(x) }
 "#,
@@ -9208,7 +9208,7 @@ fn fn_type_param_label_does_not_collide_with_call_site_arguments() {
     // having to refer to the label.
     let diags = check(
         r#"
-type Apply = (n: number) -> number
+typealias Apply = (n: number) -> number
 let _twice(f: Apply, x: number) -> number = { f(f(x)) }
 "#,
     );
@@ -9229,7 +9229,7 @@ let _twice(f: Apply, x: number) -> number = { f(f(x)) }
 fn function_type_alias_accepts_zero_arg_closure() {
     let diags = check(
         r#"
-type CreatePoop = () -> string
+typealias CreatePoop = () -> string
 export let poop: CreatePoop = () -> "poop"
 "#,
     );
@@ -9244,7 +9244,7 @@ export let poop: CreatePoop = () -> "poop"
 fn function_type_alias_accepts_one_arg_closure() {
     let diags = check(
         r#"
-type F = (number) -> number
+typealias F = (number) -> number
 export let f: F = (x) -> x + 1
 "#,
     );
@@ -9259,7 +9259,7 @@ export let f: F = (x) -> x + 1
 fn function_type_alias_call_site_returns_unwrapped_type() {
     let diags = check(
         r#"
-type F = () -> string
+typealias F = () -> string
 let f: F = () -> "x"
 export let s: string = f()
 "#,
@@ -9275,7 +9275,7 @@ export let s: string = f()
 fn function_type_alias_as_parameter_accepts_closure_literal() {
     let diags = check(
         r#"
-type F = () -> string
+typealias F = () -> string
 let run(g: F) -> string = { g() }
 export let r: string = run(() -> "z")
 "#,

--- a/crates/floe-core/src/codegen/tests.rs
+++ b/crates/floe-core/src/codegen/tests.rs
@@ -719,7 +719,7 @@ fn type_union() {
 
 #[test]
 fn type_alias() {
-    assert_eq!(emit("type Name = string"), "type Name = string;");
+    assert_eq!(emit("typealias Name = string"), "type Name = string;");
 }
 
 #[test]
@@ -745,7 +745,7 @@ fn option_type() {
 
 #[test]
 fn result_type() {
-    let result = emit("type Res = Result<User, ApiError>");
+    let result = emit("typealias Res = Result<User, ApiError>");
     assert!(result.contains("ok: true"));
     assert!(result.contains("ok: false"));
 }
@@ -2335,7 +2335,7 @@ let s = mock<Status>",
 fn typeof_function_alias() {
     let result = emit(
         "let greet(name: string) -> string = { `Hello, ${name}!` }
-type Greeter = typeof greet",
+typealias Greeter = typeof greet",
     );
     assert!(
         result.contains("type Greeter = typeof greet;"),
@@ -2348,7 +2348,7 @@ fn typeof_const_alias() {
     let result = emit(
         "type Config = { baseUrl: string }
 let config = Config(baseUrl: \"https://api.com\")
-type MyConfig = typeof config",
+typealias MyConfig = typeof config",
     );
     assert!(
         result.contains("type MyConfig = typeof config;"),
@@ -2363,7 +2363,7 @@ fn intersection_two_types() {
     let result = emit(
         "type A = { x: number }
 type B = { y: string }
-type C = A & B",
+typealias C = A & B",
     );
     assert!(
         result.contains("type C = A & B;"),
@@ -2376,7 +2376,7 @@ fn intersection_three_types() {
     let result = emit(
         "type A = { x: number }
 type B = { y: string }
-type D = A & B & { z: boolean }",
+typealias D = A & B & { z: boolean }",
     );
     assert!(
         result.contains("A & B & { z: boolean }"),
@@ -2389,7 +2389,7 @@ fn intersection_after_generic_type() {
     let result = emit(
         "type A = { x: number }
 type B = { y: string }
-type C = Array<A> & B",
+typealias C = Array<A> & B",
     );
     assert!(
         result.contains("type C = Array<A> & B;"),
@@ -2414,7 +2414,7 @@ type B = {
 
 #[test]
 fn string_literal_type_arg() {
-    let result = emit("type A = Array<\"div\">");
+    let result = emit("typealias A = Array<\"div\">");
     assert!(
         result.contains("type A = Array<\"div\">;"),
         "should emit string literal type arg, got: {result}"

--- a/crates/floe-core/src/cst.rs
+++ b/crates/floe-core/src/cst.rs
@@ -809,7 +809,7 @@ mod tests {
 
     #[test]
     fn type_alias() {
-        assert_no_errors("type Name = string");
+        assert_no_errors("typealias Name = string");
     }
 
     #[test]

--- a/crates/floe-core/src/cst/items.rs
+++ b/crates/floe-core/src/cst/items.rs
@@ -522,27 +522,20 @@ impl<'src> CstParser<'src> {
         self.eat_trivia();
         let def_kind = self.parse_type_def_after_eq();
 
-        // Validate keyword/RHS combination. Records are ambiguous (either keyword
-        // works): `type { ... }` is nominal, `typealias { ... }` is structural.
-        // Tagged unions and newtypes need nominal identity (require `type`), and
-        // function types, generic applications, intersections, tuples, and
-        // `typeof` are structural (require `typealias`). `opaque` is exempt —
-        // it is the explicit way to give a structural shape nominal identity.
-        match (is_typealias, is_opaque, def_kind) {
-            (false, false, SyntaxKind::TYPE_DEF_ALIAS) => {
-                self.error(
-                    "`type` declares a nominal type; this shape is structural. \
-                     Use `typealias` instead — it names a shape without creating \
-                     a new nominal type",
-                );
-            }
-            (true, _, SyntaxKind::TYPE_DEF_UNION) => {
-                self.error(
-                    "`typealias` names a structural shape; tagged unions and \
-                     newtypes need nominal identity. Use `type` instead",
-                );
-            }
-            _ => {}
+        // `opaque` is the explicit way to brand a structural shape as nominal,
+        // so it's exempt from the type/typealias split.
+        if !is_typealias && !is_opaque && def_kind == SyntaxKind::TYPE_DEF_ALIAS {
+            self.error(
+                "`type` declares a nominal type; this shape is structural. \
+                 Use `typealias` instead — it names a shape without creating \
+                 a new nominal type",
+            );
+        }
+        if is_typealias && def_kind == SyntaxKind::TYPE_DEF_UNION {
+            self.error(
+                "`typealias` names a structural shape; tagged unions and \
+                 newtypes need nominal identity. Use `type` instead",
+            );
         }
 
         // Optional deriving clause: `deriving (Display)`

--- a/crates/floe-core/src/cst/items.rs
+++ b/crates/floe-core/src/cst/items.rs
@@ -93,7 +93,7 @@ impl<'src> CstParser<'src> {
                 self.parse_const_decl();
                 self.builder.finish_node();
             }
-            Some(TokenKind::Opaque) | Some(TokenKind::Type) => {
+            Some(TokenKind::Opaque) | Some(TokenKind::Type) | Some(TokenKind::Typealias) => {
                 self.builder
                     .start_node_at(checkpoint, SyntaxKind::ITEM.into());
                 self.parse_type_decl();
@@ -487,12 +487,24 @@ impl<'src> CstParser<'src> {
     fn parse_type_decl(&mut self) {
         self.builder.start_node(SyntaxKind::TYPE_DECL.into());
 
-        if self.at(TokenKind::Opaque) {
+        let is_opaque = self.at(TokenKind::Opaque);
+        if is_opaque {
             self.bump();
             self.eat_trivia();
         }
 
-        self.expect(TokenKind::Type);
+        let is_typealias = self.at(TokenKind::Typealias);
+        if is_typealias {
+            if is_opaque {
+                self.error(
+                    "`opaque typealias` is not supported; `opaque` only applies to nominal \
+                     `type` declarations",
+                );
+            }
+            self.bump(); // typealias
+        } else {
+            self.expect(TokenKind::Type);
+        }
         self.eat_trivia();
         self.expect_ident();
         self.eat_trivia();
@@ -508,11 +520,40 @@ impl<'src> CstParser<'src> {
 
         self.expect(TokenKind::Equal);
         self.eat_trivia();
-        self.parse_type_def_after_eq();
+        let def_kind = self.parse_type_def_after_eq();
+
+        // Validate keyword/RHS combination. Records are ambiguous (either keyword
+        // works): `type { ... }` is nominal, `typealias { ... }` is structural.
+        // Tagged unions and newtypes need nominal identity (require `type`), and
+        // function types, generic applications, intersections, tuples, and
+        // `typeof` are structural (require `typealias`). `opaque` is exempt —
+        // it is the explicit way to give a structural shape nominal identity.
+        match (is_typealias, is_opaque, def_kind) {
+            (false, false, SyntaxKind::TYPE_DEF_ALIAS) => {
+                self.error(
+                    "`type` declares a nominal type; this shape is structural. \
+                     Use `typealias` instead — it names a shape without creating \
+                     a new nominal type",
+                );
+            }
+            (true, _, SyntaxKind::TYPE_DEF_UNION) => {
+                self.error(
+                    "`typealias` names a structural shape; tagged unions and \
+                     newtypes need nominal identity. Use `type` instead",
+                );
+            }
+            _ => {}
+        }
 
         // Optional deriving clause: `deriving (Display)`
         self.eat_trivia();
         if self.at(TokenKind::Deriving) {
+            if is_typealias {
+                self.error(
+                    "`deriving` requires a nominal `type` declaration; \
+                     `typealias` names a structural shape and cannot derive traits",
+                );
+            }
             self.builder.start_node(SyntaxKind::DERIVING_CLAUSE.into());
             self.bump(); // consume `deriving`
             self.eat_trivia();
@@ -526,36 +567,37 @@ impl<'src> CstParser<'src> {
         self.builder.finish_node();
     }
 
-    fn parse_type_def_after_eq(&mut self) {
+    fn parse_type_def_after_eq(&mut self) -> SyntaxKind {
         if self.at(TokenKind::LeftBrace) {
             self.builder.start_node(SyntaxKind::TYPE_DEF_RECORD.into());
             self.parse_record_fields();
             self.builder.finish_node();
-            return;
+            return SyntaxKind::TYPE_DEF_RECORD;
         }
 
         if self.at(TokenKind::VerticalBar) {
             self.builder.start_node(SyntaxKind::TYPE_DEF_UNION.into());
             self.parse_union_variants_inner();
             self.builder.finish_node();
-            return;
+            return SyntaxKind::TYPE_DEF_UNION;
         }
 
         if self.is_ident() && self.looks_like_nominal_sum_or_newtype() {
             self.builder.start_node(SyntaxKind::TYPE_DEF_UNION.into());
             self.parse_union_variants_inner();
             self.builder.finish_node();
-            return;
+            return SyntaxKind::TYPE_DEF_UNION;
         }
 
         if self.at_string_literal_union() {
             self.parse_string_literal_union();
-            return;
+            return SyntaxKind::TYPE_DEF_STRING_UNION;
         }
 
         self.builder.start_node(SyntaxKind::TYPE_DEF_ALIAS.into());
         self.parse_type_expr();
         self.builder.finish_node();
+        SyntaxKind::TYPE_DEF_ALIAS
     }
 
     fn looks_like_nominal_sum_or_newtype(&self) -> bool {

--- a/crates/floe-core/src/formatter/items.rs
+++ b/crates/floe-core/src/formatter/items.rs
@@ -439,7 +439,11 @@ impl Formatter<'_> {
         if self.has_token(node, SyntaxKind::KW_OPAQUE) {
             parts.push(pretty::str("opaque "));
         }
-        parts.push(pretty::str("type "));
+        if self.has_token(node, SyntaxKind::KW_TYPEALIAS) {
+            parts.push(pretty::str("typealias "));
+        } else {
+            parts.push(pretty::str("type "));
+        }
 
         let idents = self.collect_idents(node);
         if let Some(name) = idents.first() {

--- a/crates/floe-core/src/formatter/tests.rs
+++ b/crates/floe-core/src/formatter/tests.rs
@@ -65,7 +65,10 @@ fn format_type_union() {
 
 #[test]
 fn format_type_alias() {
-    assert_fmt("type StringAlias = string", "type StringAlias = string");
+    assert_fmt(
+        "typealias StringAlias = string",
+        "typealias StringAlias = string",
+    );
 }
 
 #[test]
@@ -1002,8 +1005,8 @@ fn format_zero_arg_closure_string_body() {
 #[test]
 fn format_zero_arg_closure_with_alias_annotation() {
     assert_fmt(
-        "type F = () -> string\nlet f: F = () -> \"poop\"",
-        "type F = () -> string\n\nlet f: F = () -> \"poop\"",
+        "typealias F = () -> string\nlet f: F = () -> \"poop\"",
+        "typealias F = () -> string\n\nlet f: F = () -> \"poop\"",
     );
 }
 
@@ -1024,7 +1027,7 @@ fn format_zero_arg_closure_block_body() {
 
 #[test]
 fn idempotent_zero_arg_closure_with_alias() {
-    assert_idempotent("type F = () -> string\n\nlet f: F = () -> \"poop\"\n");
+    assert_idempotent("typealias F = () -> string\n\nlet f: F = () -> \"poop\"\n");
 }
 
 #[test]

--- a/crates/floe-core/src/interop/tsgo.rs
+++ b/crates/floe-core/src/interop/tsgo.rs
@@ -1181,7 +1181,7 @@ let x = 42"#;
     fn generate_probe_includes_type_alias_probe() {
         let source = r#"import { tv, VariantProps } from "tailwind-variants"
 let spinnerVariants = tv({})
-type SpinnerProps = VariantProps<typeof spinnerVariants>"#;
+typealias SpinnerProps = VariantProps<typeof spinnerVariants>"#;
         let program = Parser::new(source).parse_program().unwrap();
         let probe = generate_probe(&program, &HashMap::new(), &HashMap::new());
         assert!(
@@ -1198,7 +1198,7 @@ type SpinnerProps = VariantProps<typeof spinnerVariants>"#;
     fn generate_probe_emits_typeof_const_for_type_probe() {
         let source = r#"import { tv, VariantProps } from "tailwind-variants"
 let spinnerVariants = tv({})
-type SpinnerProps = VariantProps<typeof spinnerVariants>"#;
+typealias SpinnerProps = VariantProps<typeof spinnerVariants>"#;
         let program = Parser::new(source).parse_program().unwrap();
         let probe = generate_probe(&program, &HashMap::new(), &HashMap::new());
         // The probe should declare spinnerVariants so typeof can resolve
@@ -1211,7 +1211,7 @@ type SpinnerProps = VariantProps<typeof spinnerVariants>"#;
     #[test]
     fn type_probe_not_emitted_for_local_only_alias() {
         let source = r#"import { useState } from "react"
-type MyNum = number"#;
+typealias MyNum = number"#;
         let program = Parser::new(source).parse_program().unwrap();
         let probe = generate_probe(&program, &HashMap::new(), &HashMap::new());
         assert!(

--- a/crates/floe-core/src/lexer.rs
+++ b/crates/floe-core/src/lexer.rs
@@ -707,7 +707,7 @@ mod tests {
     #[test]
     fn keywords() {
         assert_eq!(
-            lex("let fn export import match type opaque"),
+            lex("let fn export import match type typealias opaque"),
             vec![
                 TokenKind::Let,
                 TokenKind::Fn,
@@ -715,6 +715,7 @@ mod tests {
                 TokenKind::Import,
                 TokenKind::Match,
                 TokenKind::Type,
+                TokenKind::Typealias,
                 TokenKind::Opaque,
                 TokenKind::Eof,
             ]

--- a/crates/floe-core/src/lexer/token.rs
+++ b/crates/floe-core/src/lexer/token.rs
@@ -42,6 +42,7 @@ pub enum TokenKind {
     From,
     Match,
     Type,
+    Typealias,
     Opaque,
     /// `for` — for block keyword (grouping functions under a type)
     For,
@@ -267,6 +268,7 @@ pub fn lookup_keyword(word: &str) -> Option<TokenKind> {
         "from" => Some(TokenKind::From),
         "match" => Some(TokenKind::Match),
         "type" => Some(TokenKind::Type),
+        "typealias" => Some(TokenKind::Typealias),
         "opaque" => Some(TokenKind::Opaque),
         "for" => Some(TokenKind::For),
         "self" => Some(TokenKind::SelfKw),

--- a/crates/floe-core/src/lower.rs
+++ b/crates/floe-core/src/lower.rs
@@ -929,7 +929,7 @@ mod tests {
 
     #[test]
     fn type_alias() {
-        let item = first_item("type Name = string");
+        let item = first_item("typealias Name = string");
         let ItemKind::TypeDecl(decl) = item else {
             panic!("expected TypeDecl")
         };

--- a/crates/floe-core/src/lower/items.rs
+++ b/crates/floe-core/src/lower/items.rs
@@ -360,6 +360,7 @@ impl<'src> Lowerer<'src> {
     fn lower_type_decl(&mut self, node: &SyntaxNode, item_node: &SyntaxNode) -> Option<TypeDecl> {
         let exported = self.has_keyword(item_node, SyntaxKind::KW_EXPORT);
         let opaque = self.has_keyword(node, SyntaxKind::KW_OPAQUE);
+        let is_typealias = self.has_keyword(node, SyntaxKind::KW_TYPEALIAS);
 
         // Collect idents: first is name, rest are type params
         let idents = self.collect_idents_direct(node);
@@ -371,7 +372,17 @@ impl<'src> Lowerer<'src> {
         for child in node.children() {
             match child.kind() {
                 SyntaxKind::TYPE_DEF_RECORD => {
-                    def = Some(self.lower_type_def_record(&child));
+                    let record_def = self.lower_type_def_record(&child);
+                    // `typealias X = { ... }` is a structural alias over the
+                    // record shape — wrap in TypeDef::Alias so the checker
+                    // treats it as equivalent to the inline type and codegen
+                    // emits a plain `type X = { ... };` without the nominal
+                    // `__type` tag.
+                    def = Some(if is_typealias {
+                        self.record_def_to_structural_alias(record_def, &child)
+                    } else {
+                        record_def
+                    });
                 }
                 SyntaxKind::TYPE_DEF_UNION => {
                     def = Some(self.lower_type_def_union(&child));
@@ -397,6 +408,63 @@ impl<'src> Lowerer<'src> {
             def: def?,
             deriving,
         })
+    }
+
+    /// Convert a `TypeDef::Record` into `TypeDef::Alias(TypeExpr)` for
+    /// `typealias X = { ... }`. Records with spreads become intersections so
+    /// `typealias X = { ...Other, foo: T }` is equivalent to
+    /// `typealias X = Other & { foo: T }` — both compile to the same TS.
+    fn record_def_to_structural_alias(
+        &mut self,
+        def: TypeDef,
+        record_node: &SyntaxNode,
+    ) -> TypeDef {
+        let entries = match def {
+            TypeDef::Record(entries) => entries,
+            other => return other,
+        };
+        let span = self.node_span(record_node);
+
+        // Walk entries preserving order, grouping consecutive non-spread fields
+        // into synthetic record type exprs that sit between spreads in the
+        // resulting intersection.
+        let mut parts: Vec<TypeExpr> = Vec::new();
+        let mut pending_fields: Vec<RecordField> = Vec::new();
+        let flush = |pending: &mut Vec<RecordField>, parts: &mut Vec<TypeExpr>| {
+            if pending.is_empty() {
+                return;
+            }
+            let fields = std::mem::take(pending);
+            parts.push(TypeExpr {
+                kind: TypeExprKind::Record(fields),
+                span,
+            });
+        };
+        for entry in entries {
+            match entry {
+                RecordEntry::Field(f) => pending_fields.push(*f),
+                RecordEntry::Spread(s) => {
+                    flush(&mut pending_fields, &mut parts);
+                    if let Some(te) = s.type_expr {
+                        parts.push(te);
+                    }
+                }
+            }
+        }
+        flush(&mut pending_fields, &mut parts);
+
+        let inner = match parts.len() {
+            0 => TypeExpr {
+                kind: TypeExprKind::Record(Vec::new()),
+                span,
+            },
+            1 => parts.into_iter().next().unwrap(),
+            _ => TypeExpr {
+                kind: TypeExprKind::Intersection(parts),
+                span,
+            },
+        };
+        TypeDef::Alias(inner)
     }
 
     fn lower_for_block(&mut self, node: &SyntaxNode, item_exported: bool) -> Option<ForBlock> {

--- a/crates/floe-core/src/lower/items.rs
+++ b/crates/floe-core/src/lower/items.rs
@@ -410,10 +410,9 @@ impl<'src> Lowerer<'src> {
         })
     }
 
-    /// Convert a `TypeDef::Record` into `TypeDef::Alias(TypeExpr)` for
-    /// `typealias X = { ... }`. Records with spreads become intersections so
-    /// `typealias X = { ...Other, foo: T }` is equivalent to
-    /// `typealias X = Other & { foo: T }` — both compile to the same TS.
+    /// Records are the only RHS shape where both `type` and `typealias` are
+    /// legal; under `typealias`, spreads fold into an intersection so that
+    /// `typealias X = { ...Other, foo: T }` matches `Other & { foo: T }`.
     fn record_def_to_structural_alias(
         &mut self,
         def: TypeDef,
@@ -424,47 +423,51 @@ impl<'src> Lowerer<'src> {
             other => return other,
         };
         let span = self.node_span(record_node);
+        let has_spread = entries.iter().any(|e| matches!(e, RecordEntry::Spread(_)));
 
-        // Walk entries preserving order, grouping consecutive non-spread fields
-        // into synthetic record type exprs that sit between spreads in the
-        // resulting intersection.
-        let mut parts: Vec<TypeExpr> = Vec::new();
-        let mut pending_fields: Vec<RecordField> = Vec::new();
-        let flush = |pending: &mut Vec<RecordField>, parts: &mut Vec<TypeExpr>| {
-            if pending.is_empty() {
-                return;
-            }
-            let fields = std::mem::take(pending);
-            parts.push(TypeExpr {
+        if !has_spread {
+            let fields = entries
+                .into_iter()
+                .filter_map(|e| match e {
+                    RecordEntry::Field(f) => Some(*f),
+                    RecordEntry::Spread(_) => None,
+                })
+                .collect();
+            return TypeDef::Alias(TypeExpr {
                 kind: TypeExprKind::Record(fields),
                 span,
             });
-        };
+        }
+
+        let mut parts: Vec<TypeExpr> = Vec::new();
+        let mut pending: Vec<RecordField> = Vec::with_capacity(entries.len());
         for entry in entries {
             match entry {
-                RecordEntry::Field(f) => pending_fields.push(*f),
+                RecordEntry::Field(f) => pending.push(*f),
                 RecordEntry::Spread(s) => {
-                    flush(&mut pending_fields, &mut parts);
+                    if !pending.is_empty() {
+                        parts.push(TypeExpr {
+                            kind: TypeExprKind::Record(std::mem::take(&mut pending)),
+                            span,
+                        });
+                    }
                     if let Some(te) = s.type_expr {
                         parts.push(te);
                     }
                 }
             }
         }
-        flush(&mut pending_fields, &mut parts);
+        if !pending.is_empty() {
+            parts.push(TypeExpr {
+                kind: TypeExprKind::Record(pending),
+                span,
+            });
+        }
 
-        let inner = match parts.len() {
-            0 => TypeExpr {
-                kind: TypeExprKind::Record(Vec::new()),
-                span,
-            },
-            1 => parts.into_iter().next().unwrap(),
-            _ => TypeExpr {
-                kind: TypeExprKind::Intersection(parts),
-                span,
-            },
-        };
-        TypeDef::Alias(inner)
+        TypeDef::Alias(TypeExpr {
+            kind: TypeExprKind::Intersection(parts),
+            span,
+        })
     }
 
     fn lower_for_block(&mut self, node: &SyntaxNode, item_exported: bool) -> Option<ForBlock> {

--- a/crates/floe-core/src/parser/tests.rs
+++ b/crates/floe-core/src/parser/tests.rs
@@ -931,7 +931,7 @@ fn import_trusted_per_specifier() {
 
 #[test]
 fn type_alias() {
-    match first_item("type StringAlias = string") {
+    match first_item("typealias StringAlias = string") {
         ItemKind::TypeDecl(decl) => {
             assert_eq!(decl.name, "StringAlias");
             assert!(matches!(decl.def, TypeDef::Alias(_)));
@@ -942,7 +942,7 @@ fn type_alias() {
 
 #[test]
 fn fn_type_alias_with_labelled_params() {
-    match first_item("type Handler = (cmd: number, retries: number) -> number") {
+    match first_item("typealias Handler = (cmd: number, retries: number) -> number") {
         ItemKind::TypeDecl(decl) => match decl.def {
             TypeDef::Alias(ref te) => match &te.kind {
                 TypeExprKind::Function { params, .. } => {
@@ -962,7 +962,7 @@ fn fn_type_alias_with_labelled_params() {
 fn fn_type_alias_without_labels_still_parses() {
     // Parser still accepts unlabelled fn types — the missing-label diagnostic
     // is emitted later by the checker, not the parser.
-    match first_item("type Handler = (number) -> number") {
+    match first_item("typealias Handler = (number) -> number") {
         ItemKind::TypeDecl(decl) => match decl.def {
             TypeDef::Alias(ref te) => match &te.kind {
                 TypeExprKind::Function { params, .. } => {
@@ -973,6 +973,96 @@ fn fn_type_alias_without_labels_still_parses() {
             },
             ref other => panic!("expected alias, got {other:?}"),
         },
+        other => panic!("expected type decl, got {other:?}"),
+    }
+}
+
+#[test]
+fn type_on_structural_alias_is_error() {
+    let errs = parse("type Handler = (req: number) -> number").unwrap_err();
+    assert!(
+        errs.iter().any(|e| e.message.contains("Use `typealias`")),
+        "expected typealias suggestion, got: {:?}",
+        errs.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn typealias_on_tagged_union_is_error() {
+    let errs = parse("typealias Shape = | Circle(number) | Square(number)").unwrap_err();
+    assert!(
+        errs.iter().any(|e| e.message.contains("Use `type`")),
+        "expected type suggestion, got: {:?}",
+        errs.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn typealias_on_newtype_is_error() {
+    let errs = parse("typealias SnippetId = SnippetId(number)").unwrap_err();
+    assert!(
+        errs.iter().any(|e| e.message.contains("Use `type`")),
+        "expected type suggestion, got: {:?}",
+        errs.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn typealias_record_is_structural_alias() {
+    match first_item("typealias SnippetRow = { id: number, code: string }") {
+        ItemKind::TypeDecl(decl) => match &decl.def {
+            TypeDef::Alias(te) => match &te.kind {
+                TypeExprKind::Record(fields) => {
+                    assert_eq!(fields.len(), 2);
+                    assert_eq!(fields[0].name, "id");
+                    assert_eq!(fields[1].name, "code");
+                }
+                other => panic!("expected record type expr, got {other:?}"),
+            },
+            other => panic!("expected alias, got {other:?}"),
+        },
+        other => panic!("expected type decl, got {other:?}"),
+    }
+}
+
+#[test]
+fn typealias_record_with_spread_becomes_intersection() {
+    let item = first_item(
+        "type Base = { className: string }\n\
+         typealias Button = { ...Base, label: string }",
+    );
+    match item {
+        ItemKind::TypeDecl(_) => {}
+        other => panic!("expected type decl, got {other:?}"),
+    }
+    let program = parse_ok(
+        "type Base = { className: string }\n\
+         typealias Button = { ...Base, label: string }",
+    );
+    let ItemKind::TypeDecl(decl) = program.items.into_iter().nth(1).unwrap().kind else {
+        panic!("expected second item to be typealias")
+    };
+    match &decl.def {
+        TypeDef::Alias(te) => match &te.kind {
+            TypeExprKind::Intersection(parts) => {
+                assert_eq!(parts.len(), 2);
+                assert!(
+                    matches!(&parts[0].kind, TypeExprKind::Named { name, .. } if name == "Base")
+                );
+                assert!(matches!(&parts[1].kind, TypeExprKind::Record(fs) if fs.len() == 1));
+            }
+            other => panic!("expected intersection, got {other:?}"),
+        },
+        other => panic!("expected alias, got {other:?}"),
+    }
+}
+
+#[test]
+fn type_record_is_still_nominal() {
+    match first_item("type User = { name: string, age: number }") {
+        ItemKind::TypeDecl(decl) => {
+            assert!(matches!(decl.def, TypeDef::Record(_)));
+        }
         other => panic!("expected type decl, got {other:?}"),
     }
 }
@@ -2574,7 +2664,7 @@ fn newtype_with_named_field_is_record() {
 
 #[test]
 fn type_alias_still_parses_as_alias() {
-    let item = first_item("type Name = string");
+    let item = first_item("typealias Name = string");
     match item {
         ItemKind::TypeDecl(decl) => {
             assert_eq!(decl.name, "Name");

--- a/crates/floe-core/src/parser/tests.rs
+++ b/crates/floe-core/src/parser/tests.rs
@@ -1027,14 +1027,6 @@ fn typealias_record_is_structural_alias() {
 
 #[test]
 fn typealias_record_with_spread_becomes_intersection() {
-    let item = first_item(
-        "type Base = { className: string }\n\
-         typealias Button = { ...Base, label: string }",
-    );
-    match item {
-        ItemKind::TypeDecl(_) => {}
-        other => panic!("expected type decl, got {other:?}"),
-    }
     let program = parse_ok(
         "type Base = { className: string }\n\
          typealias Button = { ...Base, label: string }",

--- a/crates/floe-core/src/syntax.rs
+++ b/crates/floe-core/src/syntax.rs
@@ -26,6 +26,7 @@ pub enum SyntaxKind {
     KW_RETURN,
     KW_MATCH,
     KW_TYPE,
+    KW_TYPEALIAS,
     KW_OPAQUE,
     KW_FOR,
     KW_SELF,
@@ -217,6 +218,7 @@ impl SyntaxKind {
                 | Self::KW_FOR
                 | Self::KW_FROM
                 | Self::KW_TYPE
+                | Self::KW_TYPEALIAS
                 | Self::KW_EXPORT
                 | Self::KW_IMPORT
                 | Self::KW_LET
@@ -314,6 +316,7 @@ pub fn token_kind_to_syntax(kind: &TokenKind) -> SyntaxKind {
         TokenKind::From => SyntaxKind::KW_FROM,
         TokenKind::Match => SyntaxKind::KW_MATCH,
         TokenKind::Type => SyntaxKind::KW_TYPE,
+        TokenKind::Typealias => SyntaxKind::KW_TYPEALIAS,
         TokenKind::Opaque => SyntaxKind::KW_OPAQUE,
         TokenKind::For => SyntaxKind::KW_FOR,
         TokenKind::SelfKw => SyntaxKind::KW_SELF,

--- a/docs/design.md
+++ b/docs/design.md
@@ -127,8 +127,9 @@ The last expression in a block is the return value — no `return` keyword.
 | Opaque types | `opaque type HashedPw = HashedPw(string)` | `string`, but only the defining module can create/read |
 | Tagged sums | `type Route = Home \| Profile(string) \| Settings { tab: string }` | discriminated union. `(Type, ...)` variants are positional; `{ name: Type, ... }` variants are named. Mixing the two forms in one variant is a parse error. Leading `\|` optional. |
 | String literal unions | `type Method = OneOf<"GET", "POST", "PUT">` | `"GET" \| "POST" \| "PUT"` (structural — for npm interop) |
-| Intersections | `type AdminCard = Intersect<ButtonProps, { role: "admin" }>` | `ButtonProps & { role: "admin" }` (structural) |
-| Function-type alias | `type Handler = (req: Request) => Response` | `type Handler = (req: Request) => Response` (parameter labels are optional documentation; LSP hover surfaces them but they never affect assignability) |
+| Structural record alias | `typealias SnippetRow = { id: number, code: string }` | `type SnippetRow = { id: number; code: string }` (structural — matches any record of that shape without a nominal wrap) |
+| Intersections | `typealias AdminCard = ButtonProps & { role: "admin" }` | `ButtonProps & { role: "admin" }` (structural; `typealias` is required because the RHS has no nominal identity) |
+| Function-type alias | `typealias Handler = (req: Request) => Response` | `type Handler = (req: Request) => Response` (structural — `typealias` is required; parameter labels are optional documentation and never affect assignability) |
 | Nested sums | `type ApiError = Network(NetworkError) \| NotFound` | nested discriminated union (compiler generates tags) |
 | Multi-depth match | `Network(Timeout(ms)) -> ...` | nested if/else with tag checks |
 | Type constructors | `User(name: "Ryan", email: e)` | `{ name: "Ryan", email: e }` (compiler adds tags for unions) |
@@ -577,19 +578,29 @@ let partial = UpdateUser(name: Value("Ryan"))
 
 ### Type System — Every type is `type X = ...`
 
-`type X = RHS`. The RHS picks the kind; there is no legacy form.
+Floe has two keywords that look almost the same but mean very different things:
 
-| RHS shape | Kind |
-|---|---|
-| `{ field: T, ... }` | Record |
-| `A \| B \| ...` (constructor names) | Nominal tagged sum — leading `\|` optional |
-| `Name(T)` | Newtype |
-| `(Args) => Ret` | Structural function-type alias |
-| `OneOf<"a", "b", ...>` | Structural string-literal union (TS `"a" \| "b"`) |
-| `Intersect<A, B, ...>` | Structural intersection (TS `A & B`) |
-| `Partial<T>` / `Pick<T, K>` / `Omit<T, K>` / `ReturnType<...>` / ... | TS utility alias (pass-through) |
+| Keyword | Meaning | When to use |
+|---|---|---|
+| `type X = ...` | Declares a **nominal** type — `X` is a brand-new identity, distinct even from something with the same shape | Records, tagged sums, newtypes |
+| `typealias X = ...` | Names an existing **structural** shape — `X` and the RHS are interchangeable | Function types, generic applications, intersections, `typeof`, or a structural view over a record shape |
 
-`|` at the top level of a `type` declaration is **always nominal** — it declares fresh constructors. Structural string unions must use `OneOf<>`.
+The RHS picks what is allowed under each keyword:
+
+| RHS shape | `type` | `typealias` |
+|---|---|---|
+| `{ field: T, ... }` | Nominal Record (default) | Structural alias over the shape |
+| `A \| B \| ...` (constructor names) | Nominal tagged sum | **Error** — use `type` |
+| `Name(T)` | Newtype | **Error** — use `type` |
+| `(Args) -> Ret` | **Error** — use `typealias` | Structural function-type alias |
+| `"a" \| "b" \| ...` | String-literal union (nominal-ish, codegens to TS union) | Same codegen, either keyword is accepted |
+| `A & B` | **Error** — use `typealias` | Structural intersection |
+| `Partial<T>` / `ReturnType<...>` / any generic application | **Error** — use `typealias` | TS utility alias (pass-through) |
+| `typeof someValue` | **Error** — use `typealias` | Structural typeof alias |
+
+`opaque type X = RHS` is a third form: it is nominal on the outside but wraps an arbitrary structural shape on the inside, so `opaque type HashedPw = string` is valid even though bare `type HashedPw = string` is not. The `opaque` keyword is the explicit way to give a structural shape nominal identity.
+
+`|` at the top level of a `type` declaration is **always nominal** — it declares fresh constructors. Structural string unions can still be written inline (`"GET" | "POST"`) and are accepted under either keyword.
 
 ```floe
 // Record type
@@ -635,17 +646,26 @@ type Route =
 // Inline form also works
 type Filter = All | Active | Completed
 
-// Structural string-literal union (for npm interop / config values)
-type HttpMethod = OneOf<"GET", "POST", "PUT", "DELETE">
+// String-literal union (for npm interop / config values) — either keyword works
+type HttpMethod = "GET" | "POST" | "PUT" | "DELETE"
 
-// Structural intersection
-type AdminCard = Intersect<ButtonProps, { role: "admin" }>
+// Structural intersection — `typealias` is required because the RHS has
+// no nominal identity of its own
+typealias AdminCard = ButtonProps & { role: "admin" }
 
-// Function-type alias — structural. Parameter labels are optional
-// documentation; LSP hover surfaces them and they never influence
+// Function-type alias — structural; requires `typealias`. Parameter labels are
+// optional documentation; LSP hover surfaces them and they never influence
 // assignability.
-type Handler = (req: Request) -> Promise<Response>
-type Predicate<T> = (T) -> boolean
+typealias Handler = (req: Request) -> Promise<Response>
+typealias Predicate<T> = (T) -> boolean
+
+// Structural record alias — matches any record with the same fields
+// without paying for a nominal wrap. Useful for naming a TS-interop shape.
+typealias SnippetRow = {
+    id: number,
+    code: string,
+    content: string,
+}
 
 // Sums can contain sums — nest as deep as you want
 type NetworkError =

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -61,16 +61,24 @@ let names: Array<string> = ["a", "b", "c"]
 
 ## Types
 
-Every type declaration starts with `type Name = ...`. The RHS picks the kind:
+Floe has two type-declaration keywords:
 
-- `{ ... }` — record
-- `Variant | Variant | ...` — nominal tagged sum (leading `|` optional)
-- `Name(T)` — newtype (single-value wrapper)
-- `(T, ...) -> Ret` or `(label: T, ...) -> Ret` — structural function-type alias; parameter labels are optional documentation that LSP hover surfaces and do not affect structural assignability
-- `OneOf<"a", "b">` / `Intersect<A, B>` — structural string-literal union / intersection
-- `Partial<T>` / `Pick<T, K>` / `Omit<T, K>` / `ReturnType<...>` / ... — TS utility aliases
+- `type Name = RHS` — **nominal**. `Name` is a distinct new type. Use for records, tagged sums, newtypes.
+- `typealias Name = RHS` — **structural**. `Name` is just another name for the RHS shape. Use for function types, generic applications, intersections, `typeof`, or naming a structural record shape.
 
-A bare `|` of string literals (e.g. `type M = "a" | "b"`) is **E201** — use `OneOf<"a", "b">` instead.
+The RHS picks what is legal under each keyword:
+
+- `{ ... }` — record. `type` → nominal; `typealias` → structural shape alias.
+- `Variant | Variant | ...` — nominal tagged sum. **Requires `type`** (leading `|` optional).
+- `Name(T)` — newtype (single-value wrapper). **Requires `type`**.
+- `(T, ...) -> Ret` — structural function-type alias. **Requires `typealias`**. Parameter labels are optional documentation (LSP hover surfaces them; they never affect assignability).
+- `A & B` — structural intersection. **Requires `typealias`**.
+- `typeof someValue` — structural typeof alias. **Requires `typealias`**.
+- `Partial<T>` / `Pick<T, K>` / `Omit<T, K>` / `ReturnType<...>` / any generic application — TS utility alias. **Requires `typealias`**.
+- `"a" | "b" | ...` — string-literal union. Either keyword is accepted (same codegen).
+
+`opaque type Name = RHS` is a special form: nominal on the outside, wrapping an arbitrary structural shape inside — so `opaque type HashedPw = string` is valid even though bare `type HashedPw = string` is not.
+
 An inline record in a function signature (e.g. `fn f(x: { a: T })`) is **E202** — name the type.
 
 ```floe
@@ -145,25 +153,33 @@ type A = { x: number }
 type B = { y: string }
 type C = { ...A, ...B, z: boolean }
 
-// Function-type alias (structural — just a type). Labels on parameters
-// are optional documentation and do not affect assignability.
-type Handler = (req: Request) -> Promise<Response>
-type Predicate<T> = (T) -> boolean
+// Function-type alias — structural, so it uses `typealias`. Labels on
+// parameters are optional documentation and do not affect assignability.
+typealias Handler = (req: Request) -> Promise<Response>
+typealias Predicate<T> = (T) -> boolean
 
 // Opaque types (only defining module can create/read)
 opaque type HashedPassword = HashedPassword(string)
 
 // ── Structural string-literal unions / intersections ──
 
-// String-literal union via OneOf<>
-type HttpMethod = OneOf<"GET", "POST", "PUT", "DELETE">
+// String-literal union — either keyword works
+type HttpMethod = "GET" | "POST" | "PUT" | "DELETE"
 
-// Intersection via Intersect<>
-type AdminCard = Intersect<ButtonProps, { role: "admin" }>
+// Intersection — structural, so `typealias`
+typealias AdminCard = ButtonProps & { role: "admin" }
+
+// Structural record alias — names a shape without a nominal wrap,
+// so records coming from TS interop assign to it by shape
+typealias SnippetRow = {
+    id: number,
+    code: string,
+    content: string,
+}
 
 // String literal type arguments (for npm interop)
 import { ComponentProps } from "react"
-type DivProps = ComponentProps<"div">
+typealias DivProps = ComponentProps<"div">
 
 // Spread with generic types and typeof (npm interop)
 import { tv, VariantProps } from "tailwind-variants"
@@ -180,11 +196,11 @@ type Props = {
 // Record, Extract, Exclude, InstanceType,
 // Uppercase, Lowercase, Capitalize, Uncapitalize
 let createDb(id: string) -> string = { id }
-type Database = ReturnType<typeof createDb>
-type DbArgs = Parameters<typeof createDb>
+typealias Database = ReturnType<typeof createDb>
+typealias DbArgs = Parameters<typeof createDb>
 
-type PartialUser = Partial<User>
-type ReadOnlyUser = Readonly<User>
+typealias PartialUser = Partial<User>
+typealias ReadOnlyUser = Readonly<User>
 
 // Tuples
 let point: (number, number) = (10, 20)
@@ -306,7 +322,7 @@ match status {
 }
 
 // Match on string literal union (exhaustive)
-type HttpMethod = OneOf<"GET", "POST", "PUT", "DELETE">
+typealias HttpMethod = OneOf<"GET", "POST", "PUT", "DELETE">
 match method {
     "GET" -> "fetching",
     "POST" -> "creating",

--- a/docs/site/src/content/docs/docs/guide/functions.md
+++ b/docs/site/src/content/docs/docs/guide/functions.md
@@ -132,9 +132,9 @@ let double(x: number) -> number = { x * 2 }
 Use `->` to describe function types:
 
 ```floe
-type Transform = (string) -> number
-type Predicate = (Todo) -> boolean
-type Callback = () -> ()
+typealias Transform = (string) -> number
+typealias Predicate = (Todo) -> boolean
+typealias Callback = () -> ()
 ```
 
 ### Async Functions

--- a/docs/site/src/content/docs/docs/guide/types.md
+++ b/docs/site/src/content/docs/docs/guide/types.md
@@ -12,22 +12,24 @@ let active: boolean = true
 
 ## Declaring Types
 
-Every type declaration looks like this:
+Floe has two type-declaration keywords:
 
-```floe
-type Name = RHS
-```
+- `type` declares a **nominal** type — a brand-new identity distinct from anything else. Use it for records, tagged sums, and newtypes.
+- `typealias` names an existing **structural** shape. The alias and its RHS are interchangeable; nothing new is created. Use it for function types, generic applications, intersections, `typeof`, and shape-only record aliases.
 
-The RHS picks what kind of type you get:
+The RHS shape determines what you can use under each keyword:
 
-| RHS | Kind |
-|---|---|
-| `{ ... }` | Record |
-| `A \| B \| ...` | Tagged sum |
-| `Name(T)` | Newtype |
-| `(T, ...) => Ret` or `(label: T, ...) => Ret` | Function-type alias (parameter labels optional) |
-| `OneOf<"a", "b">` | Structural string-literal union |
-| `Intersect<A, B>` | Structural intersection |
+| RHS | `type` | `typealias` |
+|---|---|---|
+| `{ field: T, ... }` | Nominal record | Structural record alias |
+| `A \| B \| ...` constructors | Tagged sum | Error — tagged unions need nominal identity |
+| `Name(T)` | Newtype | Error — newtypes need nominal identity |
+| `(T, ...) -> Ret` | Error — function types have no nominal identity | Function-type alias |
+| `A & B` | Error — intersections are structural | Structural intersection |
+| `typeof value` | Error — `typeof` is structural | Structural `typeof` alias |
+| `Partial<T>` / `ReturnType<...>` / any generic | Error — generic applications are structural | TS utility alias (pass-through) |
+
+If you need nominal identity around a structural shape (e.g. a `HashedPassword` wrapping a `string`), use `opaque type` — it is the explicit way to brand a structural type as nominal.
 
 ## Records
 
@@ -289,8 +291,8 @@ opaque type Email = Email(string)
 Name a function type to use it in records or generics. Parameter labels are optional documentation:
 
 ```floe
-type Handler = (req: Request) -> Promise<Response>
-type Predicate<T> = (T) -> boolean
+typealias Handler = (req: Request) -> Promise<Response>
+typealias Predicate<T> = (T) -> boolean
 
 type Button = {
   label: string,
@@ -322,8 +324,8 @@ Tuples compile to TypeScript readonly tuples: `(number, string)` becomes `readon
 When bridging to TypeScript libraries, two utility types cover the structural operators TS uses that have no nominal equivalent in Floe:
 
 ```floe
-type HttpMethod = OneOf<"GET", "POST", "PUT", "DELETE">
-type CardProps = Intersect<VariantProps<typeof cardVariants>, { className: string }>
+typealias HttpMethod = OneOf<"GET", "POST", "PUT", "DELETE">
+typealias CardProps = Intersect<VariantProps<typeof cardVariants>, { className: string }>
 ```
 
 - `OneOf<A, B, ...>` compiles to `A | B | ...`
@@ -332,8 +334,8 @@ type CardProps = Intersect<VariantProps<typeof cardVariants>, { className: strin
 Alias existing TypeScript types with plain `=`:
 
 ```floe
-type DivProps = ComponentProps<"div">
-type PartialUser = Partial<User>
+typealias DivProps = ComponentProps<"div">
+typealias PartialUser = Partial<User>
 ```
 
 String-literal unions work with exhaustive matching:

--- a/docs/site/src/content/docs/docs/guide/typescript-interop.md
+++ b/docs/site/src/content/docs/docs/guide/typescript-interop.md
@@ -80,7 +80,7 @@ type Method = "GET" | "POST" | "PUT" | "DELETE";
 In Floe, wrap them in `OneOf<>`:
 
 ```floe
-type HttpMethod = OneOf<"GET", "POST", "PUT", "DELETE">
+typealias HttpMethod = OneOf<"GET", "POST", "PUT", "DELETE">
 
 let describe(method: HttpMethod) -> string = {
     match method {
@@ -103,9 +103,9 @@ Alias TypeScript types with plain `=`:
 ```floe
 import { ComponentProps } from "react"
 
-type DivProps = ComponentProps<"div">
-type PartialUser = Partial<User>
-type UserKeys = Pick<User, OneOf<"name", "email">>
+typealias DivProps = ComponentProps<"div">
+typealias PartialUser = Partial<User>
+typealias UserKeys = Pick<User, OneOf<"name", "email">>
 ```
 
 ### Intersections
@@ -116,7 +116,7 @@ Combine TypeScript types with `Intersect<>`:
 import { tv, VariantProps } from "tailwind-variants"
 
 let cardVariants = tv({ base: "rounded-xl", variants: { size: { sm: "p-2" } } })
-type CardProps = Intersect<VariantProps<typeof cardVariants>, { className: string }>
+typealias CardProps = Intersect<VariantProps<typeof cardVariants>, { className: string }>
 ```
 
 For Floe-native record composition, prefer `...Spread` in a `{ }` record body:
@@ -135,7 +135,7 @@ Use `->` for function types. Parameter labels are optional documentation:
 ```floe
 import { Request, Response } from "express"
 
-type Handler = (req: Request, res: Response) -> Promise<()>
+typealias Handler = (req: Request, res: Response) -> Promise<()>
 ```
 
 ## Nullable and optional type conversion

--- a/docs/site/src/content/docs/docs/reference/syntax.md
+++ b/docs/site/src/content/docs/docs/reference/syntax.md
@@ -75,10 +75,10 @@ type OrderId = OrderId(number)
 // String literal union (for npm interop)
 type HttpMethod = "GET" | "POST" | "PUT" | "DELETE"
 
-// Alias
-type Name = string
+// Structural alias
+typealias Name = string
 
-// Newtype
+// Newtype (nominal)
 type UserId = UserId(string)
 
 // Opaque

--- a/docs/site/src/content/docs/docs/reference/types.md
+++ b/docs/site/src/content/docs/docs/reference/types.md
@@ -25,19 +25,28 @@ title: Types Reference
 
 ## Type Declarations
 
-Every type declaration starts with `type Name = RHS`. The shape of the RHS picks the kind:
+Floe has two type-declaration keywords:
 
-| RHS | Kind |
-|---|---|
-| `{ field: T, ... }` | Record |
-| `A \| B \| ...` (constructors) | Tagged sum (nominal — declares fresh constructors) |
-| `Name(T)` | Newtype (single-value wrapper) |
-| `(T, ...) => Ret` or `(label: T, ...) => Ret` | Function-type alias (structural; parameter labels optional, documentation only) |
-| `OneOf<"a", "b", ...>` | Structural string-literal union |
-| `Intersect<A, B, ...>` | Structural intersection |
-| `Partial<T>` / `Pick<T, K>` / `Omit<T, K>` / `ReturnType<...>` / ... | TS utility alias (pass-through) |
+- `type Name = RHS` — **nominal** declaration. `Name` is a new, distinct identity.
+- `typealias Name = RHS` — **structural** alias. `Name` and `RHS` are interchangeable.
 
-`|` at the top level of a `type` declaration is **always nominal**. For a structural union of string literals, use `OneOf<>`.
+The RHS shape determines which keyword is allowed:
+
+| RHS | `type` | `typealias` |
+|---|---|---|
+| `{ field: T, ... }` | Nominal record (default) | Structural alias over the shape |
+| `{ ...Other, foo: T }` | Nominal record with spread | Structural intersection (`Other & { foo: T }`) |
+| `A \| B \| ...` (constructors) | Tagged sum | **Error** — requires nominal identity |
+| `Name(T)` | Newtype | **Error** — requires nominal identity |
+| `(T, ...) -> Ret` | **Error** — no nominal identity | Structural function-type alias |
+| `A & B` | **Error** — no nominal identity | Structural intersection |
+| `typeof value` | **Error** — no nominal identity | Structural typeof alias |
+| `Partial<T>` / `ReturnType<...>` / generic application | **Error** — no nominal identity | TS utility alias (pass-through) |
+| `"a" \| "b" \| ...` | String-literal union | String-literal union (same codegen) |
+
+`opaque type Name = RHS` is nominal on the outside but wraps an arbitrary structural shape inside. Use it when you need to give a structural type nominal identity explicitly (e.g. `opaque type HashedPw = string`).
+
+`|` at the top level of a `type` declaration is **always nominal** — it declares fresh constructors.
 
 ## Records
 
@@ -78,7 +87,7 @@ let cfg = Config(baseUrl: "https://api.com")
 
 ### Record Composition
 
-Include fields from other record types using `...` spread:
+Include fields from other record types using `...` spread. For structural prop shapes that don't need their own nominal identity, use `typealias` — the spread becomes a TypeScript intersection:
 
 ```floe
 type BaseProps = {
@@ -86,19 +95,21 @@ type BaseProps = {
   disabled: boolean,
 }
 
-type ButtonProps = {
+typealias ButtonProps = {
   ...BaseProps,
   onClick: () -> (),
   label: string,
 }
 ```
 
-Compiles to a TypeScript intersection:
+Compiles to:
 
 ```typescript
 type BaseProps = { className: string; disabled: boolean };
 type ButtonProps = BaseProps & { onClick: () => void; label: string };
 ```
+
+If `ButtonProps` had used `type` instead of `typealias`, it would still compile to the same TypeScript but would require explicit construction (`ButtonProps(...)`) at the Floe level — `typealias` is the right choice when you just want a structural shape, which is typical for UI prop types.
 
 Spreads work with generic types, `typeof`, and npm imports:
 
@@ -107,7 +118,7 @@ import { tv, VariantProps } from "tailwind-variants"
 
 let cardVariants = tv({ base: "rounded-xl", variants: { padding: { sm: "p-4" } } })
 
-type CardProps = {
+typealias CardProps = {
   ...VariantProps<typeof cardVariants>,
   className: string,
 }
@@ -164,9 +175,9 @@ Only code in the module that defines `Email` can construct or destructure it. Ot
 Structural function types. Use `->` between the parameter list and return type. Parameter labels are optional documentation:
 
 ```floe
-type Handler = (req: Request) -> Promise<Response>
-type Predicate<T> = (T) -> boolean
-type Reducer<S, A> = (state: S, action: A) -> S
+typealias Handler = (req: Request) -> Promise<Response>
+typealias Predicate<T> = (T) -> boolean
+typealias Reducer<S, A> = (state: S, action: A) -> S
 ```
 
 Labels never affect structural assignability — `(x: Int) -> Int` is interchangeable with `(y: Int) -> Int` and with the unlabelled `(Int) -> Int`. Use them when the name carries meaning (DDD-style workflow types, multi-param callbacks); skip them when the position is obvious. LSP hover surfaces whichever form you wrote.
@@ -176,7 +187,7 @@ Labels never affect structural assignability — `(x: Int) -> Int` is interchang
 For npm interop and config values:
 
 ```floe
-type HttpMethod = OneOf<"GET", "POST", "PUT", "DELETE">
+typealias HttpMethod = OneOf<"GET", "POST", "PUT", "DELETE">
 ```
 
 Compiles to `type HttpMethod = "GET" | "POST" | "PUT" | "DELETE"`.
@@ -199,8 +210,8 @@ Exhaustiveness is checked. Writing `type M = "a" | "b"` with a bare `|` is a com
 Combine types structurally:
 
 ```floe
-type AdminCard = Intersect<ButtonProps, { role: "admin" }>
-type CardProps = Intersect<VariantProps<typeof variants>, { className: string }>
+typealias AdminCard = Intersect<ButtonProps, { role: "admin" }>
+typealias CardProps = Intersect<VariantProps<typeof variants>, { className: string }>
 ```
 
 Compiles to `A & B`. For Floe-native record composition, prefer `...Spread` in a `{ }` record body.
@@ -208,9 +219,9 @@ Compiles to `A & B`. For Floe-native record composition, prefer `...Spread` in a
 ## Type Aliases (TS utilities)
 
 ```floe
-type DivProps = ComponentProps<"div">
-type PartialUser = Partial<User>
-type UserKeys = Pick<User, OneOf<"name", "email">>
+typealias DivProps = ComponentProps<"div">
+typealias PartialUser = Partial<User>
+typealias UserKeys = Pick<User, OneOf<"name", "email">>
 ```
 
 Recognized utilities pass through unchanged: `OneOf`, `Intersect`, `Partial`, `Required`, `Readonly`, `Pick`, `Omit`, `NonNullable`, `Record`, `Extract`, `Exclude`, `ReturnType`, `Parameters`, `ConstructorParameters`, `Awaited`, `InstanceType`, `Uppercase`, `Lowercase`, `Capitalize`, `Uncapitalize`.

--- a/editors/neovim/queries/floe/highlights.scm
+++ b/editors/neovim/queries/floe/highlights.scm
@@ -3,6 +3,7 @@
 "fn" @keyword
 "async" @keyword
 "type" @keyword
+"typealias" @keyword
 "match" @keyword
 "return" @keyword
 "import" @keyword

--- a/editors/tree-sitter-floe/grammar.js
+++ b/editors/tree-sitter-floe/grammar.js
@@ -182,7 +182,7 @@ module.exports = grammar({
     type_declaration: ($) =>
       seq(
         optional("opaque"),
-        "type",
+        choice("type", "typealias"),
         field("name", $.type_identifier),
         optional($.type_parameters),
         "=",

--- a/editors/tree-sitter-floe/queries/highlights.scm
+++ b/editors/tree-sitter-floe/queries/highlights.scm
@@ -3,6 +3,7 @@
 "fn" @keyword
 "async" @keyword
 "type" @keyword
+"typealias" @keyword
 "match" @keyword
 "return" @keyword
 "import" @keyword

--- a/editors/vscode/snippets/floe.json
+++ b/editors/vscode/snippets/floe.json
@@ -89,6 +89,13 @@
     ],
     "description": "Union type declaration"
   },
+  "Typealias": {
+    "prefix": "typealias",
+    "body": [
+      "typealias ${1:Name} = ${0:Type}"
+    ],
+    "description": "Structural type alias"
+  },
   "React Component": {
     "prefix": "comp",
     "body": [

--- a/editors/vscode/syntaxes/floe.tmLanguage.json
+++ b/editors/vscode/syntaxes/floe.tmLanguage.json
@@ -116,7 +116,7 @@
       "patterns": [
         {
           "name": "storage.type.floe",
-          "match": "\\b(let|fn|type)\\b"
+          "match": "\\b(let|fn|type|typealias)\\b"
         }
       ]
     },

--- a/examples/store/src/types.fl
+++ b/examples/store/src/types.fl
@@ -107,6 +107,19 @@ export type ShippingUpdate = {
     address: Settable<string> = Unchanged,
 }
 
+// ── Structural aliases ─────────────────────────────────
+
+// `typealias` names a structural shape. Compared to `type`, no new nominal
+// identity is created — any record with these fields can be passed in as a
+// `ProductSummary`, which is handy when consuming data shapes from the API
+// without wrapping them in a nominal constructor.
+
+export typealias ProductSummary = {
+    id: ProductId,
+    title: string,
+    price: number,
+}
+
 // ── Traits ─────────────────────────────────────────────
 
 export trait Display {


### PR DESCRIPTION
## Summary

- Introduce `typealias` as a dedicated keyword for structural type aliases, leaving `type` as the nominal declaration keyword.
- `type` now rejects RHS forms that have no nominal identity (function types, generic applications, intersections, `typeof`) with a diagnostic that points at `typealias`. `typealias` rejects tagged unions and newtypes with the reverse diagnostic. Records are ambiguous — `type` gives the nominal form, `typealias` gives the structural form.
- `typealias X = { ...Other, foo: T }` lowers to an intersection (`Other & { foo: T }`) so structural record composition works the same way nominal composition does.
- `opaque type` is exempt from the nominal-only rule — it is the explicit way to give a structural shape a nominal identity.
- Wired through the full toolchain: lexer, CST parser, lowering validation, formatter, tree-sitter / VSCode / Neovim grammars, design doc, `llms.txt`, site guides/reference, and added a structural-alias example in the `store` example app.

Closes #1313.

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `python3 -m pytest tests/lsp/ --floe-bin=./target/debug/floe` (260 passed)
- [x] `floe fmt --check`, `floe check`, `floe build` on both example apps
- [x] `floe-doc-check docs/site/ docs/llms.txt README.md`
- [x] New parser tests cover the Case 1 (`type` + structural) and Case 2 (`typealias` + nominal) error messages, the structural record alias, the `typealias` record-with-spread → intersection lowering, and the regression guard that `type` records stay nominal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)