### PR TITLE
feat: [#1226] make keywords contextual - allow `type`, `todo`, `mock` as identifiers

### DIFF
--- a/crates/floe-core/src/analyse.rs
+++ b/crates/floe-core/src/analyse.rs
@@ -94,11 +94,13 @@ pub fn analyse_parsed(
     }
     let (diagnostics, name_types, expr_types, invalid_exprs) = checker.check_all(&program);
     let name_type_map = checker.take_name_type_map();
+    let shadowed_keywords = checker.take_shadowed_keyword_exprs();
     let references = std::mem::take(&mut checker.references);
     let typed = lower_to_typed(
         program,
         &expr_types,
         &invalid_exprs,
+        &shadowed_keywords,
         &inputs.resolved_imports,
     );
     AnalysedModule {

--- a/crates/floe-core/src/checker.rs
+++ b/crates/floe-core/src/checker.rs
@@ -272,11 +272,9 @@ pub struct Checker {
     /// program. LSP features (go-to-definition, find-references, rename)
     /// query this side-table instead of re-walking the AST.
     pub(crate) references: crate::reference::ReferenceTracker,
-    /// ExprIds of `ExprKind::Todo`/`Unreachable`/`Clear`/`Unchanged` expressions
-    /// that turned out to be references to a local binding with the same name
-    /// (issue #1226). `attach_types` rewrites these to `ExprKind::Identifier`
-    /// so codegen emits a variable read rather than the keyword's runtime
-    /// panic / Settable sentinel.
+    /// `ExprId`s of `Todo`/`Unreachable`/`Clear`/`Unchanged` that resolved
+    /// to a local binding of the same name. `attach_types` rewrites them
+    /// to `ExprKind::Identifier` so codegen emits the variable read.
     pub(crate) shadowed_keyword_exprs: HashMap<ExprId, &'static str>,
 }
 
@@ -660,10 +658,6 @@ impl Checker {
         std::mem::take(&mut self.name_type_map)
     }
 
-    /// Take the set of keyword-expression IDs (`todo`, `unreachable`, `clear`,
-    /// `unchanged`) that turned out to be references to a local binding with
-    /// the same name. `attach_types` consumes this to rewrite them into
-    /// plain identifier reads (issue #1226).
     pub fn take_shadowed_keyword_exprs(&mut self) -> HashMap<ExprId, &'static str> {
         std::mem::take(&mut self.shadowed_keyword_exprs)
     }

--- a/crates/floe-core/src/checker.rs
+++ b/crates/floe-core/src/checker.rs
@@ -272,6 +272,12 @@ pub struct Checker {
     /// program. LSP features (go-to-definition, find-references, rename)
     /// query this side-table instead of re-walking the AST.
     pub(crate) references: crate::reference::ReferenceTracker,
+    /// ExprIds of `ExprKind::Todo`/`Unreachable`/`Clear`/`Unchanged` expressions
+    /// that turned out to be references to a local binding with the same name
+    /// (issue #1226). `attach_types` rewrites these to `ExprKind::Identifier`
+    /// so codegen emits a variable read rather than the keyword's runtime
+    /// panic / Settable sentinel.
+    pub(crate) shadowed_keyword_exprs: HashMap<ExprId, &'static str>,
 }
 
 /// Signature of a trait method (for checking implementations).
@@ -480,6 +486,7 @@ impl Checker {
             ts_imports_missing_tsgo: HashSet::new(),
             active_type_params: HashMap::new(),
             references: crate::reference::ReferenceTracker::new(),
+            shadowed_keyword_exprs: HashMap::new(),
         }
     }
 
@@ -610,9 +617,15 @@ impl Checker {
     pub fn check_full(
         mut self,
         program: &Program,
-    ) -> (Vec<Diagnostic>, ExprTypeMap, HashSet<ExprId>) {
+    ) -> (
+        Vec<Diagnostic>,
+        ExprTypeMap,
+        HashSet<ExprId>,
+        HashMap<ExprId, &'static str>,
+    ) {
         let (diags, _, expr_types, invalid) = self.check_all(program);
-        (diags, expr_types, invalid)
+        let shadowed = self.take_shadowed_keyword_exprs();
+        (diags, expr_types, invalid, shadowed)
     }
 
     /// Check a program and return diagnostics, name_type_map, expr_type_map,
@@ -645,6 +658,14 @@ impl Checker {
     /// Take the checker's top-level `name -> Arc<Type>` map.
     pub fn take_name_type_map(&mut self) -> HashMap<String, std::sync::Arc<Type>> {
         std::mem::take(&mut self.name_type_map)
+    }
+
+    /// Take the set of keyword-expression IDs (`todo`, `unreachable`, `clear`,
+    /// `unchanged`) that turned out to be references to a local binding with
+    /// the same name. `attach_types` consumes this to rewrite them into
+    /// plain identifier reads (issue #1226).
+    pub fn take_shadowed_keyword_exprs(&mut self) -> HashMap<ExprId, &'static str> {
+        std::mem::take(&mut self.shadowed_keyword_exprs)
     }
 
     /// Run all checks and return all maps. Takes `&mut self` so callers

--- a/crates/floe-core/src/checker/attach.rs
+++ b/crates/floe-core/src/checker/attach.rs
@@ -103,9 +103,8 @@ pub fn attach_trait_decl_shallow(decl: &TraitDecl<()>) -> TypedTraitDecl {
 struct Attacher<'a> {
     types: &'a ExprTypeMap,
     invalid_exprs: &'a HashSet<ExprId>,
-    /// ExprIds of keyword-placeholder exprs (`Todo`, `Unreachable`, `Clear`,
-    /// `Unchanged`) that are shadowed by a local binding with the same name.
-    /// Rewritten to `ExprKind::Identifier` during attach (issue #1226).
+    /// Keyword-placeholder exprs (`Todo`/`Unreachable`/`Clear`/`Unchanged`)
+    /// shadowed by a local binding — rewritten to `ExprKind::Identifier`.
     shadowed_keywords: &'a HashMap<ExprId, &'static str>,
 }
 
@@ -370,10 +369,6 @@ impl Attacher<'_> {
             .cloned()
             .unwrap_or_else(|| Arc::clone(&UNKNOWN));
 
-        // Keyword expressions (`todo`, `unreachable`, `clear`, `unchanged`)
-        // shadowed by a local binding were flagged by the checker. Rewrite
-        // them to a plain identifier read so codegen emits the variable
-        // instead of the keyword's runtime form (issue #1226).
         if let Some(&name) = self.shadowed_keywords.get(&expr.id) {
             return Expr {
                 id: expr.id,

--- a/crates/floe-core/src/checker/attach.rs
+++ b/crates/floe-core/src/checker/attach.rs
@@ -23,6 +23,9 @@ static EMPTY_TYPES: LazyLock<ExprTypeMap> = LazyLock::new(ExprTypeMap::new);
 /// Shared empty invalid-exprs set for shallow import converters.
 static EMPTY_INVALID: LazyLock<HashSet<ExprId>> = LazyLock::new(HashSet::new);
 
+/// Shared empty shadowed-keyword map for shallow import converters.
+static EMPTY_SHADOWED: LazyLock<HashMap<ExprId, &'static str>> = LazyLock::new(HashMap::new);
+
 /// Convert an untyped program into a typed program, attaching each
 /// expression's resolved type from `types`. Expressions whose IDs
 /// appear in `invalid_exprs` are replaced with `ExprKind::Invalid`
@@ -34,10 +37,12 @@ pub fn attach_types(
     program: UntypedProgram,
     types: &ExprTypeMap,
     invalid_exprs: &HashSet<ExprId>,
+    shadowed_keywords: &HashMap<ExprId, &'static str>,
 ) -> TypedProgram {
     Attacher {
         types,
         invalid_exprs,
+        shadowed_keywords,
     }
     .program(program)
 }
@@ -57,11 +62,12 @@ pub fn lower_to_typed(
     mut program: UntypedProgram,
     expr_types: &ExprTypeMap,
     invalid_exprs: &HashSet<ExprId>,
+    shadowed_keywords: &HashMap<ExprId, &'static str>,
     resolved: &HashMap<String, ResolvedImports>,
 ) -> TypedProgram {
     crate::checker::mark_async_functions(&mut program);
     crate::desugar::desugar_program(&mut program, resolved);
-    attach_types(program, expr_types, invalid_exprs)
+    attach_types(program, expr_types, invalid_exprs, shadowed_keywords)
 }
 
 /// Convert an untyped `TypeDecl` (e.g. from the resolver's list of
@@ -76,6 +82,7 @@ pub fn attach_type_decl_shallow(decl: &TypeDecl<()>) -> TypedTypeDecl {
     Attacher {
         types: &EMPTY_TYPES,
         invalid_exprs: &EMPTY_INVALID,
+        shadowed_keywords: &EMPTY_SHADOWED,
     }
     .type_decl(decl.clone())
 }
@@ -88,6 +95,7 @@ pub fn attach_trait_decl_shallow(decl: &TraitDecl<()>) -> TypedTraitDecl {
     Attacher {
         types: &EMPTY_TYPES,
         invalid_exprs: &EMPTY_INVALID,
+        shadowed_keywords: &EMPTY_SHADOWED,
     }
     .trait_decl(decl.clone())
 }
@@ -95,6 +103,10 @@ pub fn attach_trait_decl_shallow(decl: &TraitDecl<()>) -> TypedTraitDecl {
 struct Attacher<'a> {
     types: &'a ExprTypeMap,
     invalid_exprs: &'a HashSet<ExprId>,
+    /// ExprIds of keyword-placeholder exprs (`Todo`, `Unreachable`, `Clear`,
+    /// `Unchanged`) that are shadowed by a local binding with the same name.
+    /// Rewritten to `ExprKind::Identifier` during attach (issue #1226).
+    shadowed_keywords: &'a HashMap<ExprId, &'static str>,
 }
 
 impl Attacher<'_> {
@@ -357,6 +369,20 @@ impl Attacher<'_> {
             .get(&expr.id)
             .cloned()
             .unwrap_or_else(|| Arc::clone(&UNKNOWN));
+
+        // Keyword expressions (`todo`, `unreachable`, `clear`, `unchanged`)
+        // shadowed by a local binding were flagged by the checker. Rewrite
+        // them to a plain identifier read so codegen emits the variable
+        // instead of the keyword's runtime form (issue #1226).
+        if let Some(&name) = self.shadowed_keywords.get(&expr.id) {
+            return Expr {
+                id: expr.id,
+                kind: ExprKind::Identifier(name.to_string()),
+                ty,
+                span: expr.span,
+            };
+        }
+
         Expr {
             id: expr.id,
             kind: self.expr_kind(expr.kind),
@@ -578,6 +604,7 @@ mod tests {
             program,
             &ExprTypeMap::new(),
             &std::collections::HashSet::new(),
+            &std::collections::HashMap::new(),
         );
         assert!(typed.items.is_empty());
     }
@@ -604,6 +631,7 @@ mod tests {
             program,
             &ExprTypeMap::new(),
             &std::collections::HashSet::new(),
+            &std::collections::HashMap::new(),
         );
         let ItemKind::Expr(e) = &typed.items[0].kind else {
             panic!("expected Expr item");
@@ -630,7 +658,12 @@ mod tests {
             }],
             span: span(),
         };
-        let typed = attach_types(program, &types, &std::collections::HashSet::new());
+        let typed = attach_types(
+            program,
+            &types,
+            &std::collections::HashSet::new(),
+            &std::collections::HashMap::new(),
+        );
         let ItemKind::Expr(e) = &typed.items[0].kind else {
             panic!("expected Expr item");
         };

--- a/crates/floe-core/src/checker/expr.rs
+++ b/crates/floe-core/src/checker/expr.rs
@@ -202,19 +202,29 @@ impl Checker {
                 let inner_ty = self.check_expr(inner);
                 Type::Settable(Arc::new(inner_ty))
             }
-            ExprKind::Clear => Type::Settable(Arc::new(Type::Unknown)),
-            ExprKind::Unchanged => Type::Settable(Arc::new(Type::Unknown)),
+            ExprKind::Clear => self
+                .resolve_shadowed_keyword(expr.id, "clear", expr.span)
+                .unwrap_or_else(|| Type::Settable(Arc::new(Type::Unknown))),
+            ExprKind::Unchanged => self
+                .resolve_shadowed_keyword(expr.id, "unchanged", expr.span)
+                .unwrap_or_else(|| Type::Settable(Arc::new(Type::Unknown))),
             ExprKind::Todo => {
-                self.emit_warning_with_help(
-                    "`todo` is a placeholder that will panic at runtime",
-                    expr.span,
-                    ErrorCode::TodoPlaceholder,
-                    "not yet implemented",
-                    "replace with actual implementation before shipping",
-                );
-                Type::Never
+                if let Some(ty) = self.resolve_shadowed_keyword(expr.id, "todo", expr.span) {
+                    ty
+                } else {
+                    self.emit_warning_with_help(
+                        "`todo` is a placeholder that will panic at runtime",
+                        expr.span,
+                        ErrorCode::TodoPlaceholder,
+                        "not yet implemented",
+                        "replace with actual implementation before shipping",
+                    );
+                    Type::Never
+                }
             }
-            ExprKind::Unreachable => Type::Never,
+            ExprKind::Unreachable => self
+                .resolve_shadowed_keyword(expr.id, "unreachable", expr.span)
+                .unwrap_or(Type::Never),
             ExprKind::Unit => Type::Unit,
             ExprKind::Jsx(element) => {
                 self.check_jsx(element);
@@ -264,6 +274,25 @@ impl Checker {
     }
 
     // ── Extracted Expression Checkers ────────────────────────────────
+
+    /// If `name` is bound in the current scope, treat the keyword expression
+    /// `expr_id` as a reference to that local instead of a keyword. Records
+    /// the shadowing so `attach_types` can rewrite the `ExprKind` to
+    /// `Identifier` (issue #1226).
+    fn resolve_shadowed_keyword(
+        &mut self,
+        expr_id: ExprId,
+        name: &'static str,
+        span: Span,
+    ) -> Option<Type> {
+        let ty = self.env.lookup(name).cloned()?;
+        if let Some(def_span) = self.env.lookup_def_span(name) {
+            self.references.record(def_span, span);
+        }
+        self.unused.used_names.insert(name.to_string());
+        self.shadowed_keyword_exprs.insert(expr_id, name);
+        Some(ty)
+    }
 
     fn check_identifier(&mut self, name: &str, span: Span) -> Type {
         self.unused.used_names.insert(name.to_string());

--- a/crates/floe-core/src/checker/expr.rs
+++ b/crates/floe-core/src/checker/expr.rs
@@ -275,10 +275,8 @@ impl Checker {
 
     // ── Extracted Expression Checkers ────────────────────────────────
 
-    /// If `name` is bound in the current scope, treat the keyword expression
-    /// `expr_id` as a reference to that local instead of a keyword. Records
-    /// the shadowing so `attach_types` can rewrite the `ExprKind` to
-    /// `Identifier` (issue #1226).
+    /// When `name` resolves to a local binding, return its type and flag
+    /// the expression for rewrite by `attach_types`.
     fn resolve_shadowed_keyword(
         &mut self,
         expr_id: ExprId,

--- a/crates/floe-core/src/codegen/tests.rs
+++ b/crates/floe-core/src/codegen/tests.rs
@@ -1698,12 +1698,11 @@ test "math" {
     assert!(result.contains("FAIL"), "should have fail reporting");
 }
 
-// ── Contextual keywords: shadowing (issue #1226) ────────────────────
+// ── Contextual keyword shadowing ────────────────────────────
 
 #[test]
 fn bare_todo_without_shadow_still_panics() {
     let result = emit_typed("todo");
-    // With no binding in scope, `todo` keeps its panic-placeholder meaning.
     assert!(
         result.contains("throw new Error"),
         "expected throw, got: {result}"
@@ -1712,8 +1711,6 @@ fn bare_todo_without_shadow_still_panics() {
 
 #[test]
 fn local_todo_binding_shadows_keyword() {
-    // `let todo = 5` binds a local. A bare `todo` reference in the same
-    // scope should resolve to the binding, not the keyword placeholder.
     let result = emit_typed(
         r#"let todo = 5
 let used = todo"#,

--- a/crates/floe-core/src/codegen/tests.rs
+++ b/crates/floe-core/src/codegen/tests.rs
@@ -21,6 +21,7 @@ fn emit(input: &str) -> String {
         program,
         &crate::checker::ExprTypeMap::new(),
         &std::collections::HashSet::new(),
+        &std::collections::HashMap::new(),
     );
     let output = Codegen::new().generate(&typed);
     output.code.trim().to_string()
@@ -40,8 +41,9 @@ fn emit_typed(input: &str) -> String {
         )
     });
     desugar::desugar_program(&mut program, &std::collections::HashMap::new());
-    let (_diags, expr_types, invalid_exprs) = crate::checker::Checker::new().check_full(&program);
-    let typed = crate::checker::attach_types(program, &expr_types, &invalid_exprs);
+    let (_diags, expr_types, invalid_exprs, shadowed) =
+        crate::checker::Checker::new().check_full(&program);
+    let typed = crate::checker::attach_types(program, &expr_types, &invalid_exprs, &shadowed);
     let output = Codegen::new().generate(&typed);
     output.code.trim().to_string()
 }
@@ -791,6 +793,7 @@ fn jsx_detection() {
         program,
         &crate::checker::ExprTypeMap::new(),
         &std::collections::HashSet::new(),
+        &std::collections::HashMap::new(),
     );
     let output = Codegen::new().generate(&typed);
     assert!(output.has_jsx);
@@ -803,6 +806,7 @@ fn no_jsx_detection() {
         program,
         &crate::checker::ExprTypeMap::new(),
         &std::collections::HashSet::new(),
+        &std::collections::HashMap::new(),
     );
     let output = Codegen::new().generate(&typed);
     assert!(!output.has_jsx);
@@ -1352,12 +1356,16 @@ fn emit_with_types(input: &str) -> String {
                 .join("\n")
         )
     });
-    let (_, expr_types, _) = crate::checker::Checker::new().check_full(&program);
+    let (_, expr_types, _, shadowed) = crate::checker::Checker::new().check_full(&program);
     let mut program = program;
     crate::checker::mark_async_functions(&mut program);
     desugar::desugar_program(&mut program, &std::collections::HashMap::new());
-    let typed =
-        crate::checker::attach_types(program, &expr_types, &std::collections::HashSet::new());
+    let typed = crate::checker::attach_types(
+        program,
+        &expr_types,
+        &std::collections::HashSet::new(),
+        &shadowed,
+    );
     Codegen::new().generate(&typed).code.trim().to_string()
 }
 
@@ -1646,6 +1654,7 @@ fn emit_test_mode(input: &str) -> String {
         program,
         &crate::checker::ExprTypeMap::new(),
         &std::collections::HashSet::new(),
+        &std::collections::HashMap::new(),
     );
     let output = Codegen::new().with_test_mode().generate(&typed);
     output.code.trim().to_string()
@@ -1687,6 +1696,48 @@ test "math" {
     assert!(result.contains("math"), "test name should appear in output");
     assert!(result.contains("PASS"), "should have pass reporting");
     assert!(result.contains("FAIL"), "should have fail reporting");
+}
+
+// ── Contextual keywords: shadowing (issue #1226) ────────────────────
+
+#[test]
+fn bare_todo_without_shadow_still_panics() {
+    let result = emit_typed("todo");
+    // With no binding in scope, `todo` keeps its panic-placeholder meaning.
+    assert!(
+        result.contains("throw new Error"),
+        "expected throw, got: {result}"
+    );
+}
+
+#[test]
+fn local_todo_binding_shadows_keyword() {
+    // `let todo = 5` binds a local. A bare `todo` reference in the same
+    // scope should resolve to the binding, not the keyword placeholder.
+    let result = emit_typed(
+        r#"let todo = 5
+let used = todo"#,
+    );
+    assert!(
+        !result.contains("not yet implemented"),
+        "shadowed todo should not emit panic, got: {result}"
+    );
+    assert!(
+        result.contains("const used = todo"),
+        "shadowed todo should compile to identifier read, got: {result}"
+    );
+}
+
+#[test]
+fn local_unreachable_binding_shadows_keyword() {
+    let result = emit_typed(
+        r#"let unreachable = 42
+let out = unreachable"#,
+    );
+    assert!(
+        result.contains("const out = unreachable"),
+        "shadowed unreachable should compile to identifier read, got: {result}"
+    );
 }
 
 // (Inline for-declaration tests removed — only block form is supported)

--- a/crates/floe-core/src/cst.rs
+++ b/crates/floe-core/src/cst.rs
@@ -208,6 +208,57 @@ impl<'src> CstParser<'src> {
         )
     }
 
+    /// True when the current token is a keyword that can appear as an
+    /// identifier in unambiguous identifier positions (record field names,
+    /// binders, parameter names, JSX attributes, etc.). See issue #1226 for
+    /// the decision to make these contextual.
+    fn is_contextual_ident_keyword(&self) -> bool {
+        matches!(
+            self.current_kind(),
+            Some(
+                TokenKind::Type
+                    | TokenKind::Todo
+                    | TokenKind::Unreachable
+                    | TokenKind::Mock
+                    | TokenKind::Parse
+                    | TokenKind::Clear
+                    | TokenKind::Unchanged
+                    | TokenKind::Trusted
+                    | TokenKind::Opaque
+                    | TokenKind::Collect
+                    | TokenKind::Deriving
+            )
+        )
+    }
+
+    /// Accept the current token as an identifier, allowing contextual
+    /// keywords. Keyword tokens are remapped to `IDENT` in the green tree so
+    /// downstream lowering treats them uniformly.
+    fn is_ident_flex(&self) -> bool {
+        self.is_ident() || self.is_contextual_ident_keyword()
+    }
+
+    /// Consume the current token as an identifier, remapping contextual
+    /// keywords to `IDENT`. On a non-identifier token, records an error but
+    /// does not bump.
+    fn expect_ident_flex(&mut self) {
+        if matches!(self.current_kind(), Some(TokenKind::Identifier(_))) {
+            self.bump();
+        } else if self.is_contextual_ident_keyword() {
+            self.bump_remap(SyntaxKind::IDENT);
+        } else {
+            self.error_kind(
+                &format!("expected identifier, found {:?}", self.current_kind()),
+                CstErrorKind::UnexpectedToken,
+            );
+        }
+    }
+
+    /// `parse_comma_separated`-compatible wrapper for `expect_ident_flex`.
+    fn expect_ident_flex_item(&mut self) {
+        self.expect_ident_flex();
+    }
+
     /// Check if the current token is a keyword that could appear as a JSX prop name
     /// (e.g., `type`, `for`, `match`, `fn`, `const`, etc.).
     fn is_keyword(&self) -> bool {
@@ -222,6 +273,16 @@ impl<'src> CstParser<'src> {
                     | TokenKind::Import
                     | TokenKind::Export
                     | TokenKind::Trait
+                    | TokenKind::Todo
+                    | TokenKind::Unreachable
+                    | TokenKind::Mock
+                    | TokenKind::Parse
+                    | TokenKind::Clear
+                    | TokenKind::Unchanged
+                    | TokenKind::Trusted
+                    | TokenKind::Opaque
+                    | TokenKind::Collect
+                    | TokenKind::Deriving
             )
         )
     }
@@ -576,8 +637,13 @@ impl<'src> CstParser<'src> {
     }
 
     fn expect_ident(&mut self) {
-        if self.is_ident() {
+        if matches!(self.current_kind(), Some(TokenKind::Identifier(_))) {
             self.bump();
+        } else if self.at(TokenKind::Parse) {
+            // `parse` was historically accepted as an identifier but bumped
+            // with its keyword SyntaxKind — remap so lowering sees IDENT
+            // uniformly with other contextual keywords.
+            self.bump_remap(SyntaxKind::IDENT);
         } else {
             self.error_kind(
                 &format!("expected identifier, found {:?}", self.current_kind()),
@@ -604,12 +670,12 @@ impl<'src> CstParser<'src> {
 
     /// Parse a destructuring field: `ident` or `ident: ident` (with rename).
     fn parse_destructure_field(&mut self) {
-        self.expect_ident();
+        self.expect_ident_flex();
         self.eat_trivia();
         if self.at(TokenKind::Colon) {
             self.bump(); // eat ':'
             self.eat_trivia();
-            self.expect_ident(); // alias
+            self.expect_ident_flex(); // alias
         }
     }
 

--- a/crates/floe-core/src/cst.rs
+++ b/crates/floe-core/src/cst.rs
@@ -208,83 +208,42 @@ impl<'src> CstParser<'src> {
         )
     }
 
-    /// True when the current token is a keyword that can appear as an
-    /// identifier in unambiguous identifier positions (record field names,
-    /// binders, parameter names, JSX attributes, etc.). See issue #1226 for
-    /// the decision to make these contextual.
-    fn is_contextual_ident_keyword(&self) -> bool {
-        matches!(
-            self.current_kind(),
-            Some(
-                TokenKind::Type
-                    | TokenKind::Todo
-                    | TokenKind::Unreachable
-                    | TokenKind::Mock
-                    | TokenKind::Parse
-                    | TokenKind::Clear
-                    | TokenKind::Unchanged
-                    | TokenKind::Trusted
-                    | TokenKind::Opaque
-                    | TokenKind::Collect
-                    | TokenKind::Deriving
-            )
-        )
-    }
-
-    /// Accept the current token as an identifier, allowing contextual
-    /// keywords. Keyword tokens are remapped to `IDENT` in the green tree so
-    /// downstream lowering treats them uniformly.
     fn is_ident_flex(&self) -> bool {
-        self.is_ident() || self.is_contextual_ident_keyword()
+        matches!(self.current_kind(), Some(TokenKind::Identifier(_)))
+            || self.current_kind().is_some_and(|k| k.is_contextual_ident())
     }
 
-    /// Consume the current token as an identifier, remapping contextual
-    /// keywords to `IDENT`. On a non-identifier token, records an error but
-    /// does not bump.
     fn expect_ident_flex(&mut self) {
-        if matches!(self.current_kind(), Some(TokenKind::Identifier(_))) {
-            self.bump();
-        } else if self.is_contextual_ident_keyword() {
-            self.bump_remap(SyntaxKind::IDENT);
-        } else {
-            self.error_kind(
+        match self.current_kind() {
+            Some(TokenKind::Identifier(_)) => self.bump(),
+            Some(k) if k.is_contextual_ident() => self.bump_remap(SyntaxKind::IDENT),
+            _ => self.error_kind(
                 &format!("expected identifier, found {:?}", self.current_kind()),
                 CstErrorKind::UnexpectedToken,
-            );
+            ),
         }
     }
 
-    /// `parse_comma_separated`-compatible wrapper for `expect_ident_flex`.
     fn expect_ident_flex_item(&mut self) {
         self.expect_ident_flex();
     }
 
-    /// Check if the current token is a keyword that could appear as a JSX prop name
-    /// (e.g., `type`, `for`, `match`, `fn`, `const`, etc.).
+    /// Keywords accepted as JSX prop names (`<input type="text" />`,
+    /// `<label for="..." />`).
     fn is_keyword(&self) -> bool {
-        matches!(
-            self.current_kind(),
+        match self.current_kind() {
+            Some(k) if k.is_contextual_ident() => true,
             Some(
-                TokenKind::Type
-                    | TokenKind::For
-                    | TokenKind::Match
-                    | TokenKind::Fn
-                    | TokenKind::Let
-                    | TokenKind::Import
-                    | TokenKind::Export
-                    | TokenKind::Trait
-                    | TokenKind::Todo
-                    | TokenKind::Unreachable
-                    | TokenKind::Mock
-                    | TokenKind::Parse
-                    | TokenKind::Clear
-                    | TokenKind::Unchanged
-                    | TokenKind::Trusted
-                    | TokenKind::Opaque
-                    | TokenKind::Collect
-                    | TokenKind::Deriving
-            )
-        )
+                TokenKind::For
+                | TokenKind::Match
+                | TokenKind::Fn
+                | TokenKind::Let
+                | TokenKind::Import
+                | TokenKind::Export
+                | TokenKind::Trait,
+            ) => true,
+            _ => false,
+        }
     }
 
     /// Check if the current token maps to a SyntaxKind that is a valid member
@@ -637,18 +596,13 @@ impl<'src> CstParser<'src> {
     }
 
     fn expect_ident(&mut self) {
-        if matches!(self.current_kind(), Some(TokenKind::Identifier(_))) {
-            self.bump();
-        } else if self.at(TokenKind::Parse) {
-            // `parse` was historically accepted as an identifier but bumped
-            // with its keyword SyntaxKind — remap so lowering sees IDENT
-            // uniformly with other contextual keywords.
-            self.bump_remap(SyntaxKind::IDENT);
-        } else {
-            self.error_kind(
+        match self.current_kind() {
+            Some(TokenKind::Identifier(_)) => self.bump(),
+            Some(TokenKind::Parse) => self.bump_remap(SyntaxKind::IDENT),
+            _ => self.error_kind(
                 &format!("expected identifier, found {:?}", self.current_kind()),
                 CstErrorKind::UnexpectedToken,
-            );
+            ),
         }
     }
 

--- a/crates/floe-core/src/cst/exprs.rs
+++ b/crates/floe-core/src/cst/exprs.rs
@@ -268,9 +268,6 @@ impl<'src> CstParser<'src> {
                 self.builder.finish_node();
             }
 
-            // `parse` is keyword only when followed by `<` (issue #1226).
-            // Without the angle-bracket, it parses as an identifier reference
-            // so users can bind local `parse` variables.
             Some(TokenKind::Parse) if self.peek_is(TokenKind::LessThan) => {
                 self.builder.start_node(SyntaxKind::PARSE_EXPR.into());
                 self.bump(); // parse
@@ -294,7 +291,6 @@ impl<'src> CstParser<'src> {
             }
             Some(TokenKind::Parse) => self.bump_remap(SyntaxKind::IDENT),
 
-            // `mock` is keyword only when followed by `<` (issue #1226).
             Some(TokenKind::Mock) if self.peek_is(TokenKind::LessThan) => {
                 self.builder.start_node(SyntaxKind::MOCK_EXPR.into());
                 self.bump(); // mock
@@ -327,7 +323,6 @@ impl<'src> CstParser<'src> {
             Some(TokenKind::Mock) => self.bump_remap(SyntaxKind::IDENT),
 
             Some(TokenKind::Match) => self.parse_match_expr(),
-            // `collect` is keyword only when followed by `{` (issue #1226).
             Some(TokenKind::Collect) if self.peek_is(TokenKind::LeftBrace) => {
                 self.builder.start_node(SyntaxKind::COLLECT_EXPR.into());
                 self.bump(); // collect
@@ -402,11 +397,8 @@ impl<'src> CstParser<'src> {
                 self.bump();
             }
 
-            // Contextual keywords with no expression-form semantics — they
-            // are only keywords at their specific item-level positions (type
-            // declarations, import modifiers, type derives). In expression
-            // position they parse as identifier references so users can bind
-            // and read locals with these names (issue #1226).
+            // These are keywords only at item-declaration positions; in
+            // expression position they're plain identifier reads.
             Some(
                 TokenKind::Type | TokenKind::Opaque | TokenKind::Trusted | TokenKind::Deriving,
             ) => self.bump_remap(SyntaxKind::IDENT),
@@ -548,15 +540,9 @@ impl<'src> CstParser<'src> {
     fn parse_call_arg(&mut self) {
         self.builder.start_node(SyntaxKind::ARG.into());
 
-        // Named arg: `label: expr` or punned `label:`. Contextual keywords
-        // are accepted as labels (issue #1226, e.g. `Message(type: "click")`).
-        if (self.is_ident() || self.is_contextual_ident_keyword()) && self.peek_is(TokenKind::Colon)
-        {
-            if matches!(self.current_kind(), Some(TokenKind::Identifier(_))) {
-                self.bump(); // label
-            } else {
-                self.bump_remap(SyntaxKind::IDENT);
-            }
+        // Named arg: `label: expr` or punned `label:`.
+        if self.is_ident_flex() && self.peek_is(TokenKind::Colon) {
+            self.expect_ident_flex();
             self.eat_trivia();
             self.bump(); // :
 
@@ -893,23 +879,8 @@ impl<'src> CstParser<'src> {
         if i >= self.tokens.len() {
             return false;
         }
-        // The first entry must be an identifier or a contextual keyword that
-        // can appear as a field name (e.g. `{ type: ... }`).
-        if !matches!(
-            &self.tokens[i].kind,
-            TokenKind::Identifier(_)
-                | TokenKind::Type
-                | TokenKind::Todo
-                | TokenKind::Unreachable
-                | TokenKind::Mock
-                | TokenKind::Parse
-                | TokenKind::Clear
-                | TokenKind::Unchanged
-                | TokenKind::Trusted
-                | TokenKind::Opaque
-                | TokenKind::Collect
-                | TokenKind::Deriving
-        ) {
+        let first = &self.tokens[i].kind;
+        if !matches!(first, TokenKind::Identifier(_)) && !first.is_contextual_ident() {
             return false;
         }
         // Next non-trivia token after the ident must be `:` (key: value) or `,` or `}` (shorthand)

--- a/crates/floe-core/src/cst/exprs.rs
+++ b/crates/floe-core/src/cst/exprs.rs
@@ -268,7 +268,10 @@ impl<'src> CstParser<'src> {
                 self.builder.finish_node();
             }
 
-            Some(TokenKind::Parse) => {
+            // `parse` is keyword only when followed by `<` (issue #1226).
+            // Without the angle-bracket, it parses as an identifier reference
+            // so users can bind local `parse` variables.
+            Some(TokenKind::Parse) if self.peek_is(TokenKind::LessThan) => {
                 self.builder.start_node(SyntaxKind::PARSE_EXPR.into());
                 self.bump(); // parse
                 self.eat_trivia();
@@ -289,8 +292,10 @@ impl<'src> CstParser<'src> {
                 }
                 self.builder.finish_node();
             }
+            Some(TokenKind::Parse) => self.bump_remap(SyntaxKind::IDENT),
 
-            Some(TokenKind::Mock) => {
+            // `mock` is keyword only when followed by `<` (issue #1226).
+            Some(TokenKind::Mock) if self.peek_is(TokenKind::LessThan) => {
                 self.builder.start_node(SyntaxKind::MOCK_EXPR.into());
                 self.bump(); // mock
                 self.eat_trivia();
@@ -319,15 +324,18 @@ impl<'src> CstParser<'src> {
                 }
                 self.builder.finish_node();
             }
+            Some(TokenKind::Mock) => self.bump_remap(SyntaxKind::IDENT),
 
             Some(TokenKind::Match) => self.parse_match_expr(),
-            Some(TokenKind::Collect) => {
+            // `collect` is keyword only when followed by `{` (issue #1226).
+            Some(TokenKind::Collect) if self.peek_is(TokenKind::LeftBrace) => {
                 self.builder.start_node(SyntaxKind::COLLECT_EXPR.into());
                 self.bump(); // collect
                 self.eat_trivia();
                 self.parse_block_expr();
                 self.builder.finish_node();
             }
+            Some(TokenKind::Collect) => self.bump_remap(SyntaxKind::IDENT),
             Some(TokenKind::LeftBrace) => {
                 if self.is_object_literal() {
                     self.parse_object_literal();
@@ -393,6 +401,15 @@ impl<'src> CstParser<'src> {
             Some(TokenKind::SelfKw) => {
                 self.bump();
             }
+
+            // Contextual keywords with no expression-form semantics — they
+            // are only keywords at their specific item-level positions (type
+            // declarations, import modifiers, type derives). In expression
+            // position they parse as identifier references so users can bind
+            // and read locals with these names (issue #1226).
+            Some(
+                TokenKind::Type | TokenKind::Opaque | TokenKind::Trusted | TokenKind::Deriving,
+            ) => self.bump_remap(SyntaxKind::IDENT),
 
             Some(TokenKind::Identifier(name)) => {
                 let name = name.clone();
@@ -531,9 +548,15 @@ impl<'src> CstParser<'src> {
     fn parse_call_arg(&mut self) {
         self.builder.start_node(SyntaxKind::ARG.into());
 
-        // Named arg: `label: expr` or punned `label:`
-        if self.is_ident() && self.peek_is(TokenKind::Colon) {
-            self.bump(); // label
+        // Named arg: `label: expr` or punned `label:`. Contextual keywords
+        // are accepted as labels (issue #1226, e.g. `Message(type: "click")`).
+        if (self.is_ident() || self.is_contextual_ident_keyword()) && self.peek_is(TokenKind::Colon)
+        {
+            if matches!(self.current_kind(), Some(TokenKind::Identifier(_))) {
+                self.bump(); // label
+            } else {
+                self.bump_remap(SyntaxKind::IDENT);
+            }
             self.eat_trivia();
             self.bump(); // :
 
@@ -833,7 +856,7 @@ impl<'src> CstParser<'src> {
     }
 
     fn parse_record_pattern_field(&mut self) {
-        self.expect_ident();
+        self.expect_ident_flex();
         self.eat_trivia();
         if self.at(TokenKind::Colon) {
             self.bump();
@@ -847,7 +870,7 @@ impl<'src> CstParser<'src> {
     fn parse_named_variant_pattern_field(&mut self) {
         self.builder
             .start_node(SyntaxKind::VARIANT_FIELD_PATTERN.into());
-        self.expect_ident();
+        self.expect_ident_flex();
         self.eat_trivia();
         if self.at(TokenKind::Colon) {
             self.bump();
@@ -870,8 +893,23 @@ impl<'src> CstParser<'src> {
         if i >= self.tokens.len() {
             return false;
         }
-        // Must be an identifier (not a keyword)
-        if !matches!(self.tokens[i].kind, TokenKind::Identifier(_)) {
+        // The first entry must be an identifier or a contextual keyword that
+        // can appear as a field name (e.g. `{ type: ... }`).
+        if !matches!(
+            &self.tokens[i].kind,
+            TokenKind::Identifier(_)
+                | TokenKind::Type
+                | TokenKind::Todo
+                | TokenKind::Unreachable
+                | TokenKind::Mock
+                | TokenKind::Parse
+                | TokenKind::Clear
+                | TokenKind::Unchanged
+                | TokenKind::Trusted
+                | TokenKind::Opaque
+                | TokenKind::Collect
+                | TokenKind::Deriving
+        ) {
             return false;
         }
         // Next non-trivia token after the ident must be `:` (key: value) or `,` or `}` (shorthand)
@@ -899,7 +937,7 @@ impl<'src> CstParser<'src> {
 
     fn parse_object_field(&mut self) {
         self.builder.start_node(SyntaxKind::OBJECT_FIELD.into());
-        self.expect_ident();
+        self.expect_ident_flex();
         self.eat_trivia();
         if self.at(TokenKind::Colon) {
             self.bump(); // :

--- a/crates/floe-core/src/cst/items.rs
+++ b/crates/floe-core/src/cst/items.rs
@@ -285,7 +285,7 @@ impl<'src> CstParser<'src> {
         if self.looks_like_let_function_binding() {
             self.builder
                 .start_node_at(checkpoint, SyntaxKind::FUNCTION_DECL.into());
-            self.expect_ident();
+            self.expect_ident_flex();
             self.eat_trivia();
             self.parse_let_function_body();
             self.builder.finish_node();
@@ -303,7 +303,7 @@ impl<'src> CstParser<'src> {
             self.error("expected identifier, `{`, or `(`");
             self.bump();
             self.eat_trivia();
-            self.parse_comma_separated(Self::expect_ident_item, TokenKind::RightBracket);
+            self.parse_comma_separated(Self::expect_ident_flex_item, TokenKind::RightBracket);
             self.expect(TokenKind::RightBracket);
         } else if self.at(TokenKind::LeftBrace) {
             self.bump();
@@ -313,10 +313,10 @@ impl<'src> CstParser<'src> {
         } else if self.at(TokenKind::LeftParen) && self.is_const_tuple_destructuring() {
             self.bump();
             self.eat_trivia();
-            self.parse_comma_separated(Self::expect_ident_item, TokenKind::RightParen);
+            self.parse_comma_separated(Self::expect_ident_flex_item, TokenKind::RightParen);
             self.expect(TokenKind::RightParen);
         } else {
-            self.expect_ident();
+            self.expect_ident_flex();
         }
         self.eat_trivia();
 
@@ -338,7 +338,7 @@ impl<'src> CstParser<'src> {
     /// In def-form, params follow immediately after the name (with optional
     /// generics in between) — no `=` between them.
     fn looks_like_let_function_binding(&self) -> bool {
-        if !self.is_ident() {
+        if !self.is_ident_flex() {
             return false;
         }
         let mut i = self.pos + 1;
@@ -452,7 +452,7 @@ impl<'src> CstParser<'src> {
             // Tuple destructured param: (a, b)
             self.bump(); // (
             self.eat_trivia();
-            self.parse_comma_separated(Self::expect_ident_item, TokenKind::RightParen);
+            self.parse_comma_separated(Self::expect_ident_flex_item, TokenKind::RightParen);
             self.expect(TokenKind::RightParen);
             self.eat_trivia();
         } else if self.at(TokenKind::SelfKw) {
@@ -462,7 +462,7 @@ impl<'src> CstParser<'src> {
             self.bump(); // _
             self.eat_trivia();
         } else {
-            self.expect_ident();
+            self.expect_ident_flex();
             self.eat_trivia();
         }
 
@@ -772,7 +772,7 @@ impl<'src> CstParser<'src> {
 
     fn parse_record_field(&mut self) {
         self.builder.start_node(SyntaxKind::RECORD_FIELD.into());
-        self.expect_ident();
+        self.expect_ident_flex();
         self.eat_trivia();
         self.expect(TokenKind::Colon);
         self.eat_trivia();

--- a/crates/floe-core/src/lexer/token.rs
+++ b/crates/floe-core/src/lexer/token.rs
@@ -187,6 +187,27 @@ pub enum TokenKind {
     BlockComment,
 }
 
+impl TokenKind {
+    /// True for keywords that are reserved only in their specific syntactic
+    /// position and parse as identifiers elsewhere.
+    pub fn is_contextual_ident(&self) -> bool {
+        matches!(
+            self,
+            Self::Type
+                | Self::Todo
+                | Self::Unreachable
+                | Self::Mock
+                | Self::Parse
+                | Self::Clear
+                | Self::Unchanged
+                | Self::Trusted
+                | Self::Opaque
+                | Self::Collect
+                | Self::Deriving
+        )
+    }
+}
+
 /// Template literal parts: either a raw string segment or an interpolation hole.
 #[derive(Debug, Clone, PartialEq)]
 pub enum TemplatePart {

--- a/crates/floe-core/src/parser/tests.rs
+++ b/crates/floe-core/src/parser/tests.rs
@@ -2724,3 +2724,125 @@ fn parse_lossy_module_exposes_extra_even_when_errors() {
     assert_eq!(extra.comments.len(), 1);
     assert!(extra.new_lines.contains(&10));
 }
+
+// ── Contextual keywords (issue #1226) ────────────────────────
+// Keywords like `type`, `todo`, `mock` may appear as identifiers in
+// unambiguous positions (field names, binders, parameter names). The
+// parser remaps them to IDENT when consumed in those positions.
+
+fn const_name(item: ItemKind) -> String {
+    match item {
+        ItemKind::Const(c) => match c.binding {
+            ConstBinding::Name(n) => n,
+            other => panic!("expected simple-name binding, got {other:?}"),
+        },
+        ItemKind::Function(f) => f.name,
+        other => panic!("expected Const or Function, got {other:?}"),
+    }
+}
+
+#[test]
+fn let_binder_accepts_type_keyword() {
+    assert_eq!(const_name(first_item("let type = 5")), "type");
+}
+
+#[test]
+fn let_binder_accepts_todo_keyword() {
+    assert_eq!(const_name(first_item("let todo = 5")), "todo");
+}
+
+#[test]
+fn let_binder_accepts_mock_keyword() {
+    assert_eq!(const_name(first_item("let mock = 5")), "mock");
+}
+
+#[test]
+fn let_binder_accepts_parse_keyword() {
+    assert_eq!(const_name(first_item("let parse = 5")), "parse");
+}
+
+#[test]
+fn fn_name_accepts_type_keyword() {
+    assert_eq!(
+        const_name(first_item("let type(x: number) -> number = { x }")),
+        "type"
+    );
+}
+
+#[test]
+fn fn_param_accepts_type_keyword() {
+    let ItemKind::Function(f) = first_item("let f(type: number) -> number = { 0 }") else {
+        panic!("expected Function");
+    };
+    assert_eq!(f.params[0].name, "type");
+}
+
+#[test]
+fn fn_param_accepts_todo_keyword() {
+    let ItemKind::Function(f) = first_item("let save(todo: string) -> string = { todo }") else {
+        panic!("expected Function");
+    };
+    assert_eq!(f.params[0].name, "todo");
+}
+
+#[test]
+fn record_type_accepts_type_as_field_name() {
+    let prog = parse_ok("type Message = { type: string, body: string }");
+    let ItemKind::TypeDecl(decl) = &prog.items[0].kind else {
+        panic!("expected TypeDecl");
+    };
+    let TypeDef::Record(entries) = &decl.def else {
+        panic!("expected Record def");
+    };
+    let names: Vec<&str> = entries
+        .iter()
+        .filter_map(|e| match e {
+            RecordEntry::Field(f) => Some(f.name.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(names, vec!["type", "body"]);
+}
+
+#[test]
+fn record_literal_accepts_type_as_field_name() {
+    let ExprKind::Object(fields) = first_expr(r#"{ type: "click", x: 1 }"#) else {
+        panic!("expected Object literal");
+    };
+    assert_eq!(fields[0].0, "type");
+    assert_eq!(fields[1].0, "x");
+}
+
+#[test]
+fn record_pattern_accepts_type_as_field_name() {
+    // Inside a match arm, `{ type: "click" }` matches a record with a `type`
+    // field. The parser must not reject `type` here.
+    let expr = first_expr(r#"match e { { type: "click" } -> 1, _ -> 0 }"#);
+    let ExprKind::Match { arms, .. } = expr else {
+        panic!("expected Match");
+    };
+    assert_eq!(arms.len(), 2);
+}
+
+#[test]
+fn jsx_prop_accepts_type_keyword() {
+    let expr = first_expr(r#"<input type="text" />"#);
+    assert!(matches!(expr, ExprKind::Jsx(_)));
+}
+
+#[test]
+fn type_decl_still_parses_as_type_decl() {
+    let prog = parse_ok("type User = { name: string }");
+    assert!(matches!(prog.items[0].kind, ItemKind::TypeDecl { .. }));
+}
+
+#[test]
+fn bare_todo_is_still_placeholder() {
+    // Without a shadowing local, `todo` remains the panic placeholder.
+    assert_eq!(first_expr("todo"), ExprKind::Todo);
+}
+
+#[test]
+fn bare_unreachable_is_still_placeholder() {
+    assert_eq!(first_expr("unreachable"), ExprKind::Unreachable);
+}

--- a/crates/floe-core/src/parser/tests.rs
+++ b/crates/floe-core/src/parser/tests.rs
@@ -2725,10 +2725,7 @@ fn parse_lossy_module_exposes_extra_even_when_errors() {
     assert!(extra.new_lines.contains(&10));
 }
 
-// ── Contextual keywords (issue #1226) ────────────────────────
-// Keywords like `type`, `todo`, `mock` may appear as identifiers in
-// unambiguous positions (field names, binders, parameter names). The
-// parser remaps them to IDENT when consumed in those positions.
+// ── Contextual keywords ──────────────────────────────────────
 
 fn const_name(item: ItemKind) -> String {
     match item {
@@ -2815,8 +2812,6 @@ fn record_literal_accepts_type_as_field_name() {
 
 #[test]
 fn record_pattern_accepts_type_as_field_name() {
-    // Inside a match arm, `{ type: "click" }` matches a record with a `type`
-    // field. The parser must not reject `type` here.
     let expr = first_expr(r#"match e { { type: "click" } -> 1, _ -> 0 }"#);
     let ExprKind::Match { arms, .. } = expr else {
         panic!("expected Match");
@@ -2838,7 +2833,6 @@ fn type_decl_still_parses_as_type_decl() {
 
 #[test]
 fn bare_todo_is_still_placeholder() {
-    // Without a shadowing local, `todo` remains the panic placeholder.
     assert_eq!(first_expr("todo"), ExprKind::Todo);
 }
 

--- a/crates/floe-core/tests/snapshot_codegen.rs
+++ b/crates/floe-core/tests/snapshot_codegen.rs
@@ -14,9 +14,14 @@ fn compile(source: &str) -> String {
     let mut program = Parser::new(source)
         .parse_program()
         .expect("fixture should parse");
-    let (_, expr_types, _) = Checker::new().check_full(&program);
+    let (_, expr_types, _, shadowed) = Checker::new().check_full(&program);
     desugar::desugar_program(&mut program, &std::collections::HashMap::new());
-    let typed = checker::attach_types(program, &expr_types, &std::collections::HashSet::new());
+    let typed = checker::attach_types(
+        program,
+        &expr_types,
+        &std::collections::HashSet::new(),
+        &shadowed,
+    );
     Codegen::new().generate(&typed).code
 }
 
@@ -39,9 +44,14 @@ fn compile_cross_file(consumer: &str, siblings: &[(&str, &str)]) -> String {
     let resolved: HashMap<String, ResolvedImports> =
         floe_core::resolve::resolve_imports(&consumer_path, &program, &tsconfig);
 
-    let (_, expr_types, _) = Checker::with_imports(resolved.clone()).check_full(&program);
+    let (_, expr_types, _, shadowed) = Checker::with_imports(resolved.clone()).check_full(&program);
     desugar::desugar_program(&mut program, &std::collections::HashMap::new());
-    let typed = checker::attach_types(program, &expr_types, &std::collections::HashSet::new());
+    let typed = checker::attach_types(
+        program,
+        &expr_types,
+        &std::collections::HashSet::new(),
+        &shadowed,
+    );
     Codegen::with_imports(&resolved).generate(&typed).code
 }
 

--- a/crates/floe-wasm/src/lib.rs
+++ b/crates/floe-wasm/src/lib.rs
@@ -62,7 +62,8 @@ fn compile_inner(source: &str) -> CompileResult {
     };
 
     // Type check
-    let (check_diags, expr_types, invalid_exprs) = Checker::new().check_full(&program);
+    let (check_diags, expr_types, invalid_exprs, shadowed_keywords) =
+        Checker::new().check_full(&program);
     let has_errors = check_diags
         .iter()
         .any(|d| d.severity == diagnostic::Severity::Error);
@@ -78,7 +79,8 @@ fn compile_inner(source: &str) -> CompileResult {
     }
 
     // Convert to typed AST for codegen (even with type errors, for playground preview).
-    let typed_program = floe_core::checker::attach_types(program, &expr_types, &invalid_exprs);
+    let typed_program =
+        floe_core::checker::attach_types(program, &expr_types, &invalid_exprs, &shadowed_keywords);
     let output = Codegen::new().generate(&typed_program);
 
     CompileResult {

--- a/docs/design.md
+++ b/docs/design.md
@@ -198,6 +198,47 @@ The last expression in a block is the return value — no `return` keyword.
 | `if`/`else` | Redundant control flow | `match` expression |
 | `return` | Implicit returns — last expression is the value | Omit `return`; the last expression in a block is the return value |
 
+### Contextual keywords
+
+Several keywords are **contextual** — they're only recognized as keywords at
+their specific syntactic position, and parse as ordinary identifiers
+elsewhere. This unblocks idiomatic names that collide with framework
+conventions (DOM `type`, React `todo`-style fields, JSON discriminators).
+
+| Keyword | Acts as keyword when… |
+|---|---|
+| `type` | At item-declaration position (`type X = ...`, including `opaque type`) |
+| `opaque` | Immediately before `type` (`opaque type X = ...`) |
+| `trusted` | Modifier on `import` (`import trusted { ... }`) |
+| `deriving` | Tail of a record type (`type X = { ... } deriving (Display)`) |
+| `mock`, `parse` | Followed by `<` (`mock<User>`, `parse<T>(value)`) |
+| `collect` | Followed by `{` (`collect { ... }`) |
+| `todo`, `unreachable`, `clear`, `unchanged` | No local binding with the same name is in scope |
+
+Positions that accept contextual keywords as identifiers: `let`/`fn` binders,
+function parameter names, record type field names, record/object literal
+field names, record pattern field names, destructuring field names, named
+constructor arguments, and JSX attribute names.
+
+Shadowing semantics: when a local binding has the same name as a
+no-argument keyword (`todo`, `unreachable`, `clear`, `unchanged`), the local
+wins for the remainder of its scope. `let todo = 5; todo` reads the local
+`5`, not the panic placeholder.
+
+Implementation:
+1. Lexer still emits the keyword's dedicated `TokenKind` for all occurrences.
+2. Parser, at each identifier-accepting position, bumps the token with a
+   remapped `SyntaxKind::IDENT` so the green tree and lowering see a normal
+   identifier. For `mock`/`parse`/`collect`, the keyword branch is gated on
+   the lookahead token (`<` or `{`); otherwise the parser falls through to
+   the identifier branch.
+3. Checker, on `ExprKind::Todo`/`Unreachable`/`Clear`/`Unchanged`, first
+   looks up the keyword's name in the current scope. If bound, it records
+   the `ExprId` in a shadowed-keyword map and returns the local's type.
+4. `attach_types` consults the map and rewrites shadowed nodes to
+   `ExprKind::Identifier(name)` so codegen emits a variable read instead of
+   the keyword's runtime form.
+
 ---
 
 ## Syntax Examples

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -835,6 +835,28 @@ match key {
 }
 ```
 
+## Contextual keywords
+
+These keywords are recognized only in their specific positions — everywhere
+else they parse as ordinary identifiers so names don't collide with user code
+(JSX attrs, React/DOM/JSON fields, idiomatic variable names):
+
+| Keyword | Keyword only when… | Identifier elsewhere (examples) |
+|---|---|---|
+| `type` | At item start (`type X = ...`) | `{ type: "click" }`, `<input type="text" />`, `fn f(type: string)` |
+| `opaque` | Before `type` (`opaque type X = ...`) | `let opaque = 1` |
+| `trusted` | In imports (`import trusted { ... }`) | `let trusted = true` |
+| `deriving` | After a record type (`... deriving (Display)`) | `let deriving = []` |
+| `mock` | Followed by `<` (`mock<User>(...)`) | `let mock = fakeUser()` |
+| `parse` | Followed by `<` (`parse<T>(value)`) | `let parse = decoder` |
+| `collect` | Followed by `{` (`collect { ... }`) | `let collect = reducer` |
+| `todo`, `unreachable`, `clear`, `unchanged` | No local binding of the same name in scope | `let todo = "wip"; let note = todo` — reads the local |
+
+Shadowing rule for the last row: a local binding with the same name wins. Once
+you write `let todo = ...`, every later mention of `todo` in that scope reads
+the local — the panic-placeholder meaning returns only after the binding goes
+out of scope.
+
 ## Differences from TypeScript
 
 | TypeScript | Floe equivalent |

--- a/docs/site/src/content/docs/docs/reference/syntax.md
+++ b/docs/site/src/content/docs/docs/reference/syntax.md
@@ -266,6 +266,41 @@ mock<T>                           // generate test data from type, returns T
 mock<User>(name: "Alice")         // with field overrides
 ```
 
+### Contextual keywords
+
+Some keywords are only reserved in specific positions so they don't block
+common names in user code (`type` as a JSON/DOM field, `todo` as a variable,
+etc.). Outside those positions they parse as ordinary identifiers.
+
+| Keyword | Acts as keyword when… |
+|---|---|
+| `type` | Starts an item (`type X = ...`, including `opaque type`) |
+| `opaque` | Precedes `type` |
+| `trusted` | Modifies an `import` (`import trusted { ... }`) |
+| `deriving` | Tails a record type (`... deriving (Display)`) |
+| `mock`, `parse` | Followed by `<` (e.g. `parse<User>(value)`) |
+| `collect` | Followed by `{` (`collect { ... }`) |
+| `todo`, `unreachable`, `clear`, `unchanged` | No local binding with the same name is in scope |
+
+```floe
+// `type` as a record field and a parameter name — both fine
+type Message = {
+    type: string,
+    body: string,
+}
+
+let make(type: string, body: string) -> Message = {
+    Message(type: type, body: body)
+}
+
+// JSX attribute
+<input type="text" />
+
+// `todo` is shadowed by the local binding
+let todo = validateTodo(text)?
+saveTodo(todo)   // reads the local — not the panic placeholder
+```
+
 ### Qualified Variants
 
 ```floe


### PR DESCRIPTION
## Summary

Closes #1226. Makes eleven keywords contextual so they parse as identifiers in unambiguous positions: `type`, `todo`, `unreachable`, `mock`, `parse`, `clear`, `unchanged`, `trusted`, `opaque`, `collect`, `deriving`.

This unblocks idiomatic code that was previously rejected:

```floe
type Message = {
  type: string,                // `type` as a record field
  body: string,
}

let make(type: string, body: string) -> Message = {
  Message(type: type, body: body)  // `type` as a parameter and constructor label
}

<input type="text" />                    // `type` as a JSX attribute
match event { { type: "click" } -> 1 }   // `type` in a record pattern
let todo = validateTodo(text)?            // `todo` as a local binding
saveTodo(todo)                            // local wins over keyword
```

### Accepting positions (parser)
- `let`/`fn` binder names (incl. function-form `let name(params) = ...`)
- Function parameter binders
- Record type field names (`type X = { ... }`)
- Record / object literal field names
- Record pattern field names (including variant braces)
- Named constructor arguments (`Message(type: ..., body: ...)`)
- Destructuring fields (`let { type } = msg`)
- JSX attribute names

The parser uses `bump_remap(SyntaxKind::IDENT)` in these positions, so the green tree and every downstream pass sees a normal identifier.

### Lookahead-gated keywords
- `mock` / `parse` — keyword only when followed by `<`
- `collect` — keyword only when followed by `{`

### Shadowing (`todo`, `unreachable`, `clear`, `unchanged`)

These have no arguments, so the parser can't distinguish keyword-use from identifier-use by lookahead. Instead, the checker looks up the keyword's name in the current scope. If it's bound, the `ExprId` is recorded and `attach_types` rewrites the node to `ExprKind::Identifier`, so codegen emits a plain variable read instead of the keyword's panic / Settable sentinel. Without a local binding, the keyword semantics still apply.

### Tests
- 14 new parser tests covering every accepting position (`let type = 5`, `let todo = 5`, `let mock = 5`, `let parse = 5`, `fn f(type: ...)`, `{ type: string }`, `{ type: "click" }` literal, `match { { type: "click" } }`, `<input type="text" />`, plus regression guards for `type User = ...` and bare `todo` / `unreachable`)
- 3 new codegen tests for shadowing (bare `todo` still panics, `let todo = ...; todo` emits a variable read, same for `unreachable`)
- All 1601 floe-core tests, 271 LSP tests, and both example apps (todo-app, store) still pass

### Not in this PR
- Scope-aware LSP hover/goto-def resolution for shadowed keywords (the parser/checker data is there; it's a UI layer change worth its own issue)
- Editor grammar highlighting tweaks — `type`/`todo`/etc. will still be highlighted as keywords in identifier positions. Parsing is correct; only highlighting is cosmetic.

## Test plan

- [ ] CI green (cargo test, clippy, fmt, LSP tests, example-app check/build)
- [ ] Manual: `floe check` / `floe build` on a small program that uses `type` as a field, JSX attribute, and parameter name — confirm clean check and correct TypeScript output
- [ ] Manual: confirm `let todo = 5; todo` in a block does not emit the "placeholder panic" warning and compiles to `const todo = 5; todo;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)