### PR TITLE
fix: [#1316] reject `for X` import specifier when X is not in the module

### DIFF
--- a/crates/floe-core/src/checker/imports.rs
+++ b/crates/floe-core/src/checker/imports.rs
@@ -213,19 +213,43 @@ impl Checker {
             && let Some(ref resolved) = resolved
         {
             for for_spec in &decl.for_specifiers {
-                // Find all for-blocks in the resolved module that match this type
+                let mut attached = false;
                 for block in &resolved.for_blocks {
                     let base_type_name = match &block.type_name.kind {
                         TypeExprKind::Named { name, .. } => name.clone(),
                         _ => continue,
                     };
                     if base_type_name == for_spec.type_name {
+                        attached = true;
                         self.check_for_block_imported_with_source(block, &decl.source);
-                        // Mark the for-import functions as used (suppress unused import)
                         for func in &block.functions {
                             self.unused.used_names.insert(func.name.clone());
                         }
                     }
+                }
+                // `for X` is legal if X is a trait or type declared in the
+                // module, even when the module attaches no for-block to it —
+                // callers still need to name X to implement the trait locally
+                // or to import the type's methods once they exist.
+                let exists = attached
+                    || resolved
+                        .trait_decls
+                        .iter()
+                        .any(|t| t.name == for_spec.type_name)
+                    || resolved
+                        .type_decls
+                        .iter()
+                        .any(|t| t.name == for_spec.type_name);
+                if !exists {
+                    self.emit_error(
+                        format!(
+                            "module \"{}\" has no export named `{}`",
+                            decl.source, for_spec.type_name
+                        ),
+                        for_spec.span,
+                        ErrorCode::ExportNotFound,
+                        "not found in module",
+                    );
                 }
             }
         }

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -3057,6 +3057,32 @@ for User: Display {
     );
 }
 
+#[test]
+fn for_import_of_missing_type_errors() {
+    use std::collections::HashMap;
+
+    let mut imports = HashMap::new();
+    imports.insert("./types".to_string(), resolved_module_with_display_trait());
+
+    let source = r#"
+import { User, for PeePeePooPoo } from "./types"
+"#;
+
+    let program = Parser::new(source)
+        .parse_program()
+        .expect("parse should succeed");
+    let diags = Checker::with_imports(imports).check(&program);
+    assert!(
+        has_error(&diags, ErrorCode::ExportNotFound),
+        "expected ExportNotFound for unknown `for` type, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    assert!(has_error_containing(
+        &diags,
+        "has no export named `PeePeePooPoo`"
+    ));
+}
+
 // ── Bug: Pipe with stdlib member access returns Unknown ─────
 // `x |> String.length` should infer as number, not unknown
 


### PR DESCRIPTION
## Summary

- `import { Snippet, for PeePeePooPoo } from \"./snippet\"` used to parse and check without error — the `for` resolver mangled `PeePeePooPoo__*` into scope without ever verifying that `PeePeePooPoo` existed in the target module.
- Now the checker looks `X` up against the target module's type decls, trait decls, and for-blocks and emits the standard `module \"...\" has no export named \`X\`` (E044) diagnostic when none match.
- `for X` remains legal when `X` is a type or trait that exists but has no attached for-block, so local trait-impl patterns (`for MyType: Display { ... }`) keep working.

Closes #1316.

## Test plan

- [x] New unit test `for_import_of_missing_type_errors` in `crates/floe-core/src/checker/tests.rs` exercises the `for PeePeePooPoo` case.
- [x] `cargo test --workspace` (1571 pass)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `pytest tests/lsp/` (260 pass)
- [x] `floe check` on both example apps still passes (exercises `for Display` against an imported trait).

🤖 Generated with [Claude Code](https://claude.com/claude-code)