### PR TITLE
feat: [#1353] recognize functional hono API in collect_handler_paths

### DIFF
--- a/crates/floe-core/src/interop/tsgo.rs
+++ b/crates/floe-core/src/interop/tsgo.rs
@@ -1457,6 +1457,35 @@ export let app = router<Bindings>()
     }
 
     #[test]
+    fn generate_probe_recognizes_functional_handler_registration() {
+        // Regression for #1353. `collect_handler_paths` previously required
+        // the path string at arg 0 — fine for hono-native `app.get(path, h)`
+        // and for the pipe form `|> get(path, h)` (whose RHS Call still has
+        // path at arg 0), but the `@floeorg/hono` wrapper uses functional
+        // signatures like `get(router, "/x", handler)` where the path is at
+        // arg 1 and the handler at arg 2. Without a match, no
+        // `__chain_base_<fn>__<Base>` was emitted, so per-function chain
+        // probes never fired for the direct-call style.
+        let source = r#"import trusted { router, get, Context } from "hono"
+
+type Bindings = { DB: string }
+
+let handleUser(c: Context<{ Bindings: Bindings }>) -> string = {
+    c.req.param("id")
+}
+
+export let app = get(router<Bindings>(), "/users/:id", handleUser)
+"#;
+        let program = Parser::new(source).parse_program().unwrap();
+        let probe = generate_probe(&program, &HashMap::new(), &HashMap::new());
+
+        assert!(
+            probe.contains("declare const __chain_base_handleUser__Context: Context<{ Bindings: Bindings }, \"/users/:id\">;"),
+            "functional handler registration should populate the per-function chain base, got:\n{probe}"
+        );
+    }
+
+    #[test]
     fn generate_probe_preserves_nested_generic_type_argument() {
         // Regression for #1276. Without the full type annotation in the probe,
         // `c.env.DB` on `Context<{ Bindings: Bindings }>` collapses to the

--- a/crates/floe-core/src/interop/tsgo/probe_gen.rs
+++ b/crates/floe-core/src/interop/tsgo/probe_gen.rs
@@ -1136,14 +1136,20 @@ fn emit_per_handler_chain_probes(
     }
 }
 
-/// Scan pipe-chain method calls of the shape `router_method(path, handler)`
-/// and record `handler -> path`. Handlers registered by an inline lambda
-/// are skipped (no name to correlate with a function declaration).
+/// Scan method calls for handler registrations of the shape
+/// `..., "/path", handler, ...` and record `handler -> path`. Handlers
+/// registered by an inline lambda are skipped (no name to correlate
+/// with a function declaration).
 ///
-/// The shape match is heuristic — any call where arg 0 is a string
-/// starting with `/` and arg 1 is an identifier qualifies. False
-/// positives (e.g. `fs.readFile("/etc/hosts", cb)`) produce a bogus
-/// per-function probe block; tsgo emits `any` for mismatched
+/// The shape match is heuristic — we look for the first positional
+/// string arg starting with `/` followed immediately by a positional
+/// identifier arg. That covers both hono-native (`app.get("/x", h)`,
+/// and the pipe form `|> get("/x", h)` whose RHS Call still has the
+/// path at arg 0) and the `@floeorg/hono` functional wrapper
+/// (`get(r, "/x", h)` — path at arg 1, handler at arg 2).
+///
+/// False positives (e.g. `fs.readFile("/etc/hosts", cb)`) produce a
+/// bogus per-function probe block; tsgo emits `any` for mismatched
 /// instantiations and the checker's per-function chain lookup silently
 /// falls back to the global key. Harmless in practice, but a stricter
 /// check (verify the callee is actually a router method) could come
@@ -1158,26 +1164,26 @@ fn collect_handler_paths(program: &Program) -> HashMap<String, String> {
         let ExprKind::Call { args, .. } = &expr.kind else {
             return;
         };
-        if args.len() < 2 {
+        for i in 0..args.len().saturating_sub(1) {
+            let Arg::Positional(path_arg) = &args[i] else {
+                continue;
+            };
+            let ExprKind::String(path) = &path_arg.kind else {
+                continue;
+            };
+            if !path.starts_with('/') {
+                continue;
+            }
+            let Arg::Positional(handler_arg) = &args[i + 1] else {
+                continue;
+            };
+            let ExprKind::Identifier(handler_name) = &handler_arg.kind else {
+                continue;
+            };
+            out.entry(handler_name.clone())
+                .or_insert_with(|| path.clone());
             return;
         }
-        let Arg::Positional(path_arg) = &args[0] else {
-            return;
-        };
-        let Arg::Positional(handler_arg) = &args[1] else {
-            return;
-        };
-        let ExprKind::String(path) = &path_arg.kind else {
-            return;
-        };
-        if !path.starts_with('/') {
-            return;
-        }
-        let ExprKind::Identifier(handler_name) = &handler_arg.kind else {
-            return;
-        };
-        out.entry(handler_name.clone())
-            .or_insert_with(|| path.clone());
     });
     out
 }


### PR DESCRIPTION
## Summary

- `collect_handler_paths` hard-required `args[0]=path, args[1]=handler`. That matches hono-native `app.get(path, h)` and the pipe form `|> get(path, h)` (RHS Call still has path at 0), but misses the `@floeorg/hono` wrapper `get(router, "/x", handler)` where path lives at `args[1]`.
- No match → no `__chain_base_<fn>__<Base>` → per-function chain probes (from #1281) never fired for the direct-call registration style that most Floe users actually write.
- Scan positional args for the first `/`-prefixed string followed immediately by an identifier. Existing matches preserved; wrapper now picked up.

Sub-issue of #1285. Combined with #1351 (already merged), per-function chain probes now fire for `c.json(...)`-style calls in handlers registered via the functional `get(r, "/x", h)` API. Values are still `any` pending #1352.

closes #1353

## Test plan

- [x] `cargo test --workspace` (1587 passing, +1 regression test)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] New regression: `generate_probe_recognizes_functional_handler_registration` — `get(router<B>(), "/users/:id", handleUser)` now emits the per-function chain base with the registered path threaded into `Context<..., "/users/:id">`.
- [x] Pre-existing pipe-form test (`generate_probe_threads_registration_path_into_handler_context`) still passes.
- [x] Manual repro with `@floeorg/hono` direct-call form: `__chain_handleUser__Context$req$param` now emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)