### PR TITLE
feat: [#1285] infer narrow handler return types + retire E010

### DIFF
--- a/crates/floe-core/src/checker/error_codes.rs
+++ b/crates/floe-core/src/checker/error_codes.rs
@@ -29,8 +29,6 @@ pub enum ErrorCode {
     InvalidComparison,
     /// Unused import.
     UnusedImport,
-    /// Exported function must declare a return type.
-    MissingReturnType,
     /// Function must return a value of the declared type.
     MissingReturnValue,
 
@@ -155,7 +153,9 @@ impl ErrorCode {
             Self::FieldAccessOnResult => "E007",
             Self::InvalidComparison => "E008",
             Self::UnusedImport => "E009",
-            Self::MissingReturnType => "E010",
+            // E010 (`MissingReturnType`) retired — Floe now infers and
+            // exports return types from the body, including narrow
+            // tsgo-resolved shapes a user couldn't write manually.
             Self::MissingReturnValue => "E011",
             Self::ModuleNotFound => "E012",
             Self::PackageNotFound => "E013",

--- a/crates/floe-core/src/checker/expr.rs
+++ b/crates/floe-core/src/checker/expr.rs
@@ -47,11 +47,7 @@ fn fp_then_bare(fp: Option<&str>) -> impl Iterator<Item = String> + use<'_> {
         .chain(std::iter::once(String::new()))
 }
 
-/// Strip generic arguments from a Foreign type name for chain-probe lookup.
-/// `Context<unknown>` -> `Context`, `Router<A, B>` -> `Router`, `Foo` -> `Foo`.
-fn foreign_base(name: &str) -> &str {
-    name.split('<').next().unwrap_or(name)
-}
+use super::type_compat::foreign_base;
 
 /// When a destructured param's type is unresolved, use heuristics for known field names.
 /// The "error" field maps to Error because Floe's error-handling callbacks (use blocks,

--- a/crates/floe-core/src/checker/items.rs
+++ b/crates/floe-core/src/checker/items.rs
@@ -479,20 +479,6 @@ impl Checker {
     }
 
     pub(crate) fn check_function(&mut self, decl: &FunctionDecl, span: Span) {
-        // Rule: Exported functions must declare return types
-        if decl.exported && decl.return_type.is_none() {
-            self.emit_error_with_help(
-                format!(
-                    "exported function `{}` must declare a return type",
-                    decl.name
-                ),
-                span,
-                ErrorCode::MissingReturnType,
-                "missing return type",
-                "add `-> ReturnType` after the parameter list",
-            );
-        }
-
         // Hydrate the fn's generic type parameters into `Generic` vars. Each
         // unconstrained name (`T`, `U`, …) becomes a unique Generic variable
         // shared across every occurrence inside the signature. Trait-bounded

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -199,15 +199,32 @@ fn unused_import_error() {
 // ── Rule 10: Exported function return types ─────────────────
 
 #[test]
-fn exported_function_needs_return_type() {
+fn exported_function_without_return_type_infers_it() {
+    // Floe moved from Rust-style ("exported fns must declare return
+    // types") to TS/OCaml-style ("inference exports what it infers")
+    // to let Hono handlers export their narrow tsgo-resolved returns
+    // without a widening annotation. Plain returns like `a: number`
+    // infer `number` and compile clean.
     let diags = check("export let add(a: number, b: number) = { a }");
-    assert!(has_error_containing(&diags, "must declare a return type"));
+    assert!(
+        !has_error_containing(&diags, "must declare a return type"),
+        "missing-return-type diagnostic should no longer fire, got: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
 }
 
 #[test]
 fn exported_function_with_return_type_ok() {
     let diags = check("export let add(a: number, b: number) -> number = { a }");
-    assert!(!has_error(&diags, ErrorCode::MissingReturnType));
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "annotated exported fn should compile clean, got: {:?}",
+        errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
 }
 
 // ── Return type mismatch ─────────────────────────────────────
@@ -237,14 +254,28 @@ let greet() -> string = { "hello" }
 }
 
 #[test]
-fn non_exported_function_return_type_not_required() {
-    // Non-exported functions can omit -> return type
+fn function_return_type_not_required() {
+    // Return-type annotations are always optional — Floe infers and
+    // exports what it infers. Prior versions required annotations on
+    // exported functions; that rule was retired when handler inference
+    // from tsgo probes started producing narrow types (e.g. hono's
+    // `TypedResponse<_, 201, "json">`) that users couldn't write
+    // manually.
     let diags = check(
         r#"
 let helper(x: number) = { x * 2 }
+export let pub_helper(x: number) = { x * 2 }
 "#,
     );
-    assert!(!has_error(&diags, ErrorCode::MissingReturnType));
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "both exported and non-exported fns should infer their return, got: {:?}",
+        errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
 }
 
 // ── Rule 12: String concat warning ──────────────────────────
@@ -7881,6 +7912,83 @@ export let handler(c: Context<unknown>) -> string = {
         !has_error_containing(&diags, "has no field"),
         "fingerprinted probe should win lookup — accessing narrowOnly must succeed, got errors: {:?}",
         diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn handler_match_branches_infer_to_ts_union() {
+    // A handler whose match arms call `c.json(_, S1)` and `c.json(_, S2)`
+    // should infer its return as the union of each call's narrow shape.
+    // Without this, the match-arm check either errors on incompatible
+    // types (first narrow vs second narrow) or collapses to the first
+    // arm's shape — both erase half the status-code surface the RPC
+    // client consumer needs.
+    use crate::interop::tsgo::probe_gen;
+    use crate::interop::{DtsExport, TsType};
+    use std::collections::HashMap;
+
+    let program = crate::parser::Parser::new(
+        r#"
+import trusted { Context } from "hono"
+
+export let handler(c: Context<unknown>) = {
+    match c.req.param("code") {
+        "ok" -> c.json("ok", 200),
+        _ -> c.json("bad", 400),
+    }
+}
+"#,
+    )
+    .parse_program()
+    .expect("should parse");
+
+    let context_export = DtsExport {
+        name: "Context".to_string(),
+        ts_type: TsType::Any,
+    };
+    let fp_200 = probe_gen::chain_call_fingerprint(&["\"ok\"".to_string(), "200".to_string()]);
+    let fp_400 = probe_gen::chain_call_fingerprint(&["\"bad\"".to_string(), "400".to_string()]);
+    let narrow = |status: u16| TsType::Generic {
+        name: "TypedResponse".to_string(),
+        args: vec![
+            TsType::Any,
+            TsType::NumberLiteral(f64::from(status)),
+            TsType::StringLiteral("json".to_string()),
+        ],
+    };
+    let probe_200 = DtsExport {
+        name: format!("__chain_call_handler__Context$json__{fp_200}"),
+        ts_type: narrow(200),
+    };
+    let probe_400 = DtsExport {
+        name: format!("__chain_call_handler__Context$json__{fp_400}"),
+        ts_type: narrow(400),
+    };
+
+    let mut dts_imports = HashMap::new();
+    dts_imports.insert(
+        "hono".to_string(),
+        vec![context_export, probe_200, probe_400],
+    );
+
+    let checker = Checker::with_all_imports(HashMap::new(), dts_imports);
+    let (diags, types, _, _) = checker.check_with_types(&program);
+
+    let errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.severity == Severity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "handler with narrow match branches should compile, got: {:?}",
+        errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    let inferred = types.get("handler").expect("handler should be in types");
+    assert!(
+        inferred.contains("TypedResponse<unknown, 200, \"json\">")
+            && inferred.contains("TypedResponse<unknown, 400, \"json\">")
+            && inferred.contains("|"),
+        "handler type should be TsUnion of both narrow variants, got: {inferred}"
     );
 }
 

--- a/crates/floe-core/src/checker/type_compat.rs
+++ b/crates/floe-core/src/checker/type_compat.rs
@@ -27,6 +27,23 @@ fn split_foreign_name(foreign_name: &str) -> Option<(&str, Vec<&str>)> {
     Some((base, args))
 }
 
+/// Strip generic arguments from a Foreign type name for base-name
+/// comparisons. `Context<unknown>` → `Context`, `Router<A, B>` →
+/// `Router`, `Foo` → `Foo`.
+pub(crate) fn foreign_base(name: &str) -> &str {
+    name.split('<').next().unwrap_or(name)
+}
+
+/// True if two Foreign names share a base (e.g. `TypedResponse<_, 201, _>`
+/// and `TypedResponse<_, 400, _>` both have base `TypedResponse`). Used
+/// by match-arm unification to decide when two different narrow
+/// instantiations should form a `TsUnion` rather than emit an
+/// incompatible-arm error.
+pub(crate) fn same_foreign_base(a: &str, b: &str) -> bool {
+    let a_base = foreign_base(a);
+    !a_base.is_empty() && a_base == foreign_base(b)
+}
+
 /// True if a Foreign type name like `Router<E>` contains an arg that looks
 /// like an unresolved type parameter (single uppercase letter). Used to stay
 /// permissive for same-base-name Foreigns when the checker hasn't yet
@@ -131,6 +148,19 @@ impl Checker {
                         .zip(b.iter())
                         .all(|(x, y)| self.types_unifiable(x, y))
             }
+            // Same-base Foreigns with different instantiations (e.g. hono's
+            // `TypedResponse<_, 201, "json">` vs `TypedResponse<_, 400, "json">`
+            // across match arms) unify into a TsUnion in `merge_types` —
+            // callers treat them as unifiable so the match arm check doesn't
+            // reject before the union can be formed.
+            (Type::Foreign { name: a_name, .. }, Type::Foreign { name: b_name, .. })
+                if same_foreign_base(a_name, b_name) =>
+            {
+                true
+            }
+            (Type::TsUnion(parts), other) | (other, Type::TsUnion(parts)) => {
+                parts.iter().any(|p| self.types_unifiable(p, other))
+            }
             _ => self.types_compatible(a, b),
         }
     }
@@ -142,6 +172,27 @@ impl Checker {
         match (a, b) {
             (Type::Unknown | Type::Error, _) => b.clone(),
             (_, Type::Unknown | Type::Error) => a.clone(),
+            (Type::Foreign { name: a_name, .. }, Type::Foreign { name: b_name, .. })
+                if a_name != b_name && same_foreign_base(a_name, b_name) =>
+            {
+                Type::TsUnion(vec![a.clone(), b.clone()])
+            }
+            (Type::TsUnion(parts), other) => {
+                let mut merged = parts.clone();
+                if !merged.iter().any(|p| p == other) {
+                    merged.push(other.clone());
+                }
+                Type::TsUnion(merged)
+            }
+            (other, Type::TsUnion(parts)) => {
+                let mut merged = vec![other.clone()];
+                for p in parts {
+                    if !merged.iter().any(|m| m == p) {
+                        merged.push(p.clone());
+                    }
+                }
+                Type::TsUnion(merged)
+            }
             (a, b) if a.is_result() && b.is_result() => {
                 let ok = Self::merge_types(
                     a.result_ok().unwrap_or(&Type::Unknown),

--- a/crates/floe-core/src/interop/dts.rs
+++ b/crates/floe-core/src/interop/dts.rs
@@ -1016,7 +1016,15 @@ fn index_signature_kv(idx: &oxc_ast::ast::TSIndexSignature<'_>) -> Option<(TsTyp
 /// Merge intersection members. Object members' fields are concatenated
 /// (later wins on name collision); non-object members collapse through
 /// the `T & {}` no-op pattern. When only one non-empty member survives,
-/// emit it directly to avoid a spurious union-like wrapper.
+/// emit it directly to avoid a spurious union-like wrapper. When
+/// several non-object members remain, prefer the one carrying the most
+/// structural information — a `Generic<args>` beats a bare `Named`
+/// beats everything else. hono's `c.json(body, S)` return type is
+/// `Response & TypedResponse<body, S, "json">`: the intersection-with-
+/// Response is an `instanceof` assertion and the narrow literal
+/// information lives on the `TypedResponse<…>` half. Dropping the
+/// Generic would leak the full Response into the checker and erase
+/// the literal status overload that tsgo already resolved.
 fn merge_intersection(parts: Vec<TsType>) -> TsType {
     let mut merged_fields: Vec<ObjectField> = Vec::new();
     let mut field_index: HashMap<String, usize> = HashMap::new();
@@ -1041,12 +1049,53 @@ fn merge_intersection(parts: Vec<TsType>) -> TsType {
         (true, 0) => TsType::Object(Vec::new()),
         (true, 1) => non_object.into_iter().next().unwrap(),
         (false, 0) => TsType::Object(merged_fields),
-        // Mixed: surface the object side (the dominant case for npm patterns
-        // like `SomeClass & { extra: X }`). The non-object halves are
-        // usually opaque class references we can't structurally merge.
         (false, _) => TsType::Object(merged_fields),
-        (true, _) => non_object.into_iter().next().unwrap(),
+        (true, _) => pick_most_specific(non_object),
     }
+}
+
+/// Rank intersection members so the carrier with the most structural
+/// information wins. Used only when every member is non-object (there's
+/// nothing to merge by fields); the first member of the highest rank
+/// is returned.
+fn intersection_member_rank(ty: &TsType) -> u8 {
+    match ty {
+        TsType::Generic { .. }
+        | TsType::Function { .. }
+        | TsType::Array(_)
+        | TsType::Tuple(_)
+        | TsType::Union(_)
+        | TsType::IndexedAccess { .. } => 3,
+        TsType::StringLiteral(_) | TsType::NumberLiteral(_) | TsType::BooleanLiteral(_) => 2,
+        TsType::Named(_) | TsType::This => 1,
+        TsType::Primitive(_)
+        | TsType::Object(_)
+        | TsType::Null
+        | TsType::Undefined
+        | TsType::Any
+        | TsType::Unknown => 0,
+    }
+}
+
+fn pick_most_specific(non_object: Vec<TsType>) -> TsType {
+    // Fold left so at equal rank the FIRST member wins — preserves the
+    // pre-existing "first-of-many" behavior for ambient cases like
+    // `Window & typeof globalThis` (both sides rank as `Named`, no
+    // narrow winner) while still letting a `Generic<args>` override a
+    // bare `Named` when one side is clearly richer.
+    let mut iter = non_object.into_iter();
+    let Some(mut best) = iter.next() else {
+        return TsType::Object(Vec::new());
+    };
+    let mut best_rank = intersection_member_rank(&best);
+    for ty in iter {
+        let rank = intersection_member_rank(&ty);
+        if rank > best_rank {
+            best = ty;
+            best_rank = rank;
+        }
+    }
+    best
 }
 
 /// `keyof T` — when `T` is a concrete object type, yield the union of its

--- a/crates/floe-core/src/interop/tests.rs
+++ b/crates/floe-core/src/interop/tests.rs
@@ -1318,3 +1318,61 @@ export type { Context } from './context';
         other => panic!("expected TsType::Object for re-exported Context, got {other:?}"),
     }
 }
+
+#[test]
+fn intersection_prefers_generic_over_bare_named() {
+    let dts = r#"
+        export type Foo = Bar & TypedResponse<number, 201, "json">;
+    "#;
+    let exports = super::dts::parse_dts_exports_from_str(dts).unwrap();
+    let foo = exports.iter().find(|e| e.name == "Foo").unwrap();
+    match &foo.ts_type {
+        TsType::Generic { name, args } => {
+            assert_eq!(name, "TypedResponse");
+            assert_eq!(args.len(), 3);
+            assert!(
+                matches!(&args[1], TsType::NumberLiteral(n) if (*n - 201.0).abs() < f64::EPSILON),
+                "expected 201 literal at position 1, got {:?}",
+                args[1]
+            );
+        }
+        other => panic!("expected Generic TypedResponse<…>, got {other:?}"),
+    }
+}
+
+#[test]
+fn wrap_generic_preserves_number_literal_in_foreign_name() {
+    let ts = TsType::Generic {
+        name: "TypedResponse".to_string(),
+        args: vec![
+            TsType::Any,
+            TsType::NumberLiteral(201.0),
+            TsType::StringLiteral("json".to_string()),
+        ],
+    };
+    let wrapped = wrap_boundary_type(&ts);
+    let Type::Foreign { name, .. } = &wrapped else {
+        panic!("expected Foreign, got {wrapped:?}");
+    };
+    assert!(
+        name.contains("201") && name.contains("\"json\""),
+        "expected 201 and \"json\" preserved, got {name:?}"
+    );
+    assert!(
+        !name.contains(", number,") && !name.contains("<number,"),
+        "status literal 201 should not widen to `number`, got {name:?}"
+    );
+}
+
+#[test]
+fn wrap_generic_preserves_boolean_literal() {
+    let ts = TsType::Generic {
+        name: "Flag".to_string(),
+        args: vec![TsType::BooleanLiteral(true)],
+    };
+    let wrapped = wrap_boundary_type(&ts);
+    let Type::Foreign { name, .. } = &wrapped else {
+        panic!("expected Foreign, got {wrapped:?}");
+    };
+    assert_eq!(name, "Flag<true>");
+}

--- a/crates/floe-core/src/interop/wrapper.rs
+++ b/crates/floe-core/src/interop/wrapper.rs
@@ -73,8 +73,16 @@ pub fn wrap_boundary_type(ts_type: &TsType) -> Type {
                     if wrapped_args.iter().any(contains_placeholder_param) {
                         return Type::foreign(name.clone());
                     }
-                    let args_str: Vec<String> =
-                        wrapped_args.iter().map(|a| a.to_string()).collect();
+                    // Render arg strings from the raw TsType (not the wrapped
+                    // Floe Type) so numeric/boolean literals survive the
+                    // boundary. Floe's `Type` has a `StringLiteral` variant
+                    // but no `NumberLiteral` / `BooleanLiteral`, so wrapping
+                    // `TsType::NumberLiteral(201)` through `wrap_boundary_type`
+                    // widens it to `Type::Number` and the encoded name
+                    // becomes `TypedResponse<…, number, …>` — the exact
+                    // status literal that hono's narrow overloads pivot on
+                    // is erased. Direct TS-shape rendering preserves `201`.
+                    let args_str: Vec<String> = args.iter().map(render_generic_arg_ts).collect();
                     Type::foreign(format!("{}<{}>", name, args_str.join(", ")))
                 }
             }
@@ -148,6 +156,25 @@ pub fn wrap_boundary_type(ts_type: &TsType) -> Type {
         TsType::IndexedAccess { object, index } => evaluate_indexed_access(object, index)
             .map(|ts| wrap_boundary_type(&ts))
             .unwrap_or(Type::Unknown),
+    }
+}
+
+/// Render a generic argument for the Foreign name string, preserving
+/// numeric/boolean/string literals that Floe's `Type` can't carry
+/// natively. For non-literal shapes we fall back to the wrapped Type's
+/// string form (e.g. `Array<string>`, `Foo<Bar>`).
+fn render_generic_arg_ts(arg: &TsType) -> String {
+    match arg {
+        TsType::NumberLiteral(n) => {
+            if n.fract() == 0.0 && n.is_finite() {
+                format!("{}", *n as i64)
+            } else {
+                format!("{n}")
+            }
+        }
+        TsType::BooleanLiteral(b) => b.to_string(),
+        TsType::StringLiteral(s) => format!("\"{s}\""),
+        _ => wrap_boundary_type(arg).to_string(),
     }
 }
 

--- a/crates/floe-lsp/src/code_actions.rs
+++ b/crates/floe-lsp/src/code_actions.rs
@@ -1,92 +1,19 @@
-use std::collections::HashMap;
-
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 
-use super::{FloeLsp, offset_to_position, position_to_offset};
+use super::FloeLsp;
 
 impl FloeLsp {
     pub(super) async fn handle_code_action(
         &self,
-        params: CodeActionParams,
+        _params: CodeActionParams,
     ) -> Result<Option<CodeActionResponse>> {
-        let uri = params.text_document.uri;
-        let docs = self.documents.read().await;
-        let Some(doc) = docs.get(&uri) else {
-            return Ok(None);
-        };
-
-        let mut actions = Vec::new();
-
-        for diag in &params.context.diagnostics {
-            // E010: exported function missing return type — offer to insert inferred type
-            let is_e010 = diag
-                .code
-                .as_ref()
-                .is_some_and(|c| matches!(c, NumberOrString::String(s) if s == "E010"));
-
-            if !is_e010 {
-                continue;
-            }
-
-            // Find the function name from the diagnostic message
-            let fn_name = diag
-                .message
-                .strip_prefix("exported function `")
-                .and_then(|s| s.strip_suffix("` must declare a return type"));
-
-            let Some(fn_name) = fn_name else {
-                continue;
-            };
-
-            // Look up the inferred return type from the checker's type map
-            let inferred = doc.type_map.get(fn_name).and_then(|ty| {
-                // Type map stores the function type like "(number, number) -> number"
-                // Extract the return type after " -> "
-                ty.rsplit_once(" -> ").map(|(_, ret)| ret.to_string())
-            });
-
-            let return_type = inferred.unwrap_or_else(|| "unknown".to_string());
-
-            // Find the `) {` or `)  {` in the function signature to insert before `{`
-            let start_offset = position_to_offset(&doc.content, diag.range.start);
-            let end_offset = position_to_offset(&doc.content, diag.range.end);
-            let fn_text = &doc.content[start_offset..end_offset];
-
-            // Find the closing paren before the opening brace
-            if let Some(brace_pos) = fn_text.find('{') {
-                let insert_offset = start_offset + brace_pos;
-                let insert_pos = offset_to_position(&doc.content, insert_offset);
-
-                let edit = TextEdit {
-                    range: Range {
-                        start: insert_pos,
-                        end: insert_pos,
-                    },
-                    new_text: format!("-> {return_type} "),
-                };
-
-                let mut changes = HashMap::new();
-                changes.insert(uri.clone(), vec![edit]);
-
-                actions.push(CodeActionOrCommand::CodeAction(CodeAction {
-                    title: format!("Add return type `: {return_type}`"),
-                    kind: Some(CodeActionKind::QUICKFIX),
-                    diagnostics: Some(vec![diag.clone()]),
-                    edit: Some(WorkspaceEdit {
-                        changes: Some(changes),
-                        ..Default::default()
-                    }),
-                    is_preferred: Some(true),
-                    ..Default::default()
-                }));
-            }
-        }
-
-        if actions.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(actions))
-        }
+        // No quickfix code actions are currently offered. The former
+        // "add inferred return type" action existed to unstick the E010
+        // "exported function must declare a return type" diagnostic;
+        // that diagnostic no longer exists — Floe infers and exports
+        // the return type directly, including narrow tsgo-resolved
+        // shapes that a user couldn't write manually.
+        Ok(None)
     }
 }

--- a/docs/design.md
+++ b/docs/design.md
@@ -1382,7 +1382,6 @@ These are enforced at compile time with clear error messages.
 
 | Rule | Error | Fix |
 |------|-------|-----|
-| Exported functions must declare return types | `ERROR: missing return type` | Add `-> ReturnType` |
 | `const name = (x) => ...` | `ERROR: use fn instead` | `fn name(x) => T { ... }` |
 | No unused variables | `ERROR: x is never used` | Remove or prefix with `_` |
 | No unused imports | `ERROR: useRef is never used` | Remove the import |

--- a/tests/lsp/test_code_actions.py
+++ b/tests/lsp/test_code_actions.py
@@ -5,17 +5,12 @@ from . import fixtures as F
 
 
 class TestCodeActions:
-    def test_missing_return_type_has_actions(self, lsp):
-        """E010: exported fn without return type should offer a fix."""
+    def test_no_actions_when_return_type_missing(self, lsp):
+        """Return-type annotations are optional in Floe — the old
+        "add inferred return type" quickfix is no longer offered."""
         result = open_doc(lsp, URI, F.CODE_ACTION)
         actions = result_list(lsp.code_action(URI, 0, diagnostics=result.all))
-        assert len(actions) > 0, "Expected code actions for E010"
-
-    def test_add_return_type_fix(self, lsp):
-        result = open_doc(lsp, URI, F.CODE_ACTION)
-        actions = result_list(lsp.code_action(URI, 0, diagnostics=result.all))
-        titles = [a.get("title", "") for a in actions]
-        assert any("return type" in t.lower() or "-> " in t for t in titles), f"Titles: {titles}"
+        assert actions == [], f"Expected no code actions, got {actions}"
 
     def test_valid_code_no_actions(self, lsp):
         open_doc(lsp, URI, F.SIMPLE)


### PR DESCRIPTION
## Summary

Closes the epic (#1351 + #1352 + #1353 + this). A Floe handler that calls `c.json(body, 201)` now infers its return as `TypedResponse<unknown, 201, "json">`; one whose match arms call `c.json(_, 200)` and `c.json(_, 400)` infers the `TsUnion` of both; async handlers wrap in `Promise<…>`. The narrow type flows through `name_type_map` and into the emitted TS so Hono's RPC client generator reconstructs the status-discriminated response surface.

Four pieces slot together:

- **Intersection preservation** (`interop/dts.rs`). `merge_intersection` used to keep "first non-object member wins", dropping narrow Generic info from hono's `Response & TypedResponse<…>`. New `pick_most_specific` ranks members (Generic > literal > Named > primitive) and folds left to preserve first-wins at equal rank. Retains the existing `Window & typeof globalThis` behaviour.

- **Literal preservation in Generic Foreign names** (`interop/wrapper.rs`). Generic arg encoding used to round-trip `TsType::NumberLiteral(201)` through `Type::Number`, widening to `TypedResponse<_, number, _>`. New `render_generic_arg_ts` preserves number/bool/string literals verbatim in the Foreign name — `TypedResponse<_, 201, "json">` reaches the checker intact.

- **Same-base Foreign → TsUnion** (`checker/type_compat.rs`). `types_unifiable` now treats two Foreigns that share a base with different instantiations (`TypedResponse<_, 200, _>` vs `TypedResponse<_, 400, _>`) as unifiable; `merge_types` produces a `Type::TsUnion` instead of rejecting match arms as incompatible, and absorbs into itself on further merges with dedup.

- **E010 retired.** Floe compiles to TypeScript; requiring explicit return types on exported functions (the old Rust-/Go-style rule) widened hono-handler returns at the export boundary and defeated the whole narrow-inference story. Return types are always optional now — Floe infers and exports what it infers. Dropped `ErrorCode::MissingReturnType`, removed the row from `docs/design.md`, flipped the existing "must have annotation" test, removed the LSP quickfix that only existed to unstick E010.

Also moved `foreign_base` from `checker/expr.rs` into `checker/type_compat.rs` and shared it between chain-probe lookups and the new same-base comparison instead of keeping two copies.

closes #1285

## What Floe users write

```ts
import trusted { router, get, Router } from "@floeorg/hono"
import trusted { Context } from "hono"

type Env = { DB: string }

// Single status — inferred as TypedResponse<unknown, 201, "json">
let handleCreate(c: Context<{ Bindings: Env }>) = {
    c.json({ ok: true }, 201)
}

// Multi-status — inferred as TsUnion across call-site narrows
let handleUpdate(c: Context<{ Bindings: Env }>) = {
    match c.req.param("id") {
        "42" -> c.json({ ok: true }, 200),
        _ -> c.json({ error: "bad" }, 400),
    }
}

export let build() -> Router<Env> = {
    router<Env>()
        |> get("/c", handleCreate)
        |> get("/u/:id", handleUpdate)
}
```

## Test plan

- [x] `cargo test --workspace` (1594 passing, +4 regression tests for this PR)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `python3 -m pytest tests/lsp/` (270 passing; removed the one E010-quickfix test)
- [x] `floe check examples/{todo-app,store,hono-api}/src/` — all pass
- [x] Regression tests added:
  - `interop::tests::intersection_prefers_generic_over_bare_named` — `Foo & TypedResponse<…, 201, …>` resolves to the Generic half.
  - `interop::tests::wrap_generic_preserves_number_literal_in_foreign_name` — 201 survives the Generic-arg encoding.
  - `interop::tests::wrap_generic_preserves_boolean_literal` — `Flag<true>` survives.
  - `checker::tests::handler_match_branches_infer_to_ts_union` — match arms with different narrow shapes unify to `TsUnion`, handler's inferred type carries both variants.
  - `checker::tests::exported_function_without_return_type_infers_it` — flipped from the old "must declare" assertion.
- [x] Real-world verification via `examples/hono-api`: handler without return-type annotation compiles clean; hover shows the narrow `TypedResponse<_, 201, "json">` inferred type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)