### PR TITLE
fix: [#1201] make `use` contextual in TextMate grammar

### DIFF
--- a/editors/vscode/syntaxes/floe.tmLanguage.json
+++ b/editors/vscode/syntaxes/floe.tmLanguage.json
@@ -88,7 +88,11 @@
       "patterns": [
         {
           "name": "keyword.control.floe",
-          "match": "\\b(match|return|collect|deriving|for|trait|test|assert|when|todo|unreachable|parse|mock|use)\\b"
+          "match": "\\b(match|return|collect|deriving|for|trait|test|assert|when|todo|unreachable|parse|mock)\\b"
+        },
+        {
+          "name": "keyword.control.use.floe",
+          "match": "(?<=^|\\s)use\\b(?=\\s+[\\w(){}\\[\\],:\\s]+<-|\\s*<-)"
         },
         {
           "name": "keyword.control.import.floe",

--- a/editors/vscode/tests/syntax.test.fl
+++ b/editors/vscode/tests/syntax.test.fl
@@ -33,3 +33,30 @@ const x = true
 
 function bad() {}
 // <-- invalid.illegal.keyword.floe
+
+// `use` is a contextual keyword — colored only at the head of a bind statement.
+
+let x = use(promise)
+//      ^^^ -keyword.control.use.floe
+
+let y = foo.use
+//          ^^^ -keyword.control.use.floe
+
+import trusted { use, get } from "@floeorg/hono"
+//               ^^^ -keyword.control.use.floe
+
+let f() = {
+    use db <- Option.guard(maybeDb, fallback)
+//  ^^^ keyword.control.use.floe
+
+    use <- Timer.delay(1000)
+//  ^^^ keyword.control.use.floe
+
+    use (a, b) <- pair
+//  ^^^ keyword.control.use.floe
+
+    use { a, b } <- record
+//  ^^^ keyword.control.use.floe
+
+    db
+}


### PR DESCRIPTION
Partially closes #1201 (TextMate half; tree-sitter corpus work is the remaining half).

## Summary

`use` was listed in the generic keyword alternation in `floe.tmLanguage.json`, so VSCode colored it as a keyword everywhere — including inside `import { use } from "@floeorg/hono"`, `foo.use`, and `use(promise)`. Since `use` is a *contextual* keyword in Floe (only a keyword at the head of a bind statement), those positions should be plain identifiers.

## Change

Remove `use` from the generic `keyword.control.floe` alternation at `editors/vscode/syntaxes/floe.tmLanguage.json:91` and add a dedicated `keyword.control.use.floe` rule with a narrow bind-position match:

```
(?<=^|\s)use\b(?=\s+[\w(){}\[\],:\s]+<-|\s*<-)
```

Matches: `use <- expr`, `use x <- expr`, `use (a, b) <- expr`, `use { a, b } <- expr`, `use { a: x } <- expr`.
Does not match: `import { use }`, `foo.use`, `use(promise)`, bare `use`.

Verified with a node-level regex harness (14/14 cases) and with `vscode-tmgrammar-test` against the extended `tests/syntax.test.fl` fixture.

## Scope

TextMate only. Tree-sitter has the same problem (covered in #1201) but needs grammar regeneration, corpus tests, and a mirrored `editors/neovim/queries/floe/highlights.scm` update per `.claude/rules/syntax-sources.md`. That's better as a follow-up PR where it can have proper attention.

## Test plan

- [x] Added assertions to `editors/vscode/tests/syntax.test.fl` covering:
  - `let x = use(promise)` — `use` is NOT `keyword.control.use.floe`
  - `let y = foo.use` — `use` is NOT `keyword.control.use.floe`
  - `import trusted { use, get } from "@floeorg/hono"` — `use` is NOT a keyword
  - `use db <- Option.guard(...)` — `use` IS `keyword.control.use.floe`
  - `use <- Timer.delay(1000)` — `use` IS `keyword.control.use.floe`
  - `use (a, b) <- pair` — `use` IS `keyword.control.use.floe`
  - `use { a, b } <- record` — `use` IS `keyword.control.use.floe`
- [x] `vscode-tmgrammar-test` reports zero failures on these new assertions. (The 3 pre-existing failures in the fixture for lines 3 and 16 are unrelated stale assertions predating this PR.)