### PR TITLE
feat: [#1351] emit chain probes for depth-1 terminal calls

### DIFF
--- a/crates/floe-core/src/interop/tsgo.rs
+++ b/crates/floe-core/src/interop/tsgo.rs
@@ -1401,6 +1401,62 @@ export let app = router<Bindings>()
     }
 
     #[test]
+    fn generate_probe_emits_depth_1_terminal_call_chain() {
+        // Regression for #1351. hono's `c.json(body, status)` call chain is
+        // only one member step deep — `collect_param_rooted_chains` used to
+        // filter it out alongside bare `c.env` reads, and the per-function
+        // walker never emitted `__chain_call_Context$json`. Without that
+        // probe, tsgo's narrow `JSONRespondReturn<T, S>` return type can't
+        // reach the checker. The depth-1 exclusion now applies only to bare
+        // member accesses — terminal calls always emit.
+        let source = r#"import trusted { router, get, Context } from "hono"
+
+type Bindings = { DB: string }
+
+let handleCreate(c: Context<{ Bindings: Bindings }>) -> string = {
+    c.json("hi", 201)
+}
+
+export let app = router<Bindings>()
+    |> get("/x", handleCreate)
+"#;
+        let program = Parser::new(source).parse_program().unwrap();
+        let probe = generate_probe(&program, &HashMap::new(), &HashMap::new());
+
+        assert!(
+            probe.contains(
+                "export let __chain_call_handleCreate__Context$json = __chain_base_handleCreate__Context.json(null! as any);"
+            ),
+            "depth-1 terminal-call chain must emit __chain_call_ probe, got:\n{probe}"
+        );
+    }
+
+    #[test]
+    fn generate_probe_skips_depth_1_bare_member_access() {
+        // Complement to the depth-1 terminal-call regression: a bare member
+        // read like `c.env` still adds nothing beyond the parent Context
+        // probe, so the depth-1 exclusion is preserved for non-call chains.
+        let source = r#"import trusted { router, get, Context } from "hono"
+
+type Bindings = { DB: string }
+
+let handler(c: Context<{ Bindings: Bindings }>) -> unknown = {
+    c.env
+}
+
+export let app = router<Bindings>()
+    |> get("/x", handler)
+"#;
+        let program = Parser::new(source).parse_program().unwrap();
+        let probe = generate_probe(&program, &HashMap::new(), &HashMap::new());
+
+        assert!(
+            !probe.contains("__chain_handler__Context$env"),
+            "bare `c.env` should not emit a depth-1 chain probe, got:\n{probe}"
+        );
+    }
+
+    #[test]
     fn generate_probe_preserves_nested_generic_type_argument() {
         // Regression for #1276. Without the full type annotation in the probe,
         // `c.env.DB` on `Context<{ Bindings: Bindings }>` collapses to the

--- a/crates/floe-core/src/interop/tsgo/probe_gen.rs
+++ b/crates/floe-core/src/interop/tsgo/probe_gen.rs
@@ -1226,7 +1226,12 @@ fn collect_param_rooted_chains(body: &Expr, param_name: &str) -> Vec<(Vec<String
         let Some(steps) = collect_member_chain(member_expr, param_name) else {
             return;
         };
-        if steps.len() < 2 {
+        // Bare `c.env` / `c.req` reads are already resolved via the parent
+        // Context probe, so depth-1 member access adds nothing. Depth-1
+        // *calls* (`c.json(body, 201)`, `c.text(...)`, `c.html(...)`) are
+        // different — tsgo narrows the return type per-overload, and that
+        // only reaches the checker via a `__chain_call_` probe.
+        if steps.len() < 2 && !is_call {
             return;
         }
         let key = steps.join("$");


### PR DESCRIPTION
## Summary

- `collect_param_rooted_chains` was filtering out every param-rooted chain shorter than two member steps. Correct for bare reads (`c.env` already resolves through the parent Context probe), wrong for terminal calls like hono's `c.json(body, status)` / `c.text(...)` / `c.html(...)`.
- Without the `__chain_call_Context$json` probe, tsgo's narrow `JSONRespondReturn<T, S>` return type never reached the checker.
- Split the filter: depth-1 bare members are still skipped; depth-1 terminal calls now emit.

This is a **sub-issue of #1285** and unblocks it but isn't sufficient alone — the emitted probe still passes `null! as any`, so literal-narrowed overloads like `c.json(body, 201)` resolve to `JSONRespondReturn<any, any>` until #1352 threads real literal args through.

closes #1351

## Test plan

- [x] `cargo test --workspace` (1586 passing, +2 regression tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] Regression tests added:
  - `generate_probe_emits_depth_1_terminal_call_chain` — `c.json(...)` now emits `__chain_call_handleCreate__Context$json`.
  - `generate_probe_skips_depth_1_bare_member_access` — `c.env` on its own still emits nothing (no regression on the filter's original intent).
- [x] Manual repro with `@floeorg/hono` handler: probe output now contains the depth-1 chain entries; values are still `any` pending #1352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)