### PR TITLE
ci: [#1360] pin alpha base version via automated Release-As commits

### DIFF
--- a/.github/workflows/pin-alpha.yml
+++ b/.github/workflows/pin-alpha.yml
@@ -1,0 +1,82 @@
+name: Pin Alpha Version
+
+# During the pre-1.0 alpha phase, Floe pins the base version at 0.1.0 and only
+# rolls the alpha counter. release-please does not do this automatically, so
+# this workflow appends an empty `Release-As: 0.1.0-alpha.N+1` commit after
+# every user-authored push to main, which release-please then reads as an
+# override. When Floe graduates to stable, remove this workflow.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  pin-alpha:
+    runs-on: ubuntu-latest
+    # Skip our own empty commits and any commit that already carries a
+    # Release-As footer (manual overrides, release-please release commits).
+    if: >-
+      github.actor != 'github-actions[bot]' &&
+      !contains(github.event.head_commit.message, 'Release-As:') &&
+      !startsWith(github.event.head_commit.message, 'chore(main): release')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute next alpha version
+        id: version
+        run: |
+          current=$(jq -r '."."' .github/release-please-manifest.json)
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+
+          # Expect the form 0.1.0-alpha.N. If we're not on that line, bail loud.
+          if [[ ! "$current" =~ ^0\.1\.0-alpha\.([0-9]+)$ ]]; then
+            echo "::error::Manifest version '$current' is not on the 0.1.0-alpha.N line. Either alpha graduated (remove this workflow) or something bumped the base. Aborting."
+            exit 1
+          fi
+
+          n="${BASH_REMATCH[1]}"
+          next="0.1.0-alpha.$((n + 1))"
+          echo "next=$next" >> "$GITHUB_OUTPUT"
+          echo "Next alpha: $next"
+
+      - name: Append Release-As commit
+        env:
+          NEXT: ${{ steps.version.outputs.next }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Retry on race: another push may have landed between our checkout
+          # and push. Up to 5 tries with a rebase each time.
+          for attempt in 1 2 3 4 5; do
+            git fetch origin main
+            git reset --hard origin/main
+
+            # If someone else already pinned (e.g. a concurrent run beat us to
+            # it), the head commit will contain Release-As and we can exit.
+            head_msg=$(git log -1 --format=%B)
+            if grep -q "^Release-As:" <<<"$head_msg"; then
+              echo "Head already has Release-As footer, skipping."
+              exit 0
+            fi
+
+            git commit --allow-empty \
+              -m "chore: release as $NEXT" \
+              -m "Release-As: $NEXT"
+
+            if git push origin main; then
+              echo "Pushed pin for $NEXT (attempt $attempt)"
+              exit 0
+            fi
+            echo "Push failed on attempt $attempt, retrying..."
+            sleep 2
+          done
+
+          echo "::error::Failed to push Release-As commit after 5 attempts"
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,13 +82,16 @@ integrations, following the same pattern as Gleam.
 | `.github/release-please-manifest.json` | current version tracking |
 | `.github/workflows/release-please.yml` | workflow that opens Release PRs |
 | `.github/workflows/release.yml` | workflow that builds binaries on tag push |
+| `.github/workflows/pin-alpha.yml` | appends `Release-As: 0.1.0-alpha.N+1` commits to keep the alpha base pinned (remove when graduating to stable) |
 | `CHANGELOG.md` | auto-maintained changelog |
 
 ### Pre-1.0 strategy
 
-Floe is in **alpha**. All pre-stable releases ship as `0.1.0-alpha.N`, `0.1.0-beta.N`, `0.1.0-rc.N` — never as a bare `0.x.y` stable. Release-please is configured with `prerelease: true` + `prerelease-type: "alpha"` so merges automatically roll the alpha counter.
+Floe is in **alpha**. All pre-stable releases ship as `0.1.0-alpha.N`, `0.1.0-beta.N`, `0.1.0-rc.N` — never as a bare `0.x.y` stable. The base stays pinned at `0.1.0` for the entire alpha phase; only the `alpha.N` counter rolls.
 
-When a release cycle breaks things (`feat!:` in a PR), the base version bumps too: `0.1.0-alpha.5` → `0.2.0-alpha.1`. The alpha counter resets; the minor bump signals the breaking change. Breaking changes during alpha are normal and expected.
+**This is not release-please's default behavior.** Release-please with `prerelease: true` still bumps the base version on `feat:` / `fix:` commits, which would give `0.1.1-alpha`, `0.2.0-alpha`, etc. To keep the base pinned, we use a custom workflow (`.github/workflows/pin-alpha.yml`) that runs on every push to `main` and appends an empty `Release-As: 0.1.0-alpha.N+1` commit. Release-please reads that footer and proposes the pinned version in the next Release PR.
+
+**Breaking changes (`feat!:`) during alpha stay pinned too.** Breaking changes are expected during alpha; we communicate them through CHANGELOG entries rather than version bumps. Version signal (breaking vs. non-breaking) resumes at stable post-1.0.
 
 **First stable release is `1.0.0`.** We skip stable `0.x` entirely — no `0.1.0`, no `0.2.0`, no pre-1.0 stable at all. Reasons:
 


### PR DESCRIPTION
closes #1360

## Summary

release-please with `prerelease: true` does NOT keep the base pinned during a prerelease cycle — it bumps base on `feat:` / `fix:` commits as usual, just with an `-alpha.N` suffix. Past Floe alphas stayed at `0.1.0-alpha.N` only because @milkyskies manually pushed empty `chore: release as 0.1.0-alpha.N` commits (with a `Release-As:` footer) before each release cycle. PR #1336 is the first cycle without that manual override, so release-please proposed `0.1.1-alpha.3` — technically correct per the config, but not what we want during alpha.

This PR automates the manual step so the base stays pinned at `0.1.0` for the whole alpha phase without any human ceremony.

### What changed

- **`.github/workflows/pin-alpha.yml`** (new): on every push to `main`, if the head commit is from a human and does not already carry a `Release-As:` footer, append an empty `chore: release as 0.1.0-alpha.N+1` commit with the footer. release-please reads the footer and proposes the pinned version in the next Release PR. The workflow skips its own pushes, release-please's release commits, and commits that already have `Release-As:`. Retries up to 5 times on push race conditions.
- **`CLAUDE.md`**: rewrite the "Pre-1.0 strategy" section to describe the real mechanism (no more "automatic" hand-wave that wasn't actually automatic). Note that breaking changes during alpha stay pinned too — signaled via CHANGELOG, not version bumps.
- **`.github/release-please-config.json`**: **unchanged**. With the workflow always pinning, the `bump-*-pre-major` flags only matter as a fallback if the workflow skips, and `true/true` is the safer fallback.

### Follow-up after merge

Once this PR merges, the pin-alpha workflow fires on the merge commit, pushes `Release-As: 0.1.0-alpha.4`, and release-please closes #1336 + opens a new Release PR at `0.1.0-alpha.4`.

## Test plan

- [ ] CI green
- [ ] After merge, confirm the pin-alpha workflow runs successfully on the merge commit
- [ ] After merge, confirm a `chore: release as 0.1.0-alpha.4` commit lands on main with the `Release-As:` footer
- [ ] After merge, confirm release-please closes #1336 and opens a new Release PR at `0.1.0-alpha.4`
- [ ] Merge a subsequent feat/fix PR and confirm the bot pins to `0.1.0-alpha.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)