### PR TITLE
feat: [#1352] thread literal args into chain-call probes

### DIFF
--- a/crates/floe-core/src/checker/expr.rs
+++ b/crates/floe-core/src/checker/expr.rs
@@ -22,11 +22,13 @@ fn extract_chain_segments(expr: &Expr) -> Option<Vec<String>> {
 
 /// Build the chain probe key for a member access on a call result.
 /// For `db.insert(...).values`, returns `Some("db$insert$values")`.
-/// Returns `None` if the expression is not a valid import chain (depth < 3).
+/// For depth-2 terminal calls like `c.json` the key is still built
+/// (`c$json`) — the variable-rooted probe isn't emitted for those, but
+/// the caller's cascade falls through to the type-rooted key which is.
 fn extract_chain_key(object: &Expr, field: &str) -> Option<String> {
     let mut segments = extract_chain_segments(object)?;
     segments.push(field.to_string());
-    if segments.len() >= 3 {
+    if segments.len() >= 2 {
         Some(segments.join("$"))
     } else {
         None
@@ -34,6 +36,16 @@ fn extract_chain_key(object: &Expr, field: &str) -> Option<String> {
 }
 
 use super::hydrator::is_single_uppercase as is_generic_param;
+
+/// Chain-call probe lookups try the `__<fp>` fingerprinted suffix first
+/// (so literal-narrowed overloads land on their specific variant), then
+/// the bare key (backward compat for probes that don't yet include
+/// arg-tuple fingerprints).
+fn fp_then_bare(fp: Option<&str>) -> impl Iterator<Item = String> + use<'_> {
+    fp.map(|s| format!("__{s}"))
+        .into_iter()
+        .chain(std::iter::once(String::new()))
+}
 
 /// Strip generic arguments from a Foreign type name for chain-probe lookup.
 /// `Context<unknown>` -> `Context`, `Router<A, B>` -> `Router`, `Foo` -> `Foo`.
@@ -955,7 +967,7 @@ impl Checker {
         // captures `.field(null! as any)`, so arg-vs-param checks would be
         // against `any` anyway.
         if let ExprKind::Member { object, field } = &callee.kind
-            && let Some(ty) = self.lookup_chain_call_probe(object, field)
+            && let Some(ty) = self.lookup_chain_call_probe(object, field, args)
         {
             return ty;
         }
@@ -2479,7 +2491,7 @@ impl Checker {
     fn chain_key_by_root_type(&self, object: &Expr, field: &str) -> Option<String> {
         let mut segments = extract_chain_segments(object)?;
         segments.push(field.to_string());
-        if segments.len() < 3 {
+        if segments.len() < 2 {
             return None;
         }
 
@@ -2559,40 +2571,63 @@ impl Checker {
     /// type-rooted key (e.g. `Database$insert$values`). `prefix` selects the
     /// probe family: `"__chain_call_"` for overload-resolved call results,
     /// `"__chain_await_"` for awaited chain results.
+    ///
+    /// `call_site_fp` is the arg-tuple fingerprint for `__chain_call_`
+    /// lookups — when set, each base key is first probed with the
+    /// `__{fp}` suffix so literal-narrowed overloads (e.g. hono's
+    /// `c.json(body, 201)`) land on their narrow variant instead of the
+    /// generic `null! as any` fallback.
     fn lookup_prefixed_chain_probe(
         &mut self,
         prefix: &str,
         object: &Expr,
         field: &str,
+        call_site_fp: Option<&str>,
     ) -> Option<Type> {
         let chain_key = extract_chain_key(object, field)?;
-        // Per-function scoped probe first — the probe generator emits a
-        // `__chain_{prefix}{fn}__{chain_key}` entry for handlers registered
-        // to a specific route, which threads the path into Context's P
-        // parameter and lets tsgo narrow `c.req.param("code")` to `string`.
-        if let Some(fn_name) = self.ctx.current_function.as_deref()
-            && let Some(ty) = self.lookup_dts_probe(&format!("{prefix}{fn_name}__{chain_key}"))
-        {
-            return Some(ty);
+        let fn_name = self.ctx.current_function.clone();
+        // Try every base key with the fingerprint suffix first (one pass),
+        // then fall back to the bare keys. Each variant goes through the
+        // same per-function / type-rooted cascade the bare lookup used.
+        for suffix in fp_then_bare(call_site_fp) {
+            if let Some(ref fn_name) = fn_name
+                && let Some(ty) =
+                    self.lookup_dts_probe(&format!("{prefix}{fn_name}__{chain_key}{suffix}"))
+            {
+                return Some(ty);
+            }
+            if let Some(ty) = self.lookup_dts_probe(&format!("{prefix}{chain_key}{suffix}")) {
+                return Some(ty);
+            }
+            let Some(type_key) = self.chain_key_by_root_type(object, field) else {
+                continue;
+            };
+            if let Some(ref fn_name) = fn_name
+                && let Some(ty) =
+                    self.lookup_dts_probe(&format!("{prefix}{fn_name}__{type_key}{suffix}"))
+            {
+                return Some(ty);
+            }
+            if let Some(ty) = self.lookup_dts_probe(&format!("{prefix}{type_key}{suffix}")) {
+                return Some(ty);
+            }
         }
-        if let Some(ty) = self.lookup_dts_probe(&format!("{prefix}{chain_key}")) {
-            return Some(ty);
-        }
-        let type_key = self.chain_key_by_root_type(object, field)?;
-        if let Some(fn_name) = self.ctx.current_function.as_deref()
-            && let Some(ty) = self.lookup_dts_probe(&format!("{prefix}{fn_name}__{type_key}"))
-        {
-            return Some(ty);
-        }
-        self.lookup_dts_probe(&format!("{prefix}{type_key}"))
+        None
     }
 
     /// Look up the call-result chain probe for a Member chain callee
     /// (e.g. `c.req.param("code")` → `__chain_call_Context$req$param`).
     /// tsgo has already resolved the correct overload, so the probe type
     /// is the concrete return value.
-    fn lookup_chain_call_probe(&mut self, object: &Expr, field: &str) -> Option<Type> {
-        self.lookup_prefixed_chain_probe("__chain_call_", object, field)
+    fn lookup_chain_call_probe(
+        &mut self,
+        object: &Expr,
+        field: &str,
+        args: &[Arg],
+    ) -> Option<Type> {
+        let rendered = interop::tsgo::probe_gen::render_call_args(args);
+        let fp = interop::tsgo::probe_gen::chain_call_fingerprint(&rendered);
+        self.lookup_prefixed_chain_probe("__chain_call_", object, field, Some(&fp))
     }
 
     /// Look up the awaited chain probe for a chain call expression
@@ -2610,7 +2645,7 @@ impl Checker {
         let ExprKind::Member { object, field } = &callee.kind else {
             return None;
         };
-        self.lookup_prefixed_chain_probe("__chain_await_", object, field)
+        self.lookup_prefixed_chain_probe("__chain_await_", object, field, None)
     }
 
     /// Resolve a member type without emitting diagnostics (for probe key lookups).

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -7825,6 +7825,66 @@ export let handler(c: Context<unknown>) -> string = {
 }
 
 #[test]
+fn chain_call_probe_resolves_per_literal_arg_tuple() {
+    // Regression for #1352. When a handler calls `c.json(body, 201)`,
+    // the fingerprinted `__chain_call_Context$json__<fp>` probe captures
+    // the narrow `TypedResponse<any, 201, "json">`. The checker must
+    // prefer it over the bare probe (still emitted as a fallback) —
+    // we prove it by giving the two probes disjoint field sets and
+    // accessing the narrow-only field: a lookup that went to the bare
+    // probe would report "has no field".
+    use crate::interop::tsgo::probe_gen;
+    use crate::interop::{DtsExport, ObjectField, TsType};
+    use std::collections::HashMap;
+
+    let program = crate::parser::Parser::new(
+        r#"
+import trusted { Context } from "hono"
+
+export let handler(c: Context<unknown>) -> string = {
+    c.json("ok", 201).narrowOnly
+}
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+
+    let context_export = DtsExport {
+        name: "Context".to_string(),
+        ts_type: TsType::Any,
+    };
+    let bare = DtsExport {
+        name: "__chain_call_Context$json".to_string(),
+        ts_type: TsType::Object(vec![ObjectField {
+            name: "bareOnly".to_string(),
+            ty: TsType::Primitive("string".to_string()),
+            optional: false,
+        }]),
+    };
+    let fp = probe_gen::chain_call_fingerprint(&["\"ok\"".to_string(), "201".to_string()]);
+    let narrow = DtsExport {
+        name: format!("__chain_call_Context$json__{fp}"),
+        ts_type: TsType::Object(vec![ObjectField {
+            name: "narrowOnly".to_string(),
+            ty: TsType::Primitive("string".to_string()),
+            optional: false,
+        }]),
+    };
+
+    let mut dts_imports = HashMap::new();
+    dts_imports.insert("hono".to_string(), vec![context_export, bare, narrow]);
+
+    let checker = Checker::with_all_imports(HashMap::new(), dts_imports);
+    let (diags, _, _, _) = checker.check_with_types(&program);
+
+    assert!(
+        !has_error_containing(&diags, "has no field"),
+        "fingerprinted probe should win lookup — accessing narrowOnly must succeed, got errors: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn chain_probe_resolves_for_fl_alias_type_param() {
     // When a function parameter is typed as a Floe type alias (e.g. db: Database
     // where `type Database = DrizzleType`), chain probes keyed by type name should resolve

--- a/crates/floe-core/src/interop/tsgo.rs
+++ b/crates/floe-core/src/interop/tsgo.rs
@@ -5,7 +5,7 @@
 //! 2. Parsing .d.ts / .ts files directly for type definitions
 //! 3. Querying tsgo LSP (hover) for richer type resolution
 
-mod probe_gen;
+pub(crate) mod probe_gen;
 #[cfg(feature = "native")]
 mod probe_run;
 mod specifier_map;
@@ -1453,6 +1453,76 @@ export let app = router<Bindings>()
         assert!(
             !probe.contains("__chain_handler__Context$env"),
             "bare `c.env` should not emit a depth-1 chain probe, got:\n{probe}"
+        );
+    }
+
+    #[test]
+    fn generate_probe_threads_literal_args_into_call_probe() {
+        // Regression for #1352. hono's `c.json(body, status)` narrows its
+        // return via the literal status value — `201` picks
+        // `JSONRespondReturn<T, 201>`. The pre-existing probe passed a
+        // single `null! as any`, losing the literal. One `__chain_call_`
+        // variant per distinct rendered arg tuple now threads real
+        // literal values so tsgo resolves the matching overload.
+        let source = r#"import trusted { router, get, Context } from "hono"
+
+type Bindings = { DB: string }
+
+let handleCreate(c: Context<{ Bindings: Bindings }>) -> Response = {
+    c.json("hi", 201)
+}
+
+export let app = router<Bindings>()
+    |> get("/c", handleCreate)
+"#;
+        let program = Parser::new(source).parse_program().unwrap();
+        let probe = generate_probe(&program, &HashMap::new(), &HashMap::new());
+
+        assert!(
+            probe.contains("__chain_base_handleCreate__Context.json(\"hi\", 201)"),
+            "literal args should appear verbatim in the call probe, got:\n{probe}"
+        );
+        let fp = probe_gen::chain_call_fingerprint(&["\"hi\"".to_string(), "201".to_string()]);
+        assert!(
+            probe.contains(&format!(
+                "export let __chain_call_handleCreate__Context$json__{fp} ="
+            )),
+            "fingerprinted probe variant missing, got:\n{probe}"
+        );
+    }
+
+    #[test]
+    fn generate_probe_emits_distinct_fingerprints_per_literal_tuple() {
+        // A handler with two `c.json(_, status)` calls at different
+        // statuses must produce two distinct `__chain_call_` probes so
+        // tsgo narrows each to its own `JSONRespondReturn<T, S>` — a
+        // single probe would only capture one overload result.
+        let source = r#"import trusted { router, get, Context } from "hono"
+
+type Bindings = { DB: string }
+
+let handleUpdate(c: Context<{ Bindings: Bindings }>) -> Response = {
+    match c.req.param("id") {
+        None -> c.json({ error: "missing" }, 400),
+        Some(_) -> c.json({ ok: true }, 200),
+    }
+}
+
+export let app = router<Bindings>()
+    |> get("/u/:id", handleUpdate)
+"#;
+        let program = Parser::new(source).parse_program().unwrap();
+        let probe = generate_probe(&program, &HashMap::new(), &HashMap::new());
+
+        let fp200 =
+            probe_gen::chain_call_fingerprint(&["null! as any".to_string(), "200".to_string()]);
+        let fp400 =
+            probe_gen::chain_call_fingerprint(&["null! as any".to_string(), "400".to_string()]);
+        assert_ne!(fp200, fp400);
+        assert!(
+            probe.contains(&format!("__chain_call_handleUpdate__Context$json__{fp200}"))
+                && probe.contains(&format!("__chain_call_handleUpdate__Context$json__{fp400}")),
+            "expected one probe per distinct literal tuple (200, 400), got:\n{probe}"
         );
     }
 

--- a/crates/floe-core/src/interop/tsgo/probe_gen.rs
+++ b/crates/floe-core/src/interop/tsgo/probe_gen.rs
@@ -1112,17 +1112,35 @@ fn emit_per_handler_chain_probes(
         // then emit one probe per chain (plus `_call_` and `_await_` variants)
         // using the per-function scoped base.
         let chains = collect_param_rooted_chains(&decl.body, &param_name);
-        for (steps, is_call) in chains {
+        for ChainSite {
+            steps,
+            call_arg_tuples,
+        } in chains
+        {
             let chain_key = format!("{chain_prefix}${}", steps.join("$"));
             let mut expr = base_name.clone();
             for step in &steps {
                 expr = format!("{expr}.{step}");
             }
             lines.push(format!("export let __chain_{chain_key} = {expr};"));
-            if is_call {
+            // One `__chain_call_` per distinct call-site arg tuple so
+            // literal-narrowed overloads (hono's `c.json(body, 201)` →
+            // `JSONRespondReturn<T, 201>`) reach the checker with their
+            // narrow type. The bare `__chain_call_{key}` is kept as a
+            // fallback for chains where literal threading isn't relevant
+            // (e.g. existing `c.req.param(id)` tests register the bare key
+            // directly; a checker-side fallback lookup preserves those).
+            if !call_arg_tuples.is_empty() {
                 lines.push(format!(
                     "export let __chain_call_{chain_key} = {expr}(null! as any);"
                 ));
+                for rendered in &call_arg_tuples {
+                    let fp = chain_call_fingerprint(rendered);
+                    lines.push(format!(
+                        "export let __chain_call_{chain_key}__{fp} = {expr}({});",
+                        rendered.join(", ")
+                    ));
+                }
             }
             lines.push(format!("export let __chain_called_{chain_key} = {expr}();"));
             let await_fn = format!("__chain_await_{chain_key}_fn");
@@ -1217,16 +1235,34 @@ fn handler_param_with_path(
     Some((param.name.clone(), base_type.clone(), threaded_ann))
 }
 
-/// Walk `body` collecting chain expressions rooted in `param_name`. Each
-/// chain is returned once with a flag indicating whether any occurrence
-/// invoked the terminal step — that determines whether we emit the
-/// `__chain_call_` variant alongside the base `__chain_` probes.
-fn collect_param_rooted_chains(body: &Expr, param_name: &str) -> Vec<(Vec<String>, bool)> {
-    let mut by_key: HashMap<String, (Vec<String>, bool)> = HashMap::new();
+/// One chain expression rooted in a handler parameter, plus every
+/// distinct call-site argument tuple observed for its terminal call
+/// (if any). Each tuple is rendered for the probe so literal args
+/// thread through — hono's `c.json(body, 201)` overload needs the
+/// literal `201` to narrow the return type to `JSONRespondReturn<T,
+/// 201>`; `null! as any` alone loses that.
+pub(crate) struct ChainSite {
+    pub(crate) steps: Vec<String>,
+    /// Rendered arg lists, one per distinct call-site tuple. Empty
+    /// when the chain was only observed as a bare member read
+    /// (`c.env`), i.e. no `__chain_call_` variants to emit.
+    pub(crate) call_arg_tuples: Vec<Vec<String>>,
+}
+
+/// Walk `body` collecting chain expressions rooted in `param_name`.
+fn collect_param_rooted_chains(body: &Expr, param_name: &str) -> Vec<ChainSite> {
+    struct Entry {
+        steps: Vec<String>,
+        // BTreeSet keeps insertion-order-independent dedup *and* a stable
+        // iteration order for probe emission — different programs with the
+        // same arg tuples produce the same probe output.
+        tuples: std::collections::BTreeSet<Vec<String>>,
+    }
+    let mut by_key: HashMap<String, Entry> = HashMap::new();
     crate::walk::walk_expr(body, &mut |expr| {
-        let (member_expr, is_call) = match &expr.kind {
-            ExprKind::Call { callee, .. } => (callee.as_ref(), true),
-            ExprKind::Member { .. } => (expr, false),
+        let (member_expr, call_args): (&Expr, Option<&[Arg]>) = match &expr.kind {
+            ExprKind::Call { callee, args, .. } => (callee.as_ref(), Some(args)),
+            ExprKind::Member { .. } => (expr, None),
             _ => return,
         };
         let Some(steps) = collect_member_chain(member_expr, param_name) else {
@@ -1237,20 +1273,64 @@ fn collect_param_rooted_chains(body: &Expr, param_name: &str) -> Vec<(Vec<String
         // *calls* (`c.json(body, 201)`, `c.text(...)`, `c.html(...)`) are
         // different — tsgo narrows the return type per-overload, and that
         // only reaches the checker via a `__chain_call_` probe.
-        if steps.len() < 2 && !is_call {
+        if steps.len() < 2 && call_args.is_none() {
             return;
         }
         let key = steps.join("$");
-        by_key
-            .entry(key)
-            .and_modify(|(_, flag)| {
-                if is_call {
-                    *flag = true;
-                }
-            })
-            .or_insert((steps, is_call));
+        let entry = by_key.entry(key).or_insert_with(|| Entry {
+            steps: steps.clone(),
+            tuples: std::collections::BTreeSet::new(),
+        });
+        if let Some(args) = call_args {
+            entry.tuples.insert(render_call_args(args));
+        }
     });
-    by_key.into_values().collect()
+    by_key
+        .into_values()
+        .map(|e| ChainSite {
+            steps: e.steps,
+            call_arg_tuples: e.tuples.into_iter().collect(),
+        })
+        .collect()
+}
+
+/// Render a handler call site's arg list for a `__chain_call_` probe.
+/// Literal values (numbers, strings, booleans) pass through so tsgo
+/// narrows via literal-based overload resolution (hono's `c.json(body,
+/// 201)` → `JSONRespondReturn<T, 201>`). Non-literal expressions
+/// render as `null! as any` — their value doesn't affect overload
+/// selection for the hono/db patterns we care about, and threading
+/// concrete expressions through would drag the caller's whole type
+/// graph into the probe.
+pub(crate) fn render_call_args(args: &[Arg]) -> Vec<String> {
+    args.iter().map(render_call_arg).collect()
+}
+
+fn render_call_arg(arg: &Arg) -> String {
+    let expr = match arg {
+        Arg::Positional(e) | Arg::Named { value: e, .. } => e,
+    };
+    match &expr.kind {
+        ExprKind::Number(n) => n.clone(),
+        ExprKind::String(s) => {
+            let escaped = s.replace('\\', "\\\\").replace('"', "\\\"");
+            format!("\"{escaped}\"")
+        }
+        ExprKind::Bool(b) => b.to_string(),
+        _ => "null! as any".to_string(),
+    }
+}
+
+/// Identifier-safe fingerprint for a rendered arg tuple — suffixes a
+/// `__chain_call_` probe so distinct literal tuples produce distinct
+/// probes (and distinct narrow return types from tsgo). Deterministic
+/// within a single `floe` invocation, which is all the probe-gen and
+/// checker-lookup paths need to agree on.
+pub(crate) fn chain_call_fingerprint(rendered: &[String]) -> String {
+    use std::hash::{DefaultHasher, Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    rendered.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
 }
 
 /// If `expr` is a Member chain rooted in `param_name`, return the field


### PR DESCRIPTION
## Summary

- Per-handler chain probes emitted `{expr}.{field}(null! as any)` for every terminal call, collapsing literal-narrowed overloads to their widest variant. hono's `c.json(body, 201)` resolved to `JSONRespondReturn<any, ContentfulStatusCode, "json">` instead of the narrow `JSONRespondReturn<any, 201, "json">` every Hono-RPC consumer wants.
- Walk each terminal call site, render literal number/string/bool args verbatim and everything else as `null! as any`, and emit one `__chain_call_{key}__{fp}` per distinct rendered-arg tuple. Fingerprint is a `DefaultHasher` digest over the rendered strings — deterministic within a single `floe` invocation, which is all probe-gen and checker-lookup need to agree on.
- Checker's `lookup_chain_call_probe` now renders + fingerprints the call-site args and tries the suffixed key first through the existing per-function / type-rooted cascade, falling back to the bare key for chains where literal threading isn't relevant (preserves pre-existing `c.req.param(...)` tests).
- Depth threshold in `extract_chain_key` / `chain_key_by_root_type` lowered from `>= 3` to `>= 2` so depth-2 segment lists (`c.json` after pushing the terminal field) reach the type-rooted key `Context$json`.

Sub-issue of #1285. Combined with #1351 (depth-1 probes) + #1353 (functional API handler paths), `c.json(body, 201)` now resolves to its narrow `TypedResponse<any, 201, "json">` in real hono handlers.

closes #1352

## Test plan

- [x] `cargo test --workspace` (1590 passing, +3 regression tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] Three regression tests added:
  - `generate_probe_threads_literal_args_into_call_probe` — literal `201` appears verbatim; fingerprinted probe emitted.
  - `generate_probe_emits_distinct_fingerprints_per_literal_tuple` — two `c.json` calls with distinct statuses produce two distinct probes.
  - `chain_call_probe_resolves_per_literal_arg_tuple` (checker) — disjoint-field probes prove the fingerprinted probe wins over the bare fallback.
- [x] Example apps pass (`floe check examples/todo-app/src/`, `examples/store/src/`, `examples/hono-api/src/`).
- [x] Real-world verification: running `floe check` on a hono handler in the `examples/hono-api` project tree produces `__chain_call_handleCreate__Context$json__<fp>: Response & import("hono").TypedResponse<any, 201, "json">` in the tsgo output — narrow on the status literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)