### PR TITLE
chore: [#1399] harden supply chain (OSV, cargo-deny, cooldown, safe-chain)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
+      semver-major-days: 7
+      semver-minor-days: 7
+      semver-patch-days: 7
     groups:
       oxc:
         patterns:
@@ -23,6 +28,11 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
+      semver-major-days: 7
+      semver-minor-days: 7
+      semver-patch-days: 7
     ignore:
       # ovsx publish rejects the VS Code extension when
       # @types/vscode > engines.vscode. Bumping the types without also
@@ -39,3 +49,8 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
+      semver-major-days: 7
+      semver-minor-days: 7
+      semver-patch-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,20 +19,20 @@ jobs:
     name: Rust (fmt · test · clippy · build)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: "1.94.0"
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           key: ci-profile
 
       - name: Install nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@831231fdad2d3455d6c38b8144fa99d3adaca36e # nextest
 
       # fmt first — fail fast on trivial issues.
       - name: Format check
@@ -56,7 +56,7 @@ jobs:
         run: cargo run --profile ci -p floe-doc-check -- docs/site/ docs/llms.txt README.md
 
       - name: Upload binary
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: floe-binary
           path: target/ci/floe
@@ -67,10 +67,10 @@ jobs:
     needs: rust
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: floe-binary
 
@@ -78,14 +78,14 @@ jobs:
         run: chmod +x floe
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: 10
+        # No `version:` — action-setup reads packageManager from
+        # package.json so local and CI use the exact same pnpm.
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Aikido safe-chain
         # Installs PATH shims that intercept pnpm/npm/yarn/npx and check
@@ -97,7 +97,7 @@ jobs:
           # to fetch the safe-chain CLI. Disable the cooldown for this one
           # invocation; the shims it installs are the actual control.
           npm_config_minimum_release_age: "0"
-        run: pnpm dlx @aikidosec/safe-chain@latest setup-ci
+        run: pnpm dlx @aikidosec/safe-chain@1.5.1 setup-ci
 
       - name: Install example dependencies
         run: pnpm install --frozen-lockfile
@@ -130,10 +130,10 @@ jobs:
     needs: rust
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download binary
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: floe-binary
 
@@ -150,10 +150,10 @@ jobs:
     name: Tree-sitter grammar (generate + test)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install tree-sitter-cli
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@b5fddbb5361bce8a06fb168c9d403a6cc552b084 # v2.75.29
         with:
           tool: tree-sitter-cli@0.26.8
 
@@ -189,7 +189,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: shellcheck
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,18 @@ jobs:
         with:
           version: 10
 
+      - name: Setup Aikido safe-chain
+        # Installs PATH shims that intercept pnpm/npm/yarn/npx and check
+        # every package against Aikido's feed of known-malicious releases
+        # before the install runs. Must come before pnpm install so the
+        # shims are on PATH when packages are fetched.
+        env:
+          # pnpm dlx itself honors minimum-release-age, which would refuse
+          # to fetch the safe-chain CLI. Disable the cooldown for this one
+          # invocation; the shims it installs are the actual control.
+          npm_config_minimum_release_age: "0"
+        run: pnpm dlx @aikidosec/safe-chain@latest setup-ci
+
       - name: Install example dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -17,10 +17,10 @@ jobs:
     name: Build & Deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 
@@ -28,12 +28,12 @@ jobs:
         run: npm install -g pnpm
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: wasm32-unknown-unknown
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
 
       - name: Install wasm-pack
         run: cargo install wasm-pack

--- a/.github/workflows/pin-alpha.yml
+++ b/.github/workflows/pin-alpha.yml
@@ -17,7 +17,7 @@ jobs:
   pin-alpha:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Label PR from conventional commit prefix
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const title = context.payload.pull_request.title;

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
         with:
           config-file: .github/release-please-config.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,12 @@ jobs:
             archive: zip
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag_name }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: "1.94.0"
           targets: ${{ matrix.target }}
@@ -77,7 +77,7 @@ jobs:
         shell: bash
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: floe-${{ matrix.target }}
           path: floe-${{ matrix.target }}.${{ matrix.archive }}
@@ -87,18 +87,18 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag_name }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           merge-multiple: true
 
       - name: Upload assets and promote prerelease to latest
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ inputs.tag_name }}
           files: artifacts/*
@@ -116,20 +116,20 @@ jobs:
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag_name }}
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: 10
+        # No `version:` — action-setup reads packageManager from
+        # package.json so local and CI use the exact same pnpm.
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Install dependencies
         run: pnpm install
@@ -229,12 +229,12 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag_name }}
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read
       security-events: write
       actions: read
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.5
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
     with:
       scan-args: |-
         --lockfile=Cargo.lock
@@ -32,45 +32,30 @@ jobs:
       upload-sarif: true
 
   cargo-deny:
-    name: cargo-deny (advisories · licenses · sources)
+    name: cargo-deny (advisories · licenses · sources · bans)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17
         with:
           command: check advisories licenses sources bans
 
-  safe-chain-smoke:
-    # Verifies Aikido safe-chain shims load cleanly against the npm
-    # workspace. The real defensive value is the same step running
-    # before pnpm install in ci.yml; this job catches setup-ci breakage
-    # in isolation so a safe-chain regression doesn't surface as a
-    # cryptic failure inside the integration job.
-    name: Aikido safe-chain smoke
+  zizmor:
+    name: zizmor (GitHub Actions static analysis)
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-
-      - uses: pnpm/action-setup@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          version: 10
+          persist-credentials: false
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-          cache: "pnpm"
-
-      - name: Setup safe-chain
-        # `pnpm dlx` itself respects minimum-release-age in pnpm 10, which
-        # would refuse to fetch the safe-chain CLI on first run. Disable
-        # the cooldown for this one invocation; the shims it installs are
-        # the actual control we care about.
-        env:
-          npm_config_minimum_release_age: "0"
-        run: pnpm dlx @aikidosec/safe-chain@latest setup-ci
-
-      - name: Verify shims on PATH
-        run: |
-          which pnpm
-          pnpm --version
+      # continue-on-error: existing workflows have findings that are out of
+      # scope for this PR (tracked in #1404). zizmor still uploads SARIF to
+      # the Security tab so findings are visible; flip to blocking once the
+      # cleanup issue lands.
+      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        continue-on-error: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,76 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Re-scan weekly so newly-disclosed CVEs against unchanged
+    # dependencies get caught even when nothing in the repo changed.
+    - cron: "17 6 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  osv-scanner:
+    name: OSV-Scanner (Cargo + npm)
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.5
+    with:
+      scan-args: |-
+        --lockfile=Cargo.lock
+        --lockfile=pnpm-lock.yaml
+      upload-sarif: true
+
+  cargo-deny:
+    name: cargo-deny (advisories · licenses · sources)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories licenses sources bans
+
+  safe-chain-smoke:
+    # Verifies Aikido safe-chain shims load cleanly against the npm
+    # workspace. The real defensive value is the same step running
+    # before pnpm install in ci.yml; this job catches setup-ci breakage
+    # in isolation so a safe-chain regression doesn't surface as a
+    # cryptic failure inside the integration job.
+    name: Aikido safe-chain smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Setup safe-chain
+        # `pnpm dlx` itself respects minimum-release-age in pnpm 10, which
+        # would refuse to fetch the safe-chain CLI on first run. Disable
+        # the cooldown for this one invocation; the shims it installs are
+        # the actual control we care about.
+        env:
+          npm_config_minimum_release_age: "0"
+        run: pnpm dlx @aikidosec/safe-chain@latest setup-ci
+
+      - name: Verify shims on PATH
+        run: |
+          which pnpm
+          pnpm --version

--- a/.npmrc
+++ b/.npmrc
@@ -5,3 +5,9 @@ engine-strict=true
 # cooldown ensures we never install one. Mirrors the cooldown in
 # .github/dependabot.yml so Dependabot won't propose a version pnpm refuses.
 minimum-release-age=10080
+# Bypass the cooldown for specific packages by name (one entry per line).
+# Add an entry in a PR with a written justification (typically a CVE patch
+# that needs to land before the cooldown expires) and remove it once the
+# cooldown for that version has passed naturally. Excluded packages still
+# go through cargo-deny / OSV-Scanner / safe-chain.
+# minimum-release-age-exclude[]=urgent-package-name

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,7 @@
 shamefully-hoist=true
+engine-strict=true
+# Refuse any package version published less than 1 week ago. Compromised
+# npm releases are typically detected and unpublished within hours; the
+# cooldown ensures we never install one. Mirrors the cooldown in
+# .github/dependabot.yml so Dependabot won't propose a version pnpm refuses.
+minimum-release-age=10080

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "floe"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "floe-core"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "ariadne",
  "bincode",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "floe-doc-check"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "floe-lsp"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "floe-core",
  "insta",
@@ -356,14 +356,14 @@ dependencies = [
 
 [[package]]
 name = "floe-test-helpers"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "floe-core",
 ]
 
 [[package]]
 name = "floe-wasm"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "floe-core",
  "serde",

--- a/crates/floe-cli/Cargo.toml
+++ b/crates/floe-cli/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/floeorg/floe"
 keywords = ["compiler", "typescript", "react", "programming-language"]
 categories = ["compilers", "development-tools"]
 readme = "../../README.md"
+publish = false
 
 [[bin]]
 name = "floe"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,51 @@
+# cargo-deny configuration. Run `cargo deny check` locally to mirror CI.
+
+[graph]
+all-features = true
+
+[advisories]
+version = 2
+yanked = "deny"
+ignore = [
+    # bincode 2.x — the maintainers ceased development in 2025 (no
+    # security issue, no migration path). Re-evaluate if a fork or
+    # successor crate (postcard, bitcode, rkyv) becomes a better fit.
+    "RUSTSEC-2025-0141",
+]
+
+[licenses]
+version = 2
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "MPL-2.0",
+    "CC0-1.0",
+    "0BSD",
+    "BSL-1.0",
+]
+confidence-threshold = 0.93
+
+[bans]
+multiple-versions = "allow"
+wildcards = "deny"
+# Internal workspace crates use `path = "..."` without a version
+# constraint. cargo-deny flags those as wildcards by default; allow
+# them since they're first-party deps under our control.
+allow-wildcard-paths = true
+highlight = "all"
+
+[sources]
+# Only allow crates from the official registry. A transitive dep pulled
+# from a git URL or local path would bypass crates.io's signing and yank
+# protection; refuse those outright.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,7 @@
+# OSV-Scanner configuration. Mirrors deny.toml's advisories.ignore so
+# we don't get the same finding flagged by two tools. Migration off
+# bincode is tracked in #1403.
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0141"
+reason = "bincode unmaintained — no security vulnerability, no migration path. Tracked in #1403."

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "onlyBuiltDependencies": [
       "esbuild",
       "sharp"
-    ]
+    ],
+    "overrides": {
+      "brace-expansion@<2.0.3": "^2.0.3"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "private": true,
+  "packageManager": "pnpm@10.29.3",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "postinstall": "pnpm --filter \"./integrations/*\" build",
     "build:plugin": "pnpm --filter @floeorg/vite-plugin build",
@@ -10,5 +14,11 @@
     "lint": "pnpm -r lint",
     "format": "pnpm -r format",
     "clean": "pnpm -r exec rm -rf node_modules dist out"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion@<2.0.3: ^2.0.3
+
 importers:
 
   .: {}
@@ -1439,8 +1442,8 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3786,7 +3789,7 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@2.0.2:
+  brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
 
@@ -4882,7 +4885,7 @@ snapshots:
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 2.1.0
 
   mrmime@2.0.1: {}
 


### PR DESCRIPTION
## Summary
- pnpm 1-week cooldown via `minimum-release-age`, plus `engine-strict`, `packageManager` pin, and `onlyBuiltDependencies` allowlist (esbuild, sharp). `.npmrc` includes a commented-out `minimum-release-age-exclude[]` example for urgent CVE bypass.
- Dependabot cooldown matching the pnpm setting across cargo / npm / github-actions, so update PRs never propose a release pnpm would refuse
- `cargo-deny` (advisories · licenses · sources · bans) with `deny.toml` that blocks unknown registries / git URLs; ignores RUSTSEC-2025-0141 (bincode unmaintained, no migration path — tracked in #1403)
- OSV-Scanner reusable workflow scans both `Cargo.lock` and `pnpm-lock.yaml`, uploads SARIF to the GitHub Security tab (free on public repos)
- Aikido safe-chain wired into the existing `integration` job, pinned to `@1.5.1`
- **zizmor** (GitHub Actions static analysis) added to the Security workflow. `continue-on-error: true` for now — existing workflows have pre-existing findings (cleanup tracked in #1404), but SARIF still uploads to the Security tab.
- **Every action reference pinned to a 40-char SHA** with the release tag as a trailing comment (Dependabot will update SHA + comment together)
- pnpm/action-setup `version:` override removed — reads `packageManager` from `package.json`, so local and CI use the exact same pnpm
- `floe-cli` gets `publish = false` (matches CLAUDE.md — floe is not distributed via crates.io)
- Cargo.lock resynced with Cargo.toml workspace version (was alpha.3 vs alpha.4 drift)

CodeQL stays as the GitHub default setup and is intentionally untouched.

closes #1399
refs #1403 (bincode migration), #1404 (zizmor follow-up cleanup)

## Test plan
- [ ] `Security` workflow green on this PR (osv-scanner + cargo-deny + zizmor)
- [ ] `CI` workflow green (safe-chain step does not break the integration job; pnpm picks up packageManager pin)
- [ ] OSV findings appear in the GitHub Security tab after merge
- [ ] zizmor findings appear in the GitHub Security tab after merge
- [ ] Verify `cargo deny check` passes locally: `cargo deny check advisories licenses sources bans`
- [ ] Verify `pnpm install --frozen-lockfile` still works (esbuild + sharp build scripts run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)