### PR TITLE
fix: [#1278] keep short union types on one line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "floe"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ariadne",
  "bincode",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "floe-doc-check"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "floe-lsp"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "floe-core",
  "insta",
@@ -355,14 +355,14 @@ dependencies = [
 
 [[package]]
 name = "floe-test-helpers"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "floe-core",
 ]
 
 [[package]]
 name = "floe-wasm"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "floe-core",
  "serde",

--- a/crates/floe-core/src/formatter.rs
+++ b/crates/floe-core/src/formatter.rs
@@ -10,7 +10,10 @@ use crate::parse::extra::{ModuleExtra, SrcSpan};
 use crate::pretty::{self, Document};
 use crate::syntax::{SyntaxKind, SyntaxNode};
 
-const MAX_WIDTH: usize = 100;
+/// Column budget the formatter targets. Exposed so other crates (the LSP
+/// hover renderer in particular) can decide inline-vs-split with the same
+/// threshold, instead of keeping a parallel number in sync by convention.
+pub const MAX_WIDTH: usize = 100;
 
 /// Format Floe source code. Returns `None` if the file has parse errors.
 pub fn format(source: &str) -> Option<String> {

--- a/crates/floe-core/src/formatter/items.rs
+++ b/crates/floe-core/src/formatter/items.rs
@@ -488,14 +488,23 @@ impl Formatter<'_> {
             .filter(|c| c.kind() == SyntaxKind::VARIANT)
             .collect();
 
+        // Before variant 0: broken emits "\n    | ", inline emits "".
+        // Between variants: broken emits "\n    | ", inline emits " | ".
+        // `break_` handles the newline/space swap; `if_broken` adds the
+        // leading `| ` only in broken mode (break_ can't emit text after
+        // the newline).
         let mut inner = Vec::new();
-        for variant in &variants {
-            inner.push(pretty::line());
-            inner.push(pretty::str("| "));
+        for (i, variant) in variants.iter().enumerate() {
+            if i == 0 {
+                inner.push(pretty::break_("", ""));
+            } else {
+                inner.push(pretty::break_("", " | "));
+            }
+            inner.push(pretty::if_broken(pretty::str("| "), pretty::nil()));
             inner.push(self.fmt_variant(variant));
         }
 
-        pretty::nest(4, pretty::concat(inner))
+        pretty::group(pretty::nest(4, pretty::concat(inner)))
     }
 
     fn fmt_variant(&mut self, node: &SyntaxNode) -> Document {

--- a/crates/floe-core/src/formatter/tests.rs
+++ b/crates/floe-core/src/formatter/tests.rs
@@ -56,11 +56,40 @@ fn format_type_record() {
 }
 
 #[test]
-fn format_type_union() {
+fn format_short_union_stays_on_one_line() {
     assert_fmt(
         "type Route = |Home|Profile{id:string}|NotFound",
-        "type Route =\n    | Home\n    | Profile { id: string }\n    | NotFound",
+        "type Route = Home | Profile { id: string } | NotFound",
     );
+}
+
+#[test]
+fn format_single_variant_newtype_stays_on_one_line() {
+    assert_fmt(
+        "export type SnippetCode =\n    | SnippetCode(string)",
+        "export type SnippetCode = SnippetCode(string)",
+    );
+}
+
+#[test]
+fn format_enum_like_union_stays_on_one_line() {
+    assert_fmt(
+        "export type ExpiryOption = ONE_HOUR | ONE_DAY | ONE_WEEK",
+        "export type ExpiryOption = ONE_HOUR | ONE_DAY | ONE_WEEK",
+    );
+}
+
+#[test]
+fn format_long_union_splits_to_one_variant_per_line() {
+    // Over the 100-column threshold: every variant on its own `|` line.
+    let input = "type Shape = Circle(number) | Rectangle(number, number) | \
+                 Triangle(number, number, number) | Trapezoid(number, number, number, number)";
+    let expected = "type Shape =\n    \
+                    | Circle(number)\n    \
+                    | Rectangle(number, number)\n    \
+                    | Triangle(number, number, number)\n    \
+                    | Trapezoid(number, number, number, number)";
+    assert_fmt(input, expected);
 }
 
 #[test]

--- a/crates/floe-core/src/formatter/tests.rs
+++ b/crates/floe-core/src/formatter/tests.rs
@@ -93,6 +93,33 @@ fn format_long_union_splits_to_one_variant_per_line() {
 }
 
 #[test]
+fn format_union_exactly_at_column_boundary_stays_inline() {
+    // `type Roo = A | B | ... | W` is exactly 100 chars. At the boundary
+    // the width check uses `<=`, so it should stay on one line.
+    let input = "type Roo = A | B | C | D | E | F | G | H | I | J | K | L | M | \
+                 N | O | P | Q | R | S | T | U | V | W";
+    let expected = "type Roo = A | B | C | D | E | F | G | H | I | J | K | L | M | \
+                    N | O | P | Q | R | S | T | U | V | W";
+    assert_eq!(input.len(), 100);
+    assert_fmt(input, expected);
+}
+
+#[test]
+fn format_union_one_char_over_boundary_splits() {
+    // Same variants, name padded by one character — now 101 chars total,
+    // one over the budget, so the whole declaration splits.
+    let input = "type Root = A | B | C | D | E | F | G | H | I | J | K | L | M | \
+                 N | O | P | Q | R | S | T | U | V | W";
+    assert_eq!(input.len(), 101);
+    let expected = "type Root =\n    \
+                    | A\n    | B\n    | C\n    | D\n    | E\n    | F\n    | G\n    \
+                    | H\n    | I\n    | J\n    | K\n    | L\n    | M\n    | N\n    \
+                    | O\n    | P\n    | Q\n    | R\n    | S\n    | T\n    | U\n    \
+                    | V\n    | W";
+    assert_fmt(input, expected);
+}
+
+#[test]
 fn format_type_alias() {
     assert_fmt(
         "typealias StringAlias = string",

--- a/crates/floe-core/src/pretty.rs
+++ b/crates/floe-core/src/pretty.rs
@@ -49,6 +49,13 @@ pub enum Document {
     /// Force the enclosing `Group` to render as broken even if its content
     /// fits on one line.
     ForceBroken(Box<Document>),
+
+    /// Pick one of two documents based on the enclosing `Group`'s mode.
+    /// Renders `broken` when the group is broken, `unbroken` when it fits.
+    IfBroken {
+        broken: Box<Document>,
+        unbroken: Box<Document>,
+    },
 }
 
 impl Document {
@@ -125,6 +132,14 @@ fn fits(limit: isize, mut current: isize, initial: Vec<(isize, Mode, &Document)>
             }
 
             Document::ForceBroken(_) => return false,
+
+            Document::IfBroken { broken, unbroken } => {
+                let chosen = match mode {
+                    Mode::Broken => broken,
+                    Mode::Unbroken => unbroken,
+                };
+                stack.push((indent, mode, chosen));
+            }
         }
     }
     current <= limit
@@ -190,6 +205,14 @@ fn render(out: &mut impl fmt::Write, limit: isize, top: &Document) -> fmt::Resul
                 // fits() has already short-circuited to false, putting the
                 // parent into Broken mode, so we just pass the mode through.
                 stack.push((indent, mode, inner));
+            }
+
+            Document::IfBroken { broken, unbroken } => {
+                let chosen = match mode {
+                    Mode::Broken => broken,
+                    Mode::Unbroken => unbroken,
+                };
+                stack.push((indent, mode, chosen));
             }
         }
     }
@@ -263,6 +286,17 @@ pub fn force_broken(doc: Document) -> Document {
 /// anything itself. Place inside a Group to unconditionally break it.
 pub fn force_break() -> Document {
     force_broken(nil())
+}
+
+/// Render `broken` when the enclosing Group is in broken mode, `unbroken`
+/// when it fits on one line. Unlike `break_`, neither branch emits its own
+/// newline — this is for content that should differ by mode without adding
+/// a line transition.
+pub fn if_broken(broken: Document, unbroken: Document) -> Document {
+    Document::IfBroken {
+        broken: Box::new(broken),
+        unbroken: Box::new(unbroken),
+    }
 }
 
 // -- Tests ------------------------------------------------------------------
@@ -396,5 +430,27 @@ mod tests {
         // Limit equals unbroken width: should fit.
         let doc = group(concat([str("ab"), soft_space(), str("cd")]));
         assert_eq!(doc.pretty_print(5), "ab cd");
+    }
+
+    #[test]
+    fn if_broken_picks_broken_doc_in_broken_group() {
+        let doc = group(concat([
+            str("aaaa"),
+            soft_space(),
+            if_broken(str("B"), str("U")),
+            str("bbbb"),
+        ]));
+        assert_eq!(doc.pretty_print(5), "aaaa\nBbbbb");
+    }
+
+    #[test]
+    fn if_broken_picks_unbroken_doc_in_unbroken_group() {
+        let doc = group(concat([
+            str("a"),
+            soft_space(),
+            if_broken(str("B"), str("U")),
+            str("b"),
+        ]));
+        assert_eq!(doc.pretty_print(80), "a Ub");
     }
 }

--- a/crates/floe-lsp/src/index.rs
+++ b/crates/floe-lsp/src/index.rs
@@ -14,6 +14,11 @@ use tower_lsp::lsp_types::*;
 use floe_core::checker::{Type, simple_resolve_type_expr};
 use floe_core::parser::ast::*;
 
+/// Column budget that decides whether a hover body stays on one line.
+/// Matches the formatter's `MAX_WIDTH` so hover and `floe fmt` agree on
+/// when a short union type fits inline.
+const HOVER_LINE_WIDTH: usize = 100;
+
 pub(super) fn symbol_kind_to_completion(kind: SymbolKind) -> CompletionItemKind {
     match kind {
         SymbolKind::FUNCTION => CompletionItemKind::FUNCTION,
@@ -313,11 +318,11 @@ fn collect_items(items: &[TypedItem], symbols: &mut Vec<Symbol>) {
                         (body, "[record — nominal]".to_string())
                     }
                     TypeDef::Union(variants) => {
-                        let vs: Vec<String> = variants
+                        let rendered: Vec<String> = variants
                             .iter()
                             .map(|v| {
                                 if v.fields.is_empty() {
-                                    format!("    | {}", v.name)
+                                    v.name.clone()
                                 } else {
                                     let fs: Vec<String> = v
                                         .fields
@@ -334,11 +339,24 @@ fn collect_items(items: &[TypedItem], symbols: &mut Vec<Symbol>) {
                                             }
                                         })
                                         .collect();
-                                    format!("    | {}({})", v.name, fs.join(", "))
+                                    format!("{}({})", v.name, fs.join(", "))
                                 }
                             })
                             .collect();
-                        let body = format!(" =\n{}", vs.join("\n"));
+                        let inline = rendered.join(" | ");
+                        let header_width = vis.len()
+                            + opaque.len()
+                            + "type ".len()
+                            + decl.name.chars().count()
+                            + type_params.chars().count()
+                            + " = ".len();
+                        let body = if header_width + inline.chars().count() <= HOVER_LINE_WIDTH {
+                            format!(" = {}", inline)
+                        } else {
+                            let vs: Vec<String> =
+                                rendered.iter().map(|v| format!("    | {}", v)).collect();
+                            format!(" =\n{}", vs.join("\n"))
+                        };
                         let tag = if variants.len() == 1 && variants[0].name == decl.name {
                             "[newtype — nominal]".to_string()
                         } else {

--- a/crates/floe-lsp/src/index.rs
+++ b/crates/floe-lsp/src/index.rs
@@ -12,12 +12,8 @@ use std::sync::Arc;
 use tower_lsp::lsp_types::*;
 
 use floe_core::checker::{Type, simple_resolve_type_expr};
+use floe_core::formatter;
 use floe_core::parser::ast::*;
-
-/// Column budget that decides whether a hover body stays on one line.
-/// Matches the formatter's `MAX_WIDTH` so hover and `floe fmt` agree on
-/// when a short union type fits inline.
-const HOVER_LINE_WIDTH: usize = 100;
 
 pub(super) fn symbol_kind_to_completion(kind: SymbolKind) -> CompletionItemKind {
     match kind {
@@ -344,17 +340,13 @@ fn collect_items(items: &[TypedItem], symbols: &mut Vec<Symbol>) {
                             })
                             .collect();
                         let inline = rendered.join(" | ");
-                        let header_width = vis.len()
-                            + opaque.len()
-                            + "type ".len()
-                            + decl.name.chars().count()
-                            + type_params.chars().count()
-                            + " = ".len();
-                        let body = if header_width + inline.chars().count() <= HOVER_LINE_WIDTH {
-                            format!(" = {}", inline)
+                        let one_line =
+                            format!("{vis}{opaque}type {}{type_params} = {inline}", decl.name);
+                        let body = if one_line.chars().count() <= formatter::MAX_WIDTH {
+                            format!(" = {inline}")
                         } else {
                             let vs: Vec<String> =
-                                rendered.iter().map(|v| format!("    | {}", v)).collect();
+                                rendered.iter().map(|v| format!("    | {v}")).collect();
                             format!(" =\n{}", vs.join("\n"))
                         };
                         let tag = if variants.len() == 1 && variants[0].name == decl.name {

--- a/docs/design.md
+++ b/docs/design.md
@@ -1974,6 +1974,8 @@ floe migrate file.tsx     # attempt to convert .tsx to .fl
 
 The formatter enforces a canonical style. Key conventions:
 
+- **Width-adaptive tagged sums:** Union type declarations stay on one line when the whole `type Foo = A | B | C` fits in the 100-column budget; otherwise every variant splits onto its own `| ` line with a 4-space indent. There is no middle ground. LSP hover uses the same rule.
+
 - **Blank line before final expression:** In multi-statement blocks (2+ statements/expressions), the formatter inserts a blank line before the last expression (the implicit return value). Single-expression bodies are unaffected.
 
 ```floe

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -113,13 +113,16 @@ type UpdateUser = {
 // Variant fields: `(Type, ...)` is positional-only (no field names);
 // `{ name: Type, ... }` is named-only. Mixing the two forms is a parse error.
 // The leading `|` is optional.
+//
+// `floe fmt` keeps the declaration on one line when the whole `type Foo = ...`
+// fits in 100 columns; otherwise it splits every variant onto its own `|` line.
 type Route =
     | Home
     | Profile(string)
     | Settings { tab: string }
     | NotFound
 
-// Inline form is also fine
+// Short unions stay inline
 type Validation = Valid(string) | TooShort | TooLong | Empty
 
 // Nested sums

--- a/docs/site/src/content/docs/docs/guide/types.md
+++ b/docs/site/src/content/docs/docs/guide/types.md
@@ -132,6 +132,8 @@ type Color =
 type Shape = Circle(number) | Rect(number, number) | Point
 ```
 
+`floe fmt` keeps the whole declaration on one line when it fits within the 100-column line width; otherwise it splits every variant onto its own `|` line. Single-variant newtypes and short enums stay inline.
+
 `|` at the top level of a `type` declaration always declares fresh constructors. If you want a structural string union instead, use `OneOf<>`.
 
 ### Qualified Variants

--- a/examples/store/src/types.fl
+++ b/examples/store/src/types.fl
@@ -1,11 +1,9 @@
 // ── Newtype wrappers ───────────────────────────────────
 // Single-variant sums carry nominal identity (Gleam/Rust style).
 
-export type ProductId =
-    | ProductId(number)
+export type ProductId = ProductId(number)
 
-export type OrderId =
-    | OrderId(number)
+export type OrderId = OrderId(number)
 
 // ── Shared field groups ────────────────────────────────
 
@@ -48,10 +46,7 @@ export type CartItem = {
 
 // ── Nested error sums ──────────────────────────────────
 
-export type NetworkError =
-    | Timeout { ms: number }
-    | DnsFailure { host: string }
-    | ConnectionRefused
+export type NetworkError = Timeout { ms: number } | DnsFailure { host: string } | ConnectionRefused
 
 export type ApiError =
     | Network(NetworkError)
@@ -61,11 +56,7 @@ export type ApiError =
 
 // ── Sort + Filter ──────────────────────────────────────
 
-export type SortOrder =
-    | PriceLow
-    | PriceHigh
-    | Rating
-    | Name
+export type SortOrder = PriceLow | PriceHigh | Rating | Name
 
 export type PriceRange =
     | Any

--- a/examples/todo-app/src/types.fl
+++ b/examples/todo-app/src/types.fl
@@ -4,16 +4,9 @@ export type Todo = {
     done: boolean,
 }
 
-export type Filter =
-    | All
-    | Active
-    | Completed
+export type Filter = All | Active | Completed
 
-export type Validation =
-    | Valid { text: string }
-    | TooShort
-    | TooLong
-    | Empty
+export type Validation = Valid { text: string } | TooShort | TooLong | Empty
 
 export type Timestamped = {
     createdAt: number,

--- a/tests/lsp/fixtures.py
+++ b/tests/lsp/fixtures.py
@@ -717,6 +717,18 @@ for string {
 }
 """
 
+UNION_SHORT = """\
+export type Filter = All | Active | Completed
+"""
+
+UNION_LONG = """\
+export type CheckoutError =
+    | EmptyCart
+    | InvalidEmail { email: string, reason: string }
+    | InvalidPhone { phone: string, reason: string }
+    | OutOfStock { productId: number, name: string }
+"""
+
 IMPORT_FOR_BLOCK_SYNTAX = """\
 type Msg = { text: string }
 

--- a/tests/lsp/test_hover.py
+++ b/tests/lsp/test_hover.py
@@ -431,6 +431,19 @@ class TestHoverRecordSpread:
         h = hover_text(lsp.hover(URI, 0, 6))
         assert h is not None, f"Got: {h}"
 
+    def test_short_union_hover_is_inline(self, lsp):
+        open_doc(lsp, URI, F.UNION_SHORT)
+        h = hover_text(lsp.hover(URI, *at(F.UNION_SHORT, "Filter")))
+        assert h is not None, f"Expected hover, got: {h}"
+        assert "All | Active | Completed" in h, f"Expected inline union, got: {h}"
+        assert "\n    | " not in h, f"Expected no split form, got: {h}"
+
+    def test_long_union_hover_splits(self, lsp):
+        open_doc(lsp, URI, F.UNION_LONG)
+        h = hover_text(lsp.hover(URI, *at(F.UNION_LONG, "CheckoutError")))
+        assert h is not None, f"Expected hover, got: {h}"
+        assert "\n    | EmptyCart" in h, f"Expected split form, got: {h}"
+
 
 class TestHoverUseBind:
     """Hover coverage for `use` contextual keyword and its bind forms (#1200)."""


### PR DESCRIPTION
closes #1278

## Summary

`floe fmt` and LSP hover now keep a tagged-sum type declaration on one line when the whole `type Foo = A | B | C` fits in the 100-column budget. Over the threshold, every variant splits onto its own `| ` line as before — no middle ground. The single-variant newtype case (`export type SnippetCode = SnippetCode(string)`) is the biggest win.

### Implementation

- `pretty.rs` gains an `IfBroken(broken, unbroken)` combinator. `break_` can't emit text after its newline, so the leading `| ` per variant needs a mode-aware switch independent of the line break.
- `fmt_union` wraps the variants in a `group` with `break_` between them and `if_broken` for the `| ` prefix.
- `floe_core::formatter::MAX_WIDTH` is now `pub` and the LSP hover imports it, so formatter and hover share the same threshold.

## Test plan

- [x] `cargo test --workspace` (1578 passing, new boundary tests pinned at 100 and 101 chars)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt`
- [x] `python3 -m pytest tests/lsp/` (262 passing, 2 new union hover tests)
- [x] `floe fmt --check` + `floe check` on `examples/todo-app` and `examples/store`
- [x] `floe-doc-check docs/site/ docs/llms.txt README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)