### PR TITLE
fix: [#1386] register loader falls back to src/ when sibling missing in .floe/

### DIFF
--- a/integrations/register/package.json
+++ b/integrations/register/package.json
@@ -9,7 +9,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "test": "node --test --experimental-strip-types src/*.test.ts",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "floe",

--- a/integrations/register/src/index.test.ts
+++ b/integrations/register/src/index.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
+import { execFileSync } from "node:child_process";
+
+const REGISTER_DIST = resolvePath(import.meta.dirname, "..", "dist", "index.js");
+
+describe("@floeorg/register", () => {
+  let projectDir: string;
+
+  before(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "floe-register-test-"));
+    mkdirSync(join(projectDir, "src", "providers"), { recursive: true });
+    writeFileSync(
+      join(projectDir, "package.json"),
+      `{"name":"test","type":"module"}`,
+    );
+
+    // Floe module that imports a hand-written .ts sibling. The shim
+    // exposes a plain Node API; the .fl module wraps it.
+    writeFileSync(
+      join(projectDir, "src", "providers", "thing-state.ts"),
+      `export function getThing(): string { return "shim-value"; }\n`,
+    );
+    writeFileSync(
+      join(projectDir, "src", "providers", "thing.fl"),
+      `import trusted { getThing } from "./thing-state"
+
+export let read() -> string = {
+    getThing()
+}
+`,
+    );
+
+    // Entry point: a plain TS file that imports the .fl module.
+    writeFileSync(
+      join(projectDir, "src", "main.ts"),
+      `import { read } from "./providers/thing.fl";
+console.log(read());
+`,
+    );
+
+    execFileSync("floe", ["build", "src/"], {
+      cwd: projectDir,
+      stdio: "pipe",
+    });
+  });
+
+  after(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it("falls back to src/ when a compiled .fl.ts imports a hand-written .ts sibling", () => {
+    const stdout = execFileSync(
+      "node",
+      ["--import", `file://${REGISTER_DIST}`, "src/main.ts"],
+      { cwd: projectDir, encoding: "utf8" },
+    );
+    assert.equal(stdout.trim(), "shim-value");
+  });
+});

--- a/integrations/register/src/index.ts
+++ b/integrations/register/src/index.ts
@@ -48,34 +48,109 @@ function findCompiledPath(
   return null;
 }
 
+/**
+ * If `path` lives under `projectRoot/.floe/`, return the corresponding
+ * path under `projectRoot/` (the "source mirror"). Returns null when
+ * `path` is outside `.floe/`.
+ *
+ * Used to recover when a compiled `.fl.ts` in `.floe/` imports a
+ * hand-written `.ts` sibling: that sibling lives in `src/`, never
+ * gets copied into `.floe/`, and Node's default resolver can't find
+ * it. Reflecting the parent path back into `src/` lets Node resolve
+ * the sibling from its real location.
+ */
+function srcMirrorOf(path: string, projectRoot: string): string | null {
+  const floeDir = join(projectRoot, ".floe");
+  const rel = relative(floeDir, path);
+  if (rel.startsWith("..") || rel.startsWith("/")) return null;
+  return join(projectRoot, rel);
+}
+
+/**
+ * Probe the filesystem for `target`, trying TS/JS extensions and
+ * `index.*` variants. Node ESM strict mode requires explicit
+ * extensions on relative imports, but Floe's codegen passes through
+ * extensionless source paths unchanged — so once we've reflected the
+ * parent back into `src/` we have to do the extension lookup the
+ * default resolver would have done in a non-strict world.
+ */
+function probeExtensions(target: string): string | null {
+  const candidates = [
+    target,
+    `${target}.ts`,
+    `${target}.tsx`,
+    `${target}.mts`,
+    `${target}.cts`,
+    `${target}.js`,
+    `${target}.mjs`,
+    `${target}.cjs`,
+    join(target, "index.ts"),
+    join(target, "index.tsx"),
+    join(target, "index.mts"),
+    join(target, "index.cts"),
+    join(target, "index.js"),
+    join(target, "index.mjs"),
+    join(target, "index.cjs"),
+  ];
+  for (const candidate of candidates) {
+    try {
+      if (statSync(candidate).isFile()) return candidate;
+    } catch {}
+  }
+  return null;
+}
+
 registerHooks({
   resolve(specifier, context, nextResolve) {
-    if (!specifier.endsWith(".fl")) {
-      return nextResolve(specifier, context);
+    // Floe-source import (`./foo.fl`): rewrite to the compiled `.floe/`
+    // path. Bare `.fl` specifiers fall through to default resolution.
+    if (specifier.endsWith(".fl") && specifier.startsWith(".")) {
+      const parentPath = context.parentURL
+        ? fileURLToPath(context.parentURL)
+        : join(process.cwd(), "__entry__");
+      const flFile = resolve(dirname(parentPath), specifier);
+      const projectRoot = findProjectRoot(dirname(flFile));
+      const compiled = findCompiledPath(flFile, projectRoot);
+
+      if (compiled) {
+        return {
+          url: pathToFileURL(compiled).href,
+          shortCircuit: true,
+        };
+      }
+
+      throw new Error(
+        `Floe: compiled output not found for "${specifier}". ` +
+          `Run \`floe build\` or \`floe watch\` first.`,
+      );
     }
 
-    // Only handle relative imports — bare specifiers go through normal resolution
-    if (!specifier.startsWith(".")) {
+    // Anything else: try default resolution. If it fails AND the parent
+    // is a compiled file under `.floe/`, retry by probing the same
+    // relative path from the corresponding `src/` location — that's
+    // where hand-written sibling `.ts` files live (they never get
+    // copied into `.floe/`).
+    try {
       return nextResolve(specifier, context);
-    }
-
-    const parentPath = context.parentURL
-      ? fileURLToPath(context.parentURL)
-      : join(process.cwd(), "__entry__");
-    const flFile = resolve(dirname(parentPath), specifier);
-    const projectRoot = findProjectRoot(dirname(flFile));
-    const compiled = findCompiledPath(flFile, projectRoot);
-
-    if (compiled) {
+    } catch (err) {
+      if (
+        !specifier.startsWith(".") ||
+        !context.parentURL ||
+        (err as { code?: string })?.code !== "ERR_MODULE_NOT_FOUND"
+      ) {
+        throw err;
+      }
+      const parentPath = fileURLToPath(context.parentURL);
+      const projectRoot = findProjectRoot(dirname(parentPath));
+      const srcParent = srcMirrorOf(parentPath, projectRoot);
+      if (!srcParent) throw err;
+      const target = resolve(dirname(srcParent), specifier);
+      const probed = probeExtensions(target);
+      if (!probed) throw err;
       return {
-        url: pathToFileURL(compiled).href,
+        url: pathToFileURL(probed).href,
         shortCircuit: true,
       };
     }
-
-    throw new Error(
-      `Floe: compiled output not found for "${specifier}". ` +
-        `Run \`floe build\` or \`floe watch\` first.`,
-    );
   },
 });

--- a/integrations/register/tsconfig.json
+++ b/integrations/register/tsconfig.json
@@ -11,5 +11,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
closes #1386

## Summary

Floe doesn't copy or compile non-\`.fl\` files into \`.floe/\`, so a compiled \`.fl\` module that imports a hand-written \`.ts\` sibling fails at runtime — Node looks for the sibling next to the compiled file (under \`.floe/\`), where it doesn't exist.

When default resolution fails with \`ERR_MODULE_NOT_FOUND\` from a parent under \`.floe/\`, the hook now reflects the parent back into the project's \`src/\` tree and probes common TS/JS extensions (\`.ts\`, \`.tsx\`, \`.mts\`, \`.cts\`, \`.js\`, \`.mjs\`, \`.cjs\`, and the same set under \`index.*\`). The probe is needed because Node ESM strict mode doesn't auto-resolve extensions on relative imports — the previous default-resolver delegate would still throw even with the parent reflected.

## Test plan

- [x] New integration test in \`integrations/register/src/index.test.ts\` — compiles a \`.fl\` module that imports a hand-written \`.ts\` sibling, runs it through \`node --import register\`, expects the sibling's value to print.
- [x] Manual repro: same as the user's mock-server pattern, \`shim-value\` prints instead of \`ERR_MODULE_NOT_FOUND\`.
- [ ] CI: full test pass.

## Out of scope

- Same fallback for \`@floeorg/vite-plugin\` and \`@floeorg/esbuild-plugin\` — file separately if anyone hits it there. Both work differently enough that one shared helper isn't worth carving out yet.
- Switching the \`.floe/\` mirror layout itself (see #1385, closed — mirror stays).