### PR TITLE
chore: [#1397] skip chore label for Dependabot PRs in pr-labeler

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -14,6 +14,8 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
+            if (context.payload.pull_request.user.login === 'dependabot[bot]') return;
+
             const title = context.payload.pull_request.title;
             const labels = [];
 


### PR DESCRIPTION
## Summary
- Dependabot PRs were getting a `chore` label because their titles start with `chore(deps):`, triggering the pr-labeler workflow
- Added an early return in `pr-labeler.yml` to skip labeling when the PR author is `dependabot[bot]`
- Dependabot PRs already get the `dependencies` label via `dependabot.yml` — no change needed there

closes #1397

🤖 Generated with [Claude Code](https://claude.com/claude-code)