### PR TITLE
feat: [#1319] wrap remaining Hono router methods in @floeorg/hono

### DIFF
--- a/integrations/hono/src/index.test.ts
+++ b/integrations/hono/src/index.test.ts
@@ -1,7 +1,25 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { router, get, post, put, patch, del, handle, type Handler } from "./index.ts";
+import {
+  router,
+  get,
+  post,
+  put,
+  patch,
+  del,
+  all,
+  on,
+  use,
+  route,
+  basePath,
+  onError,
+  notFound,
+  mount,
+  handle,
+  request,
+  type Handler,
+} from "./index.ts";
 
 type TestEnv = { readonly greeting: string };
 
@@ -60,6 +78,13 @@ describe("@floeorg/hono shim", () => {
     assert.equal(put(r, "/", noop), r);
     assert.equal(patch(r, "/", noop), r);
     assert.equal(del(r, "/", noop), r);
+    assert.equal(all(r, "/a", noop), r);
+    assert.equal(on(r, "PURGE", "/o", noop), r);
+    assert.equal(use(r, "*", async (_c, next) => { await next(); }), r);
+    assert.equal(route(r, "/sub", router<TestEnv>()), r);
+    assert.equal(onError(r, (err) => new Response(err.message, { status: 500 })), r);
+    assert.equal(notFound(r, () => new Response("nope", { status: 404 })), r);
+    assert.equal(mount(r, "/ext", () => new Response("mounted")), r);
   });
 
   it("put / patch / del dispatch correctly", async () => {
@@ -85,6 +110,102 @@ describe("@floeorg/hono shim", () => {
   it("routes see the env object passed to handle()", async () => {
     const app = get(router<TestEnv>(), "/env", (c) => new Response(c.env.greeting));
     const res = await handle(app, new Request("http://local/env"), { greeting: "hey" });
+    assert.equal(await res.text(), "hey");
+  });
+
+  it("use() registers middleware that runs before the handler and can short-circuit", async () => {
+    const trail: string[] = [];
+    const app = get(
+      use(router<TestEnv>(), "*", async (_c, next) => {
+        trail.push("before");
+        await next();
+        trail.push("after");
+      }),
+      "/x",
+      () => {
+        trail.push("handler");
+        return new Response("ok");
+      },
+    );
+    const res = await handle(app, new Request("http://local/x"), { greeting: "" });
+    assert.equal(await res.text(), "ok");
+    assert.deepEqual(trail, ["before", "handler", "after"]);
+
+    const gate = use(router<TestEnv>(), "*", () => new Response("denied", { status: 401 }));
+    get(gate, "/private", () => new Response("secret"));
+    const blocked = await handle(gate, new Request("http://local/private"), { greeting: "" });
+    assert.equal(blocked.status, 401);
+    assert.equal(await blocked.text(), "denied");
+  });
+
+  it("all() matches every HTTP method on the same path", async () => {
+    const app = all(router<TestEnv>(), "/any", (c) => new Response(c.req.method));
+    for (const method of ["GET", "POST", "PUT", "DELETE"]) {
+      const res = await handle(app, new Request("http://local/any", { method }), { greeting: "" });
+      assert.equal(await res.text(), method);
+    }
+  });
+
+  it("on() matches custom HTTP methods", async () => {
+    const app = on(router<TestEnv>(), "PURGE", "/cache", () => new Response("purged"));
+    const res = await handle(app, new Request("http://local/cache", { method: "PURGE" }), { greeting: "" });
+    assert.equal(await res.text(), "purged");
+  });
+
+  it("route() mounts a sub-router under a path prefix", async () => {
+    const users = get(router<TestEnv>(), "/", () => new Response("list"));
+    get(users, "/:id", (c) => new Response(`user ${c.req.param("id")}`));
+
+    const app = route(router<TestEnv>(), "/users", users);
+    const list = await handle(app, new Request("http://local/users"), { greeting: "" });
+    assert.equal(await list.text(), "list");
+    const one = await handle(app, new Request("http://local/users/42"), { greeting: "" });
+    assert.equal(await one.text(), "user 42");
+  });
+
+  it("basePath() prefixes every route added after it", async () => {
+    const app = get(basePath(router<TestEnv>(), "/api"), "/health", () => new Response("ok"));
+    const hit = await handle(app, new Request("http://local/api/health"), { greeting: "" });
+    assert.equal(await hit.text(), "ok");
+    const miss = await handle(app, new Request("http://local/health"), { greeting: "" });
+    assert.equal(miss.status, 404);
+  });
+
+  it("onError() catches thrown errors from handlers", async () => {
+    const app = onError(
+      get(router<TestEnv>(), "/boom", () => {
+        throw new Error("kaboom");
+      }),
+      (err) => new Response(`caught: ${err.message}`, { status: 500 }),
+    );
+    const res = await handle(app, new Request("http://local/boom"), { greeting: "" });
+    assert.equal(res.status, 500);
+    assert.equal(await res.text(), "caught: kaboom");
+  });
+
+  it("notFound() customizes the response for unmatched paths", async () => {
+    const app = notFound(
+      get(router<TestEnv>(), "/real", () => new Response("ok")),
+      () => new Response("custom 404", { status: 404 }),
+    );
+    const res = await handle(app, new Request("http://local/missing"), { greeting: "" });
+    assert.equal(res.status, 404);
+    assert.equal(await res.text(), "custom 404");
+  });
+
+  it("mount() forwards requests to a non-Hono handler", async () => {
+    const app = mount(
+      router<TestEnv>(),
+      "/ext",
+      (req) => new Response(`mounted ${new URL(req.url).pathname}`),
+    );
+    const res = await handle(app, new Request("http://local/ext/anything"), { greeting: "" });
+    assert.equal(await res.text(), "mounted /anything");
+  });
+
+  it("request() is a test helper that dispatches without a real HTTP server", async () => {
+    const app = get(router<TestEnv>(), "/hi", () => new Response("hey"));
+    const res = await request(app, "/hi");
     assert.equal(await res.text(), "hey");
   });
 });

--- a/integrations/hono/src/index.ts
+++ b/integrations/hono/src/index.ts
@@ -1,4 +1,10 @@
-import { Hono, type Context } from "hono";
+import {
+  Hono,
+  type Context,
+  type ErrorHandler,
+  type MiddlewareHandler,
+  type NotFoundHandler,
+} from "hono";
 
 type Env = Record<string, unknown>;
 
@@ -21,6 +27,21 @@ export type Router<E extends Env = Env> = {
 export type Handler<E extends Env = Env> = (
   c: Context<{ Bindings: E }>,
 ) => Response | Promise<Response>;
+
+export type Middleware<E extends Env = Env> = MiddlewareHandler<{
+  Bindings: E;
+}>;
+
+export type ErrorResponder<E extends Env = Env> = ErrorHandler<{
+  Bindings: E;
+}>;
+
+export type NotFoundResponder<E extends Env = Env> = NotFoundHandler<{
+  Bindings: E;
+}>;
+
+type MountApplicationHandler = Parameters<Hono["mount"]>[1];
+type MountOptions = Parameters<Hono["mount"]>[2];
 
 export function router<E extends Env = Env>(): Router<E> {
   const inner = new Hono<{ Bindings: E }>();
@@ -74,10 +95,90 @@ export function del<E extends Env>(
   return r;
 }
 
+export function all<E extends Env>(
+  r: Router<E>,
+  path: string,
+  handler: Handler<E>,
+): Router<E> {
+  r.__inner.all(path, handler);
+  return r;
+}
+
+export function on<E extends Env>(
+  r: Router<E>,
+  method: string,
+  path: string,
+  handler: Handler<E>,
+): Router<E> {
+  r.__inner.on(method, path, handler);
+  return r;
+}
+
+export function use<E extends Env>(
+  r: Router<E>,
+  path: string,
+  handler: Middleware<E>,
+): Router<E> {
+  r.__inner.use(path, handler);
+  return r;
+}
+
+export function route<E extends Env>(
+  r: Router<E>,
+  path: string,
+  sub: Router<E>,
+): Router<E> {
+  r.__inner.route(path, sub.__inner);
+  return r;
+}
+
+export function basePath<E extends Env>(
+  r: Router<E>,
+  path: string,
+): Router<E> {
+  const rebased = r.__inner.basePath(path) as Hono<{ Bindings: E }>;
+  return { __inner: rebased, fetch: rebased.fetch.bind(rebased) };
+}
+
+export function onError<E extends Env>(
+  r: Router<E>,
+  handler: ErrorResponder<E>,
+): Router<E> {
+  r.__inner.onError(handler);
+  return r;
+}
+
+export function notFound<E extends Env>(
+  r: Router<E>,
+  handler: NotFoundResponder<E>,
+): Router<E> {
+  r.__inner.notFound(handler);
+  return r;
+}
+
+export function mount<E extends Env>(
+  r: Router<E>,
+  path: string,
+  handler: MountApplicationHandler,
+  options?: MountOptions,
+): Router<E> {
+  r.__inner.mount(path, handler, options);
+  return r;
+}
+
 export function handle<E extends Env>(
   r: Router<E>,
   request: Request,
   env: E,
 ): Response | Promise<Response> {
   return r.__inner.fetch(request, env);
+}
+
+export function request<E extends Env>(
+  r: Router<E>,
+  input: Request | string | URL,
+  init?: RequestInit,
+  env?: E,
+): Response | Promise<Response> {
+  return r.__inner.request(input, init, env);
 }


### PR DESCRIPTION
closes #1319

## Summary

`@floeorg/hono` previously wrapped only 7 of Hono's router methods, forcing users to reach into `__inner` or fall back to plain TS for middleware, error handlers, sub-router composition, and test dispatch. This adds the remaining 9 wrappers so a Floe app can be built end-to-end via pipe.

New exports in `integrations/hono/src/index.ts`:

- `use(r, path, handler)` - middleware
- `all(r, path, handler)` - match all methods
- `on(r, method, path, handler)` - custom method (single string; the array overload is an ergonomic edge case users can reach into `__inner` for)
- `route(r, path, sub)` - mount sub-router
- `basePath(r, path)` - prefix all subsequent routes
- `onError(r, handler)` - global error handler
- `notFound(r, handler)` - custom 404
- `mount(r, path, handler, options?)` - mount non-Hono handler
- `request(r, input, init?, env?)` - test dispatch helper

Plus type aliases `Middleware<E>`, `ErrorResponder<E>`, `NotFoundResponder<E>` that bind Hono's `MiddlewareHandler` / `ErrorHandler` / `NotFoundHandler` to `{ Bindings: E }`, matching how the existing `Handler<E>` adapts `Context`.

## Test plan

- [x] `pnpm build` in `integrations/hono` - passes (tsc clean)
- [x] `pnpm test` in `integrations/hono` - 16/16 tests pass
- [x] Each new wrapper has a dedicated `it()` block covering the behavior described in the issue
- [x] `use()` test verifies both `await next()` passthrough and short-circuit responses
- [x] `all()` test hits GET/POST/PUT/DELETE on the same path
- [x] `basePath()` test verifies both the prefixed route hits and the unprefixed path 404s
- [x] `onError()` test verifies a thrown `Error` is caught and mapped
- [x] `mount()` test verifies requests are forwarded with the prefix stripped (Hono's documented behavior)