### PR TITLE
docs: [#1383] replace stale "const" mentions with "let" across docs and fixtures

### DIFF
--- a/crates/floe-core/tests/fixtures/todo_unreachable.fl
+++ b/crates/floe-core/tests/fixtures/todo_unreachable.fl
@@ -12,7 +12,7 @@ let describe(n: number) -> string = {
   }
 }
 
-// todo in const
+// todo in let
 let placeholder = todo
 
 // unreachable as expression

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -46,7 +46,7 @@ let y = x + 1
 ## Variables
 
 ```floe
-// Only const — no let, no var
+// Only let — no const, no var
 let name = "Ryan"
 let count = 42
 
@@ -227,7 +227,7 @@ let err = ApiError.Network(NetworkError.Timeout(ms: 3000))
 
 // Qualified variants required when ambiguous:
 // type Color = | Red | Green and type Light = | Red | Yellow
-// const c = Red        // Error: ambiguous
+// let c = Red          // Error: ambiguous
 let c = Color.Red     // OK — qualified
 // Bare variants work when unambiguous or in match arms
 
@@ -876,7 +876,7 @@ out of scope.
 |------------|----------------|
 | `any` | `unknown` + narrowing |
 | `null`, `undefined` | `Option<T>` with `Some`/`None` |
-| `let`, `var` | `const` |
+| `let`, `var` | `let` (always immutable) |
 | `class` | Functions + types |
 | `enum` | `type Name = { \| A \| B }` variants |
 | `throw` | Return `Result<T, E>` |
@@ -948,5 +948,5 @@ floe lsp                     # start language server (used by editors)
 13. **Implicit returns** — last expression in a block is the return value; no `return` keyword
 14. **Blank line before final expression** — `floe fmt` inserts a blank line before the last expression in multi-statement blocks (2+ statements) to visually separate the return value
 15. **Call argument rules** — positional must precede named; named may be in any order (reordered at compile time); every required param must be covered; no slot can be covered twice; defaulted params must be passed by name, not positionally
-16. **No array destructure in `const`** — `[a, b]` is a parse error in a `const` binding because it would lie about runtime length on arrays and hide the shape on tuples. Tuples: `const (a, b) = pair`. Arrays: `Array.get(arr, i)` (returns `Option<T>`) or `match arr { [a, b, ..] -> ..., _ -> ... }`. `useState(0)` returns a tuple, so `const (count, setCount) = useState(0)`
+16. **No array destructure in `let`** — `[a, b]` is a parse error in a `let` binding because it would lie about runtime length on arrays and hide the shape on tuples. Tuples: `let (a, b) = pair`. Arrays: `Array.get(arr, i)` (returns `Option<T>`) or `match arr { [a, b, ..] -> ..., _ -> ... }`. `useState(0)` returns a tuple, so `let (count, setCount) = useState(0)`
 17. **`__` is Floe's fingerprint in emitted TypeScript** — tagged-union discriminators compile to `__tag`, for-block methods mangle to `Type__method`. User records are free to use a plain `tag` field without colliding

--- a/docs/site/src/content/docs/docs/guide/from-typescript.md
+++ b/docs/site/src/content/docs/docs/guide/from-typescript.md
@@ -20,7 +20,7 @@ Floe is designed to be familiar to TypeScript developers.
 | `function` | `fn` | `fn greet(name: string) => string { ... }` |
 | `: ReturnType` | `-> ReturnType` | `fn add(a: number, b: number) => number` |
 | `.filter().map()` | `\|> filter \|> map` | `items \|> filter(.active) \|> map(.name)` |
-| `let` / `const` | `const` only | No mutation |
+| `let` / `const` | `let` only | No mutation |
 | `===` | `==` | `==` compiles to `===` |
 | `switch` | `match` | Exhaustive, no fall-through |
 | `try/catch` | Untrusted imports (default) | `import { parseYaml } from "yaml-lib"` (auto-wrapped in Result) |
@@ -33,7 +33,7 @@ Floe is designed to be familiar to TypeScript developers.
 
 | Feature | Why | Alternative |
 |---------|-----|-------------|
-| `let` / `var` | Mutation bugs | `const` only |
+| `let` / `var` | Mutation bugs | `let` only (always immutable) |
 | `class` | Complex inheritance hierarchies | Functions + records |
 | `this` | Implicit context bugs | Explicit parameters |
 | `any` | Type safety escape | `unknown` + narrowing |

--- a/docs/site/src/content/docs/docs/guide/functions.md
+++ b/docs/site/src/content/docs/docs/guide/functions.md
@@ -1,10 +1,10 @@
 ---
-title: Functions & Const
+title: Functions & Let
 ---
 
-## Const Declarations
+## Let Declarations
 
-All bindings are immutable. Use `const`:
+All bindings are immutable. Use `let`:
 
 ```floe
 let name = "Floe"
@@ -26,7 +26,7 @@ let (left, right) = getPair()      // `()` — tuple
 let { name, age } = getUser()      // `{}` — record
 ```
 
-Array destructuring (`const [a, b] = arr`) is a parse error in `const`
+Array destructuring (`let [a, b] = arr`) is a parse error in `let`
 bindings — it would lie about runtime length. Use `Array.get(arr, i) =>
 Option<T>` or a match pattern:
 
@@ -117,7 +117,7 @@ todos |> Array.map(.text)
 users |> Array.sortBy(.name)
 ```
 
-**`const name = (x) => ...` is a compile error.** If it has a name, use `fn`:
+**`let name = (x) => ...` is a compile error.** If it has a name, use `fn`:
 
 ```floe
 // COMPILE ERROR
@@ -197,7 +197,7 @@ Console.log("done")
 
 ## What's Not Here
 
-- **No `let` or `var`** - all bindings are `const`
+- **No `const` or `var`** - all bindings use `let` and are always immutable
 - **No `class`** - use functions and records
 - **No `this`** - functions are pure by default
 - **No `function*` generators** - use arrays and pipes

--- a/docs/site/src/content/docs/docs/guide/use.md
+++ b/docs/site/src/content/docs/docs/guide/use.md
@@ -202,7 +202,7 @@ use { user, session } <- Context.guard(ctx, <LoginPage />)
 // user and session are unwrapped from the Context result
 ```
 
-Renames work the same way as in `const`:
+Renames work the same way as in `let`:
 
 ```floe
 use { user: currentUser, session: sess } <- Context.guard(ctx, fallback)

--- a/docs/site/src/content/docs/docs/reference/syntax.md
+++ b/docs/site/src/content/docs/docs/reference/syntax.md
@@ -22,7 +22,7 @@ export let PI = 3.14159
 // Destructuring
 let (a, b) = pair             // tuple
 let { name, age } = user      // record
-// (array destructuring not allowed in `const`; use `Array.get` or a match pattern)
+// (array destructuring not allowed in `let`; use `Array.get` or a match pattern)
 ```
 
 ### Function

--- a/docs/site/src/content/docs/docs/reference/vscode.md
+++ b/docs/site/src/content/docs/docs/reference/vscode.md
@@ -24,7 +24,7 @@ npm run build
 ### Syntax Highlighting
 
 Full TextMate grammar for `.fl` files:
-- Keywords (`const`, `fn`, `match`, `type`, etc.)
+- Keywords (`let`, `fn`, `match`, `type`, etc.)
 - Operators (`|>`, `->`, `=>`, `?`)
 - JSX elements and attributes
 - Template literals with interpolation

--- a/editors/vscode/tests/syntax.test.fl
+++ b/editors/vscode/tests/syntax.test.fl
@@ -28,8 +28,8 @@ let handleDelete(id: string) = {
 //    ^^^ entity.name.tag.floe
 }
 
-const x = true
-//        ^^^^ constant.language.boolean.floe
+let x = true
+//      ^^^^ constant.language.boolean.floe
 
 function bad() {}
 // <-- invalid.illegal.keyword.floe

--- a/examples/todo-app/src/pages/type-tests.fl
+++ b/examples/todo-app/src/pages/type-tests.fl
@@ -22,15 +22,15 @@ let _name = item.text
 let _done = item.done
 
 // ✓ hover: boolean
-// const _bad = item.nonexistent // ✗ uncomment → "type `Todo` has no field `nonexistent`"
+// let _bad = item.nonexistent // ✗ uncomment → "type `Todo` has no field `nonexistent`"
 // ── Constructor validation ───────────────────────────────
 // Wrong field types should error
 
 let _good = Todo(id: "1", text: "hi", done: false)
 
 // ✓
-// const _bad1 = Todo(id: 42, text: "hi", done: false)   // ✗ uncomment → field `id`: expected `string`, found `number`
-// const _bad2 = Todo(id: "1", text: "hi", done: "yes")  // ✗ uncomment → field `done`: expected `boolean`, found `string`
+// let _bad1 = Todo(id: 42, text: "hi", done: false)   // ✗ uncomment → field `id`: expected `string`, found `number`
+// let _bad2 = Todo(id: "1", text: "hi", done: "yes")  // ✗ uncomment → field `done`: expected `boolean`, found `string`
 // ── Match arm consistency ────────────────────────────────
 // All arms must return the same type
 
@@ -68,12 +68,12 @@ let double(x: number) -> number = {
 let _piped = 5 |> double
 
 // ✓
-// const _badPipe = "hi" |> double  // ✗ uncomment → expected `number`, found `string`
+// let _badPipe = "hi" |> double  // ✗ uncomment → expected `number`, found `string`
 // ── Shadowing ────────────────────────────────────────────
 
 let myVal = 5
 
-// const myVal = 10  // ✗ uncomment → already defined and cannot be shadowed
+// let myVal = 10  // ✗ uncomment → already defined and cannot be shadowed
 // ── Return type mismatch ─────────────────────────────────
 
 let greet() -> string = {


### PR DESCRIPTION
closes #1383

## Summary

Floe uses `let` for bindings, not `const`. Several docs and fixtures still claimed otherwise — most painfully in `docs/llms.txt` (the LLM-facing reference) and `docs/site/` (the user-facing guide).

## Files touched

- `docs/llms.txt` — example comment, ambiguous-variant snippet, TS↔Floe table row, array-destructure rule
- `docs/site/src/content/docs/docs/guide/from-typescript.md` — two table rows
- `docs/site/src/content/docs/docs/guide/use.md` — rename example
- `docs/site/src/content/docs/docs/guide/functions.md` — title, heading, intro, destructure note, anonymous-fn rule, "what's not here" list
- `docs/site/src/content/docs/docs/reference/syntax.md` — destructure comment
- `docs/site/src/content/docs/docs/reference/vscode.md` — keywords list
- `examples/todo-app/src/pages/type-tests.fl` — five commented examples
- `crates/floe-core/tests/fixtures/todo_unreachable.fl` — comment
- `editors/vscode/tests/syntax.test.fl` — TextMate fixture

Left alone: `examples/store-ts/*.ts` (real TypeScript), `as const` codegen output, TS code blocks inside markdown.

## Test plan

- [x] `floe check` on the two `.fl` files I edited — both pass
- [ ] CI: `floe-doc-check` against updated `llms.txt` and `docs/site/`
- [ ] CI: example apps still build