### PR TITLE
fix: [#1357] register ambient TS type aliases alongside interfaces

### DIFF
--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -9668,3 +9668,33 @@ export default something
         diags.iter().map(|d| &d.message).collect::<Vec<_>>()
     );
 }
+
+// ── Ambient type aliases (#1357) ─────────────────────────────
+
+#[test]
+fn ambient_type_alias_resolves_as_type() {
+    use crate::interop::ambient::AmbientDeclarations;
+
+    let mut ambient = AmbientDeclarations::default();
+    ambient
+        .types
+        .insert("AlgorithmIdentifier".to_string(), Type::String);
+
+    let source = "export let f(v: AlgorithmIdentifier) -> number = { 0 }";
+    let program = Parser::new(source).parse_program().expect("parse");
+    let checker = Checker::from_context(
+        HashMap::new(),
+        HashMap::new(),
+        Some(ambient),
+        HashSet::new(),
+    );
+    let diags = checker.check(&program);
+    assert!(
+        !has_error(&diags, ErrorCode::UndefinedName),
+        "pure type alias from ambient should resolve, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/floe-core/src/interop/ambient.rs
+++ b/crates/floe-core/src/interop/ambient.rs
@@ -18,7 +18,10 @@ use oxc_ast::ast::Statement;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
-use super::dts::{collect_and_resolve_interfaces, convert_function, convert_variable_declarator};
+use super::dts::{
+    collect_and_resolve_interfaces, collect_type_aliases, convert_function,
+    convert_variable_declarator,
+};
 use super::wrapper::wrap_boundary_type;
 use crate::checker::Type;
 
@@ -382,9 +385,18 @@ fn parse_ambient_lib(content: &str) -> AmbientDeclarations {
         return AmbientDeclarations::default();
     }
 
-    // Phase 1: Collect and resolve all interface definitions
+    // Phase 1: Collect and resolve all interface + type-alias definitions.
+    // Aliases lose to interfaces on name collision — interface members are
+    // richer (resolved inheritance chain, call signatures), so when a lib
+    // file declares both `interface X` and `type X = ...` the interface
+    // wins.
     let interface_bodies = collect_and_resolve_interfaces(&ret.program.body);
     let mut types: HashMap<String, Type> = HashMap::new();
+    for (name, ts_type) in collect_type_aliases(&ret.program.body) {
+        if !interface_bodies.contains_key(&name) {
+            types.insert(name, wrap_boundary_type(&ts_type));
+        }
+    }
     for (name, fields) in &interface_bodies {
         let ts_type = super::TsType::Object(fields.clone());
         types.insert(name.clone(), wrap_boundary_type(&ts_type));
@@ -626,5 +638,45 @@ interface Foo { x: number; }
         assert_eq!(refs.len(), 2);
         assert_eq!(refs[0], "globals.d.ts");
         assert_eq!(refs[1], "web-globals/fetch.d.ts");
+    }
+
+    #[test]
+    fn top_level_type_alias_registers_as_ambient_type() {
+        let content = r#"
+            type AlgorithmIdentifier = string | { name: string };
+        "#;
+        let result = parse_ambient_lib(content);
+        assert!(
+            result.types.contains_key("AlgorithmIdentifier"),
+            "expected AlgorithmIdentifier in types, got {:?}",
+            result.types.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn type_alias_inside_declare_global_registers() {
+        let content = r#"
+            declare global {
+                type MyToken = string;
+            }
+        "#;
+        let result = parse_ambient_lib(content);
+        assert!(result.types.contains_key("MyToken"));
+    }
+
+    #[test]
+    fn interface_wins_when_name_collides_with_type_alias() {
+        // lib files sometimes declare both an interface and an alias by the
+        // same name. The interface has richer member info — keep it.
+        let content = r#"
+            type Foo = string;
+            interface Foo { bar: number; }
+        "#;
+        let result = parse_ambient_lib(content);
+        let ty = result.types.get("Foo").expect("Foo should be present");
+        assert!(
+            matches!(ty, Type::Record(_) | Type::Foreign { .. }),
+            "expected the interface body to win, got {ty:?}"
+        );
     }
 }

--- a/crates/floe-core/src/interop/dts.rs
+++ b/crates/floe-core/src/interop/dts.rs
@@ -1753,6 +1753,49 @@ pub(super) fn collect_and_resolve_interfaces(
     bodies
 }
 
+/// Collect top-level and `declare global` type aliases (`type Foo = ...`).
+/// Used alongside `collect_and_resolve_interfaces` so ambient lib types like
+/// `AlgorithmIdentifier` or `BufferSource` register without a backing value.
+pub(super) fn collect_type_aliases(stmts: &[Statement<'_>]) -> HashMap<String, TsType> {
+    let mut aliases: HashMap<String, TsType> = HashMap::new();
+    for stmt in stmts {
+        collect_type_alias_info(stmt, &mut aliases);
+    }
+    aliases
+}
+
+fn collect_type_alias_info(stmt: &Statement<'_>, aliases: &mut HashMap<String, TsType>) {
+    match stmt {
+        Statement::TSTypeAliasDeclaration(type_decl) => {
+            let name = type_decl.id.name.to_string();
+            aliases
+                .entry(name)
+                .or_insert_with(|| convert_oxc_type(&type_decl.type_annotation));
+        }
+        Statement::ExportNamedDeclaration(export_decl) => {
+            if let Some(Declaration::TSTypeAliasDeclaration(type_decl)) = &export_decl.declaration {
+                let name = type_decl.id.name.to_string();
+                aliases
+                    .entry(name)
+                    .or_insert_with(|| convert_oxc_type(&type_decl.type_annotation));
+            }
+        }
+        Statement::TSModuleDeclaration(ns_decl) => {
+            if let Some(TSModuleDeclarationBody::TSModuleBlock(block)) = &ns_decl.body {
+                for inner_stmt in &block.body {
+                    collect_type_alias_info(inner_stmt, aliases);
+                }
+            }
+        }
+        Statement::TSGlobalDeclaration(global_decl) => {
+            for inner_stmt in &global_decl.body.body {
+                collect_type_alias_info(inner_stmt, aliases);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Collect type alias default values from statements.
 /// For `type DraggableId<TId extends string = string> = TId`, records
 /// DraggableId → Primitive("string") (the default type parameter value).


### PR DESCRIPTION
Closes #1357.

## What I found

While investigating, the primary symptom in the issue (`URL`, `Response`, `Blob` failing) already compiles cleanly on main — today's merge of #1334 added a value-as-type path that accepts `declare var URL: {...}` as a valid type annotation because the value's type is `Record<...>`.

But the issue's root-cause analysis identified a real, still-present gap: the ambient collector's interface path registers `interface X` but does nothing with `type X = ...`. That means **pure type aliases with no backing value** still fail to resolve. Concretely, `lib.dom.d.ts` declares 352 top-level type aliases — things like `AlgorithmIdentifier = Algorithm | string`, `BufferSource`, `NodeFilter`, `AllowSharedBufferSource` — none of which registered. Repro before the fix:

```ts
// tsconfig: { "compilerOptions": { "lib": ["DOM"] } }
export let f(v: AlgorithmIdentifier) -> number = { 0 }
// [E002] unknown type `AlgorithmIdentifier`
```

## The fix

Add `collect_type_aliases` in `dts.rs` that walks the same statement shapes as the interface collector — top-level, `export`, `TSModuleDeclaration` body, and `declare global` body — and registers each alias RHS into `AmbientDeclarations.types` via the existing `convert_oxc_type` converter.

Interfaces win on name collision (they have resolved extends chains and call signatures; aliases don't), so when a lib file declares both `interface Foo` and `type Foo = ...` the interface path survives.

## Tests

- Unit: top-level `type Alias = ...` registers as an ambient type
- Unit: `type X = ...` inside `declare global` registers
- Unit: interface wins on name collision
- Checker integration: `f(v: AlgorithmIdentifier)` resolves when the ambient map contains the alias

All 1614 floe-core tests, 271 LSP tests, and both example apps pass.

## Not in this PR

The "secondary symptom" from the issue — `let u = URL(str)` constructor-callable semantics — is split to #1358 and depends on constructor-interface-type support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)