### PR TITLE
feat: cover .astro pages in floe-doc-check and refresh landing samples

### DIFF
--- a/crates/floe-doc-check/src/extract_astro.rs
+++ b/crates/floe-doc-check/src/extract_astro.rs
@@ -1,0 +1,237 @@
+//! Extract Floe code samples from `.astro` source files.
+//!
+//! Astro pages embed code as JavaScript template literals — either inside
+//! `<Code code={`...`} lang={floeLang} />` Astro components or as standalone
+//! variables. Neither shape is a Markdown fence, so the markdown extractor
+//! never sees them.
+//!
+//! Why a marker instead of auto-detecting `lang={floeLang}`: parsing JSX
+//! attributes and template literals robustly without a real parser is
+//! fiddly, and Floe samples can themselves contain backticks (tagged
+//! templates from npm interop) which would confuse a regex. The marker is
+//! one extra line per block and zero ambiguity.
+//!
+//! Unescaped `${...}` interpolation is replaced with a placeholder
+//! identifier — real interpolation in a Floe sample would be an author
+//! mistake, and a placeholder keeps the surrounding code parseable so the
+//! rest of the block still gets checked.
+
+use std::path::Path;
+
+use floe_core::line_numbers::LineNumbers;
+
+use crate::extract::CodeBlock;
+
+const MARKER: &str = "@floe-check";
+
+pub fn extract_astro_blocks(source: &str, path: &Path) -> Vec<CodeBlock> {
+    let line_numbers = LineNumbers::new(source);
+    let mut blocks = Vec::new();
+    let mut search_from = 0;
+
+    while let Some(rel) = source[search_from..].find(MARKER) {
+        let marker_pos = search_from + rel;
+        let after_marker = marker_pos + MARKER.len();
+
+        let extracted = source[after_marker..]
+            .find('`')
+            .map(|off| after_marker + off)
+            .and_then(|tick_pos| {
+                decode_template_literal(source, tick_pos)
+                    .map(|(code, end_pos)| (tick_pos, code, end_pos))
+            });
+
+        match extracted {
+            Some((tick_pos, code, end_pos)) => {
+                let start_line = line_numbers.line_number((tick_pos + 1) as u32) as usize;
+                blocks.push(CodeBlock {
+                    path: path.to_path_buf(),
+                    code,
+                    start_line,
+                    info: "floe".to_string(),
+                });
+                search_from = end_pos;
+            }
+            None => {
+                search_from = after_marker;
+            }
+        }
+    }
+
+    blocks
+}
+
+/// Walk a JavaScript template literal whose opening backtick is at
+/// `source.as_bytes()[open]`. Returns the decoded inner text and the byte
+/// index just past the closing backtick.
+fn decode_template_literal(source: &str, open: usize) -> Option<(String, usize)> {
+    debug_assert_eq!(source.as_bytes()[open], b'`');
+    let mut out = String::new();
+    let mut iter = source[open + 1..].char_indices().peekable();
+
+    while let Some((rel, c)) = iter.next() {
+        match c {
+            '\\' => match iter.next() {
+                Some((_, '`')) => out.push('`'),
+                Some((_, '$')) => out.push('$'),
+                Some((_, '\\')) => out.push('\\'),
+                Some((_, 'n')) => out.push('\n'),
+                Some((_, 't')) => out.push('\t'),
+                Some((_, 'r')) => out.push('\r'),
+                Some((_, other)) => {
+                    // Unknown escape — keep verbatim so we don't silently
+                    // change the author's intent.
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => return None,
+            },
+            '$' if iter.peek().map(|(_, c)| *c) == Some('{') => {
+                iter.next();
+                let mut depth = 1usize;
+                for (_, c) in iter.by_ref() {
+                    match c {
+                        '{' => depth += 1,
+                        '}' => {
+                            depth -= 1;
+                            if depth == 0 {
+                                break;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                out.push_str("__interp__");
+            }
+            '`' => {
+                let close_byte = open + 1 + rel;
+                return Some((out, close_byte + 1));
+            }
+            other => out.push(other),
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn extract(src: &str) -> Vec<CodeBlock> {
+        extract_astro_blocks(src, Path::new("test.astro"))
+    }
+
+    #[test]
+    fn extracts_jsx_marker_block() {
+        let src = "\
+<div>
+  {/* @floe-check */}
+  <Code
+    code={`let x = 1`}
+    lang={floeLang}
+  />
+</div>
+";
+        let blocks = extract(src);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].code, "let x = 1");
+    }
+
+    #[test]
+    fn extracts_line_comment_marker_block() {
+        let src = "\
+// @floe-check
+let defaultCode = `let greet(name: string) -> string = { name }`;
+";
+        let blocks = extract(src);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(
+            blocks[0].code,
+            "let greet(name: string) -> string = { name }"
+        );
+    }
+
+    #[test]
+    fn unescapes_template_escapes() {
+        let src = "\
+// @floe-check
+let s = `a \\` b \\$ c \\\\ d`;
+";
+        let blocks = extract(src);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].code, "a ` b $ c \\ d");
+    }
+
+    #[test]
+    fn replaces_interpolation_with_placeholder() {
+        let src = "\
+// @floe-check
+let s = `let x = ${1 + 2}`;
+";
+        let blocks = extract(src);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].code, "let x = __interp__");
+    }
+
+    #[test]
+    fn skips_blocks_without_marker() {
+        let src = "\
+let other = `let x = 1`;
+<Code code={`let y = 2`} lang={floeLang} />
+";
+        let blocks = extract(src);
+        assert!(blocks.is_empty());
+    }
+
+    #[test]
+    fn extracts_multiple_blocks() {
+        let src = "\
+{/* @floe-check */}
+<Code code={`let x = 1`} lang={floeLang} />
+prose
+// @floe-check
+let s = `let y = 2`;
+";
+        let blocks = extract(src);
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0].code, "let x = 1");
+        assert_eq!(blocks[1].code, "let y = 2");
+    }
+
+    #[test]
+    fn line_number_points_at_first_code_line() {
+        let src = "prose\n\
+                   {/* @floe-check */}\n\
+                   <Code\n\
+                     code={`first\n\
+                   second`}\n\
+                     lang={floeLang}\n\
+                   />\n";
+        let blocks = extract(src);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].start_line, 4);
+    }
+
+    #[test]
+    fn marker_without_template_is_ignored() {
+        let src = "// @floe-check\nlet x = 1;\n";
+        let blocks = extract(src);
+        assert!(blocks.is_empty());
+    }
+
+    #[test]
+    fn unterminated_template_is_ignored() {
+        let src = "// @floe-check\nlet x = `unterminated\n";
+        let blocks = extract(src);
+        assert!(blocks.is_empty());
+    }
+
+    #[test]
+    fn preserves_multibyte_utf8() {
+        let src = "// @floe-check\nlet s = `let greeting = \"こんにちは\"`;\n";
+        let blocks = extract(src);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].code, "let greeting = \"こんにちは\"");
+    }
+}

--- a/crates/floe-doc-check/src/lib.rs
+++ b/crates/floe-doc-check/src/lib.rs
@@ -1,19 +1,24 @@
-//! Syntax-check Floe code samples embedded in Markdown documentation.
+//! Syntax-check Floe code samples embedded in documentation.
 //!
-//! Walks a set of Markdown files, extracts every ```floe fenced code block,
-//! and runs each through the Floe parser. Reports parse errors as
+//! Walks a set of doc files (Markdown and Astro), extracts every Floe code
+//! sample, and runs each through the Floe parser. Reports parse errors as
 //! `path:line:column: message` with line numbers rewritten back to the
-//! original Markdown file so editors can jump straight to the bad sample.
+//! original source file so editors can jump straight to the bad sample.
+//!
+//! Markdown sources contribute every ```floe fenced block. Astro sources
+//! contribute every template literal preceded by an `@floe-check` marker
+//! comment — see `extract_astro` for the rationale.
 
 use std::path::{Path, PathBuf};
 
 use floe_core::parser::Parser;
 
 pub mod extract;
+pub mod extract_astro;
 
 pub use extract::{CodeBlock, extract_blocks};
+pub use extract_astro::extract_astro_blocks;
 
-/// A parse error reported against its original position in the Markdown file.
 #[derive(Debug, Clone)]
 pub struct BlockError {
     pub path: PathBuf,
@@ -35,7 +40,6 @@ impl std::fmt::Display for BlockError {
     }
 }
 
-/// Parse the code in a block and map any errors back to the Markdown file.
 pub fn check_block(block: &CodeBlock) -> Vec<BlockError> {
     match Parser::parse(&block.code) {
         Ok(_) => Vec::new(),
@@ -51,38 +55,51 @@ pub fn check_block(block: &CodeBlock) -> Vec<BlockError> {
     }
 }
 
-/// Recursively find Markdown files under `root`.
-///
-/// Includes `*.md` and `*.mdx`. Symlinks are not followed, to avoid cycles.
-pub fn find_markdown_files(root: &Path) -> Vec<PathBuf> {
+/// Recursively collect every file under `root` whose extension matches one
+/// of `extensions`. Symlinks are not followed, to avoid cycles.
+pub fn find_files_with_extensions(root: &Path, extensions: &[&str]) -> Vec<PathBuf> {
+    let matches_ext = |p: &Path| {
+        p.extension()
+            .and_then(|s| s.to_str())
+            .is_some_and(|e| extensions.contains(&e))
+    };
+
     if root.is_file() {
-        return vec![root.to_path_buf()];
+        return if matches_ext(root) {
+            vec![root.to_path_buf()]
+        } else {
+            Vec::new()
+        };
     }
+
     walkdir::WalkDir::new(root)
         .follow_links(false)
         .into_iter()
         .filter_map(Result::ok)
         .filter(|e| e.file_type().is_file())
         .map(|e| e.into_path())
-        .filter(|p| {
-            matches!(
-                p.extension().and_then(|s| s.to_str()),
-                Some("md") | Some("mdx")
-            )
-        })
+        .filter(|p| matches_ext(p))
         .collect()
 }
 
-/// Check every ```floe block in every Markdown file under `roots`.
-///
-/// Returns the full error list. An empty vector means every sample parsed.
 pub fn check_paths(roots: &[PathBuf]) -> std::io::Result<Vec<BlockError>> {
     let mut errors = Vec::new();
-    let mut files: Vec<PathBuf> = roots.iter().flat_map(|r| find_markdown_files(r)).collect();
-    files.sort();
-    files.dedup();
 
-    for path in &files {
+    let mut markdown_files: Vec<PathBuf> = roots
+        .iter()
+        .flat_map(|r| find_files_with_extensions(r, &["md", "mdx"]))
+        .collect();
+    markdown_files.sort();
+    markdown_files.dedup();
+
+    let mut astro_files: Vec<PathBuf> = roots
+        .iter()
+        .flat_map(|r| find_files_with_extensions(r, &["astro"]))
+        .collect();
+    astro_files.sort();
+    astro_files.dedup();
+
+    for path in &markdown_files {
         let source = std::fs::read_to_string(path)?;
         for block in extract_blocks(&source, path) {
             if block.is_ignored() {
@@ -91,5 +108,13 @@ pub fn check_paths(roots: &[PathBuf]) -> std::io::Result<Vec<BlockError>> {
             errors.extend(check_block(&block));
         }
     }
+
+    for path in &astro_files {
+        let source = std::fs::read_to_string(path)?;
+        for block in extract_astro_blocks(&source, path) {
+            errors.extend(check_block(&block));
+        }
+    }
+
     Ok(errors)
 }

--- a/docs/design.md
+++ b/docs/design.md
@@ -1036,11 +1036,11 @@ let config = Config(baseUrl: "https://api.example.com", timeout: 10000)
 // timeout overridden, rest defaulted
 
 // On functions
-fn fetchUsers(
+let fetchUsers(
   page: number = 1,
   limit: number = 20,
   sort: SortOrder = Ascending,
-): Result<Array<User>, ApiError> {
+) -> Result<Array<User>, ApiError> = {
   // page, limit, sort are always concrete values — never Option, never undefined
 }
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1781,7 +1781,7 @@ let user = fetchUser(id) |> await
 // user: Result<User, Error>
 
 // Compose with |> await? for concise async error handling.
-// `async fn f() -> T` is sugar for `fn f() -> Promise<T>` — write the inner type:
+// `async let f() -> T = { ... }` is sugar for `let f() -> Promise<T> = { ... }` — write the inner type:
 async let loadProfile(id: string) -> Result<Profile, Error> = {
   let user = fetchUser(id) |> await?
   let posts = fetchPosts(user.id) |> await?

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -7,7 +7,7 @@ Floe is a programming language that compiles to TypeScript. It targets TypeScrip
 ## Core Syntax
 
 ```floe
-// Named functions use fn keyword with -> return type.
+// Named functions use let with -> return type.
 // Match arms use ->. Every other type-position arrow uses ->.
 let add(a: number, b: number) -> number = {
     a + b
@@ -79,7 +79,7 @@ The RHS picks what is legal under each keyword:
 
 `opaque type Name = RHS` is a special form: nominal on the outside, wrapping an arbitrary structural shape inside — so `opaque type HashedPw = string` is valid even though bare `type HashedPw = string` is not.
 
-An inline record in a function signature (e.g. `fn f(x: { a: T })`) is **E202** — name the type.
+An inline record in a function signature (e.g. `let f(x: { a: T })`) is **E202** — name the type.
 
 ```floe
 // Record type
@@ -236,7 +236,7 @@ let c = Color.Red     // OK — qualified
 let toValidation = Validation  // (errors) -> ({ __tag: "Validation", errors })
 let toApi = SaveError.Api      // (message) -> ({ __tag: "Api", message })
 // Useful with mapErr:
-result |> Result.mapErr(Validation)  // instead of Result.mapErr(fn(e) Validation(e))
+result |> Result.mapErr(Validation)  // instead of Result.mapErr((e) -> Validation(e))
 ```
 
 ## Pipe Operator
@@ -443,7 +443,7 @@ users |> Array.mapResult(validateUser)          // Result<Array<ValidUser>, Erro
 result |> Result.orElse((e) -> tryFallback(e))   // lazy fallback chain
 
 // Array helpers
-items |> Array.filterMap((x) -> if_valid(x))     // map + filter in one pass (fn returns Option)
+items |> Array.filterMap((x) -> if_valid(x))     // map + filter in one pass (callback returns Option)
 items |> Array.partition(.active)                 // (active, inactive) — split by predicate
 nested |> Array.flatten                           // Array<Array<T>> -> Array<T>
 users |> Array.uniqueBy(.email)                   // deduplicate by key function (keeps first)
@@ -454,10 +454,10 @@ items |> Array.dropWhile(.done)                   // drop while predicate holds
 let joined = ["a", "b", "c"] |> Array.intersperse(", ")  // ["a", ", ", "b", ", ", "c"]
 
 // Promise helpers
-// Promise.await (or bare `await`): Promise<T> -> T (compiles to await, infers async on enclosing fn)
+// Promise.await (or bare `await`): Promise<T> -> T (compiles to await, infers async on enclosing function)
 // Functions using await must return Promise<T> (like ? requires Result<T, E>)
-// `async fn f() -> T` is sugar for `fn f() -> Promise<T>` — write the inner type
-//   async fn fetchUser(id: number) -> Result<User, Error> { Http.get(url) |> await? |> parse<User> }
+// `async let f() -> T = { ... }` is sugar for `let f() -> Promise<T> = { ... }` — write the inner type
+//   async let fetchUser(id: number) -> Result<User, Error> = { Http.get(url) |> await? |> parse<User> }
 // Emits TS `async function ...: Promise<T>`. Callers still use `|> await` to unwrap.
 let users = Promise.all([fetchUser(1), fetchUser(2)]) |> await
 let fastest = Promise.race([fetchFromCDN(url), fetchFromOrigin(url)]) |> await
@@ -639,8 +639,8 @@ Console.log("done")
 `use` is a **contextual keyword**. Bind shapes:
 - `use <- expr`                    — zero-binding callback
 - `use x <- expr`                  — single ident
-- `use (a, b) <- expr`             — multi-parameter callback → `fn(a, b) { ... }`
-- `use { a, b } <- expr`           — object-destructured single param → `fn({ a, b }) { ... }`
+- `use (a, b) <- expr`             — multi-parameter callback → `(a, b) -> { ... }`
+- `use { a, b } <- expr`           — object-destructured single param → `({ a, b }) -> { ... }`
 - `use { a: x, b: y } <- expr`     — object destructure with renames
 
 `use(promise)`, `import { use } from "react"`, and `foo.use` are plain identifier uses — so React 19's `use()` hook works unchanged.
@@ -856,7 +856,7 @@ else they parse as ordinary identifiers so names don't collide with user code
 
 | Keyword | Keyword only when… | Identifier elsewhere (examples) |
 |---|---|---|
-| `type` | At item start (`type X = ...`) | `{ type: "click" }`, `<input type="text" />`, `fn f(type: string)` |
+| `type` | At item start (`type X = ...`) | `{ type: "click" }`, `<input type="text" />`, `let f(type: string)` |
 | `opaque` | Before `type` (`opaque type X = ...`) | `let opaque = 1` |
 | `trusted` | In imports (`import trusted { ... }`) | `let trusted = true` |
 | `deriving` | After a record type (`... deriving (Display)`) | `let deriving = []` |
@@ -885,18 +885,18 @@ out of scope.
 | `?.` (optional chain) | `match` on `Option` or `?` |
 | `??` (nullish coalesce) | `Option.unwrapOr` |
 | `->` (arrow function) | `(x) -> expr` closure; function types also use `->`: `(T) -> U` |
-| `function` keyword | `fn` |
+| `function` keyword | `let` (named) or `(params) -> body` (anonymous) |
 | `void` | Unit type `()` |
 | `as` (type assertion) | Type guards or `match` |
 | `return` | Implicit returns — last expression is the return value |
-| `async`/`await` | `\|> await` (or `\|> Promise.await`); return type `Promise<T>` or `async fn f() -> T` (sugar) |
+| `async`/`await` | `\|> await` (or `\|> Promise.await`); return type `Promise<T>` or `async let f() -> T` (sugar) |
 
 ## Compilation Examples
 
 | Floe | TypeScript Output |
 |------|-------------------|
-| `fn f(x: number) -> number { x }` | `function f(x: number): number { return x; }` |
-| `fn f<T>(x: T) -> T { x }` | `function f<T>(x: T): T { return x; }` |
+| `let f(x: number) -> number = { x }` | `function f(x: number): number { return x; }` |
+| `let f<T>(x: T) -> T = { x }` | `function f<T>(x: T): T { return x; }` |
 | `a \|> f(b)` | `f(a, b)` |
 | `a \|> f(b, _, c)` | `f(b, a, c)` |
 | `a \|> match { 1 -> "one", _ -> "other" }` | `match a { ... }` (desugared) |
@@ -912,8 +912,8 @@ out of scope.
 | `Console.log(x)` | `console.log(x)` |
 | `(1, 2)` | `[1, 2] as const` |
 | `()` (unit) | `undefined` |
-| `expr \|> await` | `await expr` (enclosing fn inferred `async`) |
-| `async fn f() -> T { body }` | `async function f(): Promise<T> { return body; }` |
+| `expr \|> await` | `await expr` (enclosing function inferred `async`) |
+| `async let f() -> T = { body }` | `async function f(): Promise<T> { return body; }` |
 | `` tag`a ${x} b` `` | `` tag`a ${x} b` `` (byte-identical tagged template — passes a `TemplateStringsArray` to `tag`) |
 
 ## CLI Commands
@@ -936,7 +936,7 @@ floe lsp                     # start language server (used by editors)
 1. **No semicolons** in Floe source
 2. **Exported functions must have explicit return types** with `->`
 3. **match is exhaustive** — all variants must be handled
-4. **`?` only works** inside functions returning `Result` or `Option`; **`|> await` requires** return type `Promise<T>` (or `async fn`)
+4. **`?` only works** inside functions returning `Result` or `Option`; **`|> await` requires** return type `Promise<T>` (or `async let`)
 5. **`==` is structural equality** — only between same types
 6. **No bracket indexing** — use `Map.get(map, key)` for maps, `Record.get(obj, key)` for plain-object records, `Array.get(arr, i)` for arrays (all return `Option<T>`). `obj[key]` is not valid Floe syntax
 7. **npm imports are untrusted by default** — calls auto-wrap in `Result<T, Error>`; use `import trusted` for safe imports

--- a/docs/site/src/pages/index.astro
+++ b/docs/site/src/pages/index.astro
@@ -492,6 +492,7 @@ import floeLang from "../../../../editors/vscode/syntaxes/floe.tmLanguage.json";
             <span class="dot dot-fl"></span>
             app.fl
           </div>
+          {/* @floe-check */}
           <Code
             code={`import { useState } from "react"
 
@@ -506,8 +507,8 @@ type Status =
   | Failed(string)
   | Ready(Array<User>)
 
-export fn Dashboard() -> JSX.Element {
-  const (status, setStatus) = useState<Status>(Loading)
+export let Dashboard() -> JSX.Element = {
+  let (status, setStatus) = useState<Status>(Loading)
 
   status |> match {
     Loading -> <Spinner />,
@@ -519,7 +520,7 @@ export fn Dashboard() -> JSX.Element {
 
       <div>
         <h2>{active |> length} active</h2>
-        {active |> map((u) =>
+        {active |> map((u) ->
           <Card key={u.name} title={u.name} badge={u.role} />
         )}
       </div>
@@ -594,6 +595,7 @@ export function Dashboard(): JSX.Element {
           <span class="dot dot-fl"></span>
           pipeline.fl
         </div>
+        {/* @floe-check */}
         <Code
           code={`// Dot shorthand — .field becomes an accessor function
 let activeNames = users
@@ -629,14 +631,15 @@ users
             <span class="dot dot-fl"></span>
             route.fl
           </div>
+          {/* @floe-check */}
           <Code
-            code={`type Route = 
+            code={`type Route =
   | Home
   | Profile(string)
   | Settings
   | NotFound
 
-fn render(route: Route) -> JSX.Element {
+let render(route: Route) -> JSX.Element = {
   match route {
     Home -> <HomePage />,
     Profile(id) -> <ProfilePage id={id} />,
@@ -663,8 +666,9 @@ fn render(route: Route) -> JSX.Element {
           <span class="dot dot-fl"></span>
           user.fl
         </div>
+        {/* @floe-check */}
         <Code
-          code={`fn getUser(id: string) -> Promise<Result<User, ApiError>> {
+          code={`let getUser(id: string) -> Promise<Result<User, ApiError>> = {
   let response = fetch("/api/users/{id}") |> await?
   let user = response.json() |> await?
 

--- a/docs/site/src/pages/playground.astro
+++ b/docs/site/src/pages/playground.astro
@@ -450,7 +450,8 @@
     ]));
 
     // ===== Default code =====
-    let defaultCode = `fn greet(name: string) -> string {
+    // @floe-check
+    let defaultCode = `let greet(name: string) -> string = {
   \`Hello, \${name}!\`
 }
 
@@ -461,7 +462,7 @@ type Color = | Red
   | Green
   | Blue
 
-fn describe(color: Color) -> string {
+let describe(color: Color) -> string = {
   match color {
     Red -> "red",
     Green -> "green",
@@ -469,7 +470,7 @@ fn describe(color: Color) -> string {
   }
 }
 
-fn safeDivide(a: number, b: number) -> Result<number, string> {
+let safeDivide(a: number, b: number) -> Result<number, string> = {
   match b {
     0 -> Err("division by zero"),
     _ -> Ok(a / b),


### PR DESCRIPTION
closes #1388

The landing page (`docs/site/src/pages/index.astro`) and playground (`docs/site/src/pages/playground.astro`) had stale `fn`/`const` Floe samples that no longer compile. `docs/design.md` and `docs/llms.txt` had stale `fn` mentions too. The doc-checker missed the `.astro` ones because it only walked `.md`/`.mdx` files.

## Changes

1. Refreshes every stale Floe sample in `index.astro`, `playground.astro`, and `design.md` to the current `let name(args) -> Ret = { ... }` form.
2. Sweeps `docs/llms.txt` for the same drift — comment text, the Differences-from-TypeScript table (`function` keyword row, `async`/`await` row), the compilation table, the contextual-keywords table, and the use-callback shapes. Also updates the matching `async fn` sugar comment in `design.md:1784`.
3. Adds `crates/floe-doc-check/src/extract_astro.rs` — pulls Floe template literals out of `.astro` files when they're tagged with a `@floe-check` marker comment (`// @floe-check` or `{/* @floe-check */}`). Walks the source as `&str` chars so multi-byte UTF-8 round-trips intact.
4. Wires `.astro` into `check_paths` alongside `.md`/`.mdx`. The CI invocation (`cargo run -p floe-doc-check -- docs/site/ docs/llms.txt README.md`) is unchanged — it now scans `.astro` automatically.
5. Adds `@floe-check` markers before each Floe `<Code>` in `index.astro` (4 blocks) and the `defaultCode` template in `playground.astro` so they're checked from now on.
6. Replaces `find_markdown_files` / `find_astro_files` near-duplicates with a single `find_files_with_extensions(root, exts)` helper, and reuses `floe_core::line_numbers::LineNumbers` for line-number mapping rather than rolling our own.

## Test plan

- [x] `cargo test -p floe-doc-check` — 22 unit tests, including 10 new for `.astro` extraction (markers, escape decoding, `${...}` placeholder, multi-block, line numbers, missing-marker / missing-template / unterminated-template skip, multi-byte UTF-8 preservation).
- [x] `cargo run -p floe-doc-check -- docs/site/ docs/llms.txt README.md` parses cleanly.
- [x] `cargo clippy -p floe-doc-check --all-targets -- -D warnings` clean.
- [x] `cargo fmt -p floe-doc-check --check` clean.
- [x] Negative spot-check: synthetic `.astro` with `fn foo() ...` after a marker reports `path:line:col: unexpected token: Fn`.
- [ ] Reviewer: visit the rendered landing page locally (`mise run dev 1388` then http://localhost:4321/) and confirm code samples render correctly.

## Out of scope

`docs/design.md` still has a number of stale `fn` references in design-rationale sections (lexer `Fn` token name, error-message strings, the `function → "Use fn instead"` row, the `Generic functions | fn identity<T>...` example, etc.). They're entangled with historical design notes and want a focused review rather than a sweep — flagging for a separate PR.