### PR TITLE
fix: [#1380] surface implicit Object methods on interop record types

### DIFF
--- a/crates/floe-core/src/checker.rs
+++ b/crates/floe-core/src/checker.rs
@@ -318,7 +318,7 @@ impl Checker {
         // importing. Defined as Records so member access works through
         // the normal type-checking path.
 
-        let response_record = Type::Record(vec![
+        let mut response_fields = vec![
             (
                 "json".to_string(),
                 Type::Function {
@@ -340,15 +340,19 @@ impl Checker {
             ("statusText".to_string(), Type::String),
             ("headers".to_string(), Type::Named("Headers".to_string())),
             ("url".to_string(), Type::String),
-        ]);
+        ];
+        crate::interop::inject_implicit_object_methods(&mut response_fields);
+        let response_record = Type::Record(response_fields);
 
-        let error_record = Type::Record(vec![
+        let mut error_fields = vec![
             ("message".to_string(), Type::String),
             ("name".to_string(), Type::String),
             ("stack".to_string(), Type::option_of(Type::String)),
-        ]);
+        ];
+        crate::interop::inject_implicit_object_methods(&mut error_fields);
+        let error_record = Type::Record(error_fields);
 
-        let event_record = Type::Record(vec![
+        let mut event_fields = vec![
             (
                 "target".to_string(),
                 Type::Record(vec![
@@ -374,7 +378,9 @@ impl Checker {
                     required_params: 0,
                 },
             ),
-        ]);
+        ];
+        crate::interop::inject_implicit_object_methods(&mut event_fields);
+        let event_record = Type::Record(event_fields);
 
         // Register as named types that display nicely and resolve to
         // records for member access via resolve_type_to_concrete

--- a/crates/floe-core/src/checker/tests.rs
+++ b/crates/floe-core/src/checker/tests.rs
@@ -9764,3 +9764,95 @@ fn ambient_type_alias_resolves_as_type() {
             .collect::<Vec<_>>()
     );
 }
+
+// ── Implicit Object methods on interop records (#1380) ──────
+
+#[test]
+fn ambient_record_exposes_to_string() {
+    use crate::interop::ObjectField;
+    use crate::interop::TsType;
+    use crate::interop::ambient::AmbientDeclarations;
+
+    // Mirror @types/node's `URL` interface: declares `href` but not
+    // `toString`. Without the implicit Object-method injection,
+    // `url.toString()` fails with E021 even though every JS object
+    // has `toString` via `Object.prototype`.
+    let url_type = crate::interop::wrap_boundary_type(&TsType::Object(vec![ObjectField {
+        name: "href".to_string(),
+        ty: TsType::Primitive("string".to_string()),
+        optional: false,
+    }]));
+    let mut ambient = AmbientDeclarations::default();
+    ambient.types.insert("URL".to_string(), url_type);
+
+    let source = r#"
+export let f(u: URL) -> string = {
+    u.toString()
+}
+"#;
+    let program = Parser::new(source).parse_program().expect("parse");
+    let checker = Checker::from_context(
+        HashMap::new(),
+        HashMap::new(),
+        Some(ambient),
+        HashSet::new(),
+    );
+    let diags = checker.check(&program);
+    assert!(
+        diags.iter().all(|d| d.severity != Severity::Error),
+        "url.toString() should typecheck; diags: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn implicit_object_methods_do_not_block_assignment() {
+    use crate::interop::ObjectField;
+    use crate::interop::TsType;
+    use crate::interop::{DtsExport, FunctionParam};
+
+    // Foreign function expects `{ code: string }`. After interop wrapping
+    // the parameter shape gains `toString`/`toLocaleString`/`valueOf`, but
+    // the user passes a plain Floe record without them — assignability
+    // must still succeed. Exact pattern caught by #1380's regression.
+    let program = Parser::new(
+        r#"
+import trusted { write } from "some-lib"
+type Row = { code: string }
+let _u = write(Row(code: "abc"))
+"#,
+    )
+    .parse_program()
+    .expect("parse");
+
+    let export = DtsExport {
+        name: "write".to_string(),
+        ts_type: TsType::Function {
+            params: vec![FunctionParam {
+                ty: TsType::Object(vec![ObjectField {
+                    name: "code".to_string(),
+                    ty: TsType::Primitive("string".to_string()),
+                    optional: false,
+                }]),
+                optional: false,
+            }],
+            return_type: Box::new(TsType::Primitive("void".to_string())),
+        },
+    };
+    let mut dts = HashMap::new();
+    dts.insert("some-lib".to_string(), vec![export]);
+
+    let checker = Checker::with_all_imports(HashMap::new(), dts);
+    let (diags, _, _, _) = checker.check_with_types(&program);
+    assert!(
+        diags.iter().all(|d| d.severity != Severity::Error),
+        "plain Floe record should still be assignable to wrapped param; diags: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/floe-core/src/checker/type_compat.rs
+++ b/crates/floe-core/src/checker/type_compat.rs
@@ -2,6 +2,13 @@ use std::sync::Arc;
 
 use super::*;
 
+/// Names that the interop boundary injects on every Record because TypeScript
+/// implicitly extends every interface from `Object`. Source records may omit
+/// them and target records may carry them without breaking assignability.
+fn is_implicit_object_method(name: &str) -> bool {
+    matches!(name, "toString" | "toLocaleString" | "valueOf")
+}
+
 /// Split a Foreign type name like `Foo<a, b<c>>` into a (base, args) pair
 /// where args are the top-level comma-separated segments. Returns `None`
 /// when the name carries no generic arguments.
@@ -247,13 +254,17 @@ impl Checker {
                     false
                 }
             } else {
-                // Field omitted — OK if it's Settable or Option
-                ty.is_settable() || ty.is_option()
+                // Field omitted — OK if it's Settable, Option, or one of the implicit
+                // Object.prototype methods that the interop boundary injects on every
+                // Record. Every JS object inherits these, so a Floe value lacking them
+                // explicitly is still assignable to a parameter shape that does.
+                ty.is_settable() || ty.is_option() || is_implicit_object_method(name)
             }
         })
-        // No extra fields in actual that aren't in expected
+        // No extra fields in actual that aren't in expected — implicit Object methods
+        // on the actual side don't count as "extra" for the same reason.
         && actual.iter().all(|(name, _)| {
-            expected.iter().any(|(n, _)| n == name)
+            expected.iter().any(|(n, _)| n == name) || is_implicit_object_method(name)
         })
     }
 

--- a/crates/floe-core/src/checker/type_compat.rs
+++ b/crates/floe-core/src/checker/type_compat.rs
@@ -1,13 +1,7 @@
 use std::sync::Arc;
 
 use super::*;
-
-/// Names that the interop boundary injects on every Record because TypeScript
-/// implicitly extends every interface from `Object`. Source records may omit
-/// them and target records may carry them without breaking assignability.
-fn is_implicit_object_method(name: &str) -> bool {
-    matches!(name, "toString" | "toLocaleString" | "valueOf")
-}
+use crate::interop::is_implicit_object_method;
 
 /// Split a Foreign type name like `Foo<a, b<c>>` into a (base, args) pair
 /// where args are the top-level comma-separated segments. Returns `None`

--- a/crates/floe-core/src/interop.rs
+++ b/crates/floe-core/src/interop.rs
@@ -34,7 +34,7 @@ pub use dts::{
 };
 pub use ts_types::{FunctionParam, ObjectField, TsType, ts_type_to_string};
 pub use tsgo::{TsgoResolver, TsgoResult};
-pub use wrapper::wrap_boundary_type;
+pub use wrapper::{inject_implicit_object_methods, wrap_boundary_type};
 
 // Re-export internal helpers so tests (and sibling submodules) can access via `use super::*`
 #[cfg(test)]

--- a/crates/floe-core/src/interop.rs
+++ b/crates/floe-core/src/interop.rs
@@ -34,7 +34,10 @@ pub use dts::{
 };
 pub use ts_types::{FunctionParam, ObjectField, TsType, ts_type_to_string};
 pub use tsgo::{TsgoResolver, TsgoResult};
-pub use wrapper::{inject_implicit_object_methods, wrap_boundary_type};
+pub use wrapper::{
+    IMPLICIT_OBJECT_METHOD_NAMES, inject_implicit_object_methods, is_implicit_object_method,
+    wrap_boundary_type,
+};
 
 // Re-export internal helpers so tests (and sibling submodules) can access via `use super::*`
 #[cfg(test)]

--- a/crates/floe-core/src/interop/tests.rs
+++ b/crates/floe-core/src/interop/tests.rs
@@ -340,6 +340,36 @@ fn wrap_required_nullable_stays_option() {
     );
 }
 
+#[test]
+fn explicit_to_string_overrides_implicit() {
+    // An interface that declares its own `toString` keeps that signature
+    // — the implicit injection must not clobber a user-declared method.
+    let ts = TsType::Object(vec![ObjectField {
+        name: "toString".to_string(),
+        ty: TsType::Function {
+            params: vec![],
+            return_type: Box::new(TsType::Primitive("number".to_string())),
+        },
+        optional: false,
+    }]);
+    let wrapped = wrap_boundary_type(&ts);
+    let Type::Record(fields) = wrapped else {
+        panic!("expected Record, got {wrapped:?}");
+    };
+    let to_string_count = fields.iter().filter(|(n, _)| n == "toString").count();
+    assert_eq!(to_string_count, 1, "toString must not be duplicated");
+    let (_, ty) = fields.iter().find(|(n, _)| n == "toString").unwrap();
+    assert_eq!(
+        ty,
+        &Type::Function {
+            params: vec![],
+            return_type: Arc::new(Type::Number),
+            required_params: 0,
+        },
+        "explicit toString signature should win over the implicit string-returning one",
+    );
+}
+
 // ── .d.ts Parsing ───────────────────────────────────────────
 
 #[test]

--- a/crates/floe-core/src/interop/tests.rs
+++ b/crates/floe-core/src/interop/tests.rs
@@ -3,6 +3,15 @@ use std::sync::Arc;
 
 use super::*;
 
+/// Build a `Type::Record` with the implicit Object methods (`toString`,
+/// `toLocaleString`, `valueOf`) appended. Mirrors what `wrap_boundary_type`
+/// produces for `TsType::Object`, so boundary tests can express the
+/// declared fields without restating the implicit ones every time.
+fn record_with_object_methods(mut fields: Vec<(String, Type)>) -> Type {
+    inject_implicit_object_methods(&mut fields);
+    Type::Record(fields)
+}
+
 // ── Type Parsing ────────────────────────────────────────────
 
 #[test]
@@ -270,7 +279,7 @@ fn wrap_object_wraps_fields() {
     let wrapped = wrap_boundary_type(&ts);
     assert_eq!(
         wrapped,
-        Type::Record(vec![
+        record_with_object_methods(vec![
             ("name".to_string(), Type::String),
             ("value".to_string(), Type::option_of(Type::Number)),
         ])
@@ -288,7 +297,7 @@ fn wrap_optional_nullable_becomes_settable() {
     let wrapped = wrap_boundary_type(&ts);
     assert_eq!(
         wrapped,
-        Type::Record(vec![(
+        record_with_object_methods(vec![(
             "email".to_string(),
             Type::Settable(Arc::new(Type::String))
         ),])
@@ -306,7 +315,7 @@ fn wrap_optional_non_nullable_becomes_option() {
     let wrapped = wrap_boundary_type(&ts);
     assert_eq!(
         wrapped,
-        Type::Record(vec![(
+        record_with_object_methods(vec![(
             "nickname".to_string(),
             Type::option_of(Type::String),
         )])
@@ -324,7 +333,7 @@ fn wrap_required_nullable_stays_option() {
     let wrapped = wrap_boundary_type(&ts);
     assert_eq!(
         wrapped,
-        Type::Record(vec![(
+        record_with_object_methods(vec![(
             "deletedAt".to_string(),
             Type::option_of(Type::String),
         )])

--- a/crates/floe-core/src/interop/wrapper.rs
+++ b/crates/floe-core/src/interop/wrapper.rs
@@ -197,6 +197,16 @@ pub(super) fn evaluate_indexed_access(object: &TsType, index: &TsType) -> Option
     }
 }
 
+/// Names of the methods that TypeScript inherits from `Object` onto every
+/// interface. Single source of truth for both the wrapper (which injects them)
+/// and the assignability check (which knows to skip them).
+pub const IMPLICIT_OBJECT_METHOD_NAMES: &[&str] = &["toString", "toLocaleString", "valueOf"];
+
+/// True if `name` is one of `IMPLICIT_OBJECT_METHOD_NAMES`.
+pub fn is_implicit_object_method(name: &str) -> bool {
+    IMPLICIT_OBJECT_METHOD_NAMES.contains(&name)
+}
+
 /// Append the methods that TypeScript inherits from `Object` to every interface
 /// (`toString`, `toLocaleString`, `valueOf`). TS treats every interface as
 /// implicitly extending `Object`, but Floe's interop only collects the members
@@ -205,34 +215,24 @@ pub(super) fn evaluate_indexed_access(object: &TsType, index: &TsType) -> Option
 /// same name win, so an interface that explicitly overrides `toString` keeps
 /// its declared signature.
 pub fn inject_implicit_object_methods(fields: &mut Vec<(String, Type)>) {
-    let to_string = (
-        "toString".to_string(),
-        Type::Function {
-            params: vec![],
-            return_type: Arc::new(Type::String),
-            required_params: 0,
-        },
-    );
-    let to_locale_string = (
-        "toLocaleString".to_string(),
-        Type::Function {
-            params: vec![],
-            return_type: Arc::new(Type::String),
-            required_params: 0,
-        },
-    );
-    let value_of = (
-        "valueOf".to_string(),
-        Type::Function {
-            params: vec![],
-            return_type: Arc::new(Type::Unknown),
-            required_params: 0,
-        },
-    );
-    for implicit in [to_string, to_locale_string, value_of] {
-        if !fields.iter().any(|(n, _)| n == &implicit.0) {
-            fields.push(implicit);
+    for name in IMPLICIT_OBJECT_METHOD_NAMES {
+        if fields.iter().any(|(n, _)| n == name) {
+            continue;
         }
+        // `valueOf` returns `Object` in TS — widen to `unknown` so the user
+        // narrows before use. The other two return `string`.
+        let return_type = match *name {
+            "valueOf" => Type::Unknown,
+            _ => Type::String,
+        };
+        fields.push((
+            (*name).to_string(),
+            Type::Function {
+                params: vec![],
+                return_type: Arc::new(return_type),
+                required_params: 0,
+            },
+        ));
     }
 }
 

--- a/crates/floe-core/src/interop/wrapper.rs
+++ b/crates/floe-core/src/interop/wrapper.rs
@@ -113,7 +113,7 @@ pub fn wrap_boundary_type(ts_type: &TsType) -> Type {
         TsType::Array(inner) => Type::Array(Arc::new(wrap_boundary_type(inner))),
 
         TsType::Object(fields) => {
-            let wrapped: Vec<(String, Type)> = fields
+            let mut wrapped: Vec<(String, Type)> = fields
                 .iter()
                 .map(|f| {
                     let ty = if f.optional && f.ty.is_nullable() {
@@ -130,6 +130,7 @@ pub fn wrap_boundary_type(ts_type: &TsType) -> Type {
                     (f.name.clone(), ty)
                 })
                 .collect();
+            inject_implicit_object_methods(&mut wrapped);
             Type::Record(wrapped)
         }
 
@@ -193,6 +194,45 @@ pub(super) fn evaluate_indexed_access(object: &TsType, index: &TsType) -> Option
         TsType::Any => Some(TsType::Any),
         TsType::Unknown => Some(TsType::Unknown),
         _ => None,
+    }
+}
+
+/// Append the methods that TypeScript inherits from `Object` to every interface
+/// (`toString`, `toLocaleString`, `valueOf`). TS treats every interface as
+/// implicitly extending `Object`, but Floe's interop only collects the members
+/// written in the interface body — so legitimate calls like `url.toString()`
+/// or `date.toLocaleString()` would otherwise miss. Existing fields with the
+/// same name win, so an interface that explicitly overrides `toString` keeps
+/// its declared signature.
+pub fn inject_implicit_object_methods(fields: &mut Vec<(String, Type)>) {
+    let to_string = (
+        "toString".to_string(),
+        Type::Function {
+            params: vec![],
+            return_type: Arc::new(Type::String),
+            required_params: 0,
+        },
+    );
+    let to_locale_string = (
+        "toLocaleString".to_string(),
+        Type::Function {
+            params: vec![],
+            return_type: Arc::new(Type::String),
+            required_params: 0,
+        },
+    );
+    let value_of = (
+        "valueOf".to_string(),
+        Type::Function {
+            params: vec![],
+            return_type: Arc::new(Type::Unknown),
+            required_params: 0,
+        },
+    );
+    for implicit in [to_string, to_locale_string, value_of] {
+        if !fields.iter().any(|(n, _)| n == &implicit.0) {
+            fields.push(implicit);
+        }
     }
 }
 


### PR DESCRIPTION
closes #1380

## Summary

TypeScript implicitly extends every interface from `Object`, which declares `toString()`, `toLocaleString()`, and `valueOf()`. Floe's interop loader only collected the members written in each interface body, so `url.toString()` failed with `E021` even though the WHATWG / `@types/node` URL interface relies on `Object` inheritance for that method. Same gap affected `Date.toString`, `Date.toLocaleString`, `Error.toString`, etc.

The fix:

- `wrap_boundary_type` now appends those three methods (when not already present) to every Record produced from the interop boundary — single source of truth in `IMPLICIT_OBJECT_METHOD_NAMES` (`crates/floe-core/src/interop/wrapper.rs`).
- The same helper runs on the hand-crafted `Response`/`Error`/`Event` records in the checker (`crates/floe-core/src/checker.rs`).
- `records_compatible` (`crates/floe-core/src/checker/type_compat.rs`) skips the implicit names on both sides of structural assignability, so plain Floe records are still assignable to wrapped param shapes — every JS object inherits these, so it would be wrong to require source records to declare them.

User-defined Floe records (`type User = { ... }`) bypass `wrap_boundary_type`, so they still reject `.toString()` with E021 — only interop-boundary records gain the implicit methods.

## Test plan

- [x] `crates/floe-core/src/checker/tests.rs::ambient_record_exposes_to_string` — `url.toString()` typechecks against an ambient URL with only `href` declared
- [x] `crates/floe-core/src/checker/tests.rs::implicit_object_methods_do_not_block_assignment` — plain Floe record still assignable to wrapped foreign param
- [x] `crates/floe-core/src/interop/tests.rs::explicit_to_string_overrides_implicit` — user-declared `toString(): number` keeps its signature
- [x] Existing `wrap_*` tests updated via `record_with_object_methods` helper
- [x] Quality gate on examples: `floe fmt` + `floe check` + `floe build` on `examples/todo-app/` and `examples/store/` — all pass
- [x] `cargo test --release -p floe-core --lib` — 1615 passed
- [x] `cargo clippy --all-targets --release -- -D warnings` — clean