### PR TITLE
fix: [#1407] remove needless_pass_by_value suppressions in cst.rs

### DIFF
--- a/crates/floe-core/src/cst.rs
+++ b/crates/floe-core/src/cst.rs
@@ -108,10 +108,9 @@ impl<'src> CstParser<'src> {
             .unwrap_or(Span::new(self.source.len(), self.source.len(), 1, 1))
     }
 
-    #[allow(clippy::needless_pass_by_value)]
-    fn at(&self, kind: TokenKind) -> bool {
+    fn at(&self, kind: &TokenKind) -> bool {
         self.current_kind()
-            .is_some_and(|k| std::mem::discriminant(&k) == std::mem::discriminant(&kind))
+            .is_some_and(|k| std::mem::discriminant(&k) == std::mem::discriminant(kind))
     }
 
     fn at_identifier(&self, name: &str) -> bool {
@@ -189,13 +188,13 @@ impl<'src> CstParser<'src> {
     }
 
     fn at_pipe_in_union(&self) -> bool {
-        self.at(TokenKind::VerticalBar)
+        self.at(&TokenKind::VerticalBar)
     }
 
     /// Check if we're at a string literal union: `"A" | "B" | ...`
     /// This is true when the current token is a string and the next non-trivia token is `|`.
     fn at_string_literal_union(&self) -> bool {
-        self.at(TokenKind::String(String::new()))
+        self.at(&TokenKind::String(String::new()))
             && matches!(
                 self.peek_nth_non_trivia_kind(1),
                 Some(TokenKind::VerticalBar)
@@ -256,7 +255,7 @@ impl<'src> CstParser<'src> {
     }
 
     fn at_end(&self) -> bool {
-        self.pos >= self.tokens.len() || self.at(TokenKind::Eof)
+        self.pos >= self.tokens.len() || self.at(&TokenKind::Eof)
     }
 
     /// Check if the previous trivia token contains a newline.
@@ -340,14 +339,13 @@ impl<'src> CstParser<'src> {
         false
     }
 
-    #[allow(clippy::needless_pass_by_value)]
-    fn peek_is(&self, kind: TokenKind) -> bool {
+    fn peek_is(&self, kind: &TokenKind) -> bool {
         // Skip trivia to find the next non-trivia token
         let mut i = self.pos + 1;
         while i < self.tokens.len() {
             if !self.tokens[i].kind.is_trivia() {
                 return std::mem::discriminant(&self.tokens[i].kind)
-                    == std::mem::discriminant(&kind);
+                    == std::mem::discriminant(kind);
             }
             i += 1;
         }
@@ -478,7 +476,7 @@ impl<'src> CstParser<'src> {
         if self.suppress_function_type {
             return false;
         }
-        self.is_paren_followed_by(TokenKind::ThinArrow)
+        self.is_paren_followed_by(&TokenKind::ThinArrow)
     }
 
     /// Heuristic: is the current `(` the start of an arrow closure
@@ -487,12 +485,11 @@ impl<'src> CstParser<'src> {
         if self.suppress_function_type {
             return false;
         }
-        self.is_paren_followed_by(TokenKind::ThinArrow)
+        self.is_paren_followed_by(&TokenKind::ThinArrow)
     }
 
     /// Check if the `(` at position `start` has a matching `)` followed by `kind`.
-    #[allow(clippy::needless_pass_by_value)]
-    fn is_paren_followed_by_at(&self, start: usize, kind: TokenKind) -> bool {
+    fn is_paren_followed_by_at(&self, start: usize, kind: &TokenKind) -> bool {
         let mut depth = 0;
         let mut i = start;
         while i < self.tokens.len() {
@@ -506,7 +503,7 @@ impl<'src> CstParser<'src> {
                         while i < self.tokens.len() && self.tokens[i].kind.is_trivia() {
                             i += 1;
                         }
-                        return i < self.tokens.len() && self.tokens[i].kind == kind;
+                        return i < self.tokens.len() && self.tokens[i].kind == *kind;
                     }
                 }
                 TokenKind::Eof => return false,
@@ -518,7 +515,7 @@ impl<'src> CstParser<'src> {
     }
 
     /// Check if the `(` at the current position has a matching `)` followed by `kind`.
-    fn is_paren_followed_by(&self, kind: TokenKind) -> bool {
+    fn is_paren_followed_by(&self, kind: &TokenKind) -> bool {
         self.is_paren_followed_by_at(self.pos, kind)
     }
 
@@ -574,9 +571,8 @@ impl<'src> CstParser<'src> {
         }
     }
 
-    #[allow(clippy::needless_pass_by_value)]
-    fn expect(&mut self, kind: TokenKind) {
-        if self.at(kind.clone()) {
+    fn expect(&mut self, kind: &TokenKind) {
+        if self.at(kind) {
             self.bump();
         } else {
             self.error_kind(
@@ -586,9 +582,8 @@ impl<'src> CstParser<'src> {
         }
     }
 
-    #[allow(clippy::needless_pass_by_value)]
-    fn expect_kind(&mut self, kind: TokenKind) {
-        if self.at(kind.clone()) {
+    fn expect_kind(&mut self, kind: &TokenKind) {
+        if self.at(kind) {
             self.bump();
         } else {
             self.error_kind(
@@ -617,7 +612,7 @@ impl<'src> CstParser<'src> {
     fn parse_type_param(&mut self) {
         self.expect_ident();
         self.eat_trivia();
-        if self.at(TokenKind::Colon) {
+        if self.at(&TokenKind::Colon) {
             self.bump(); // :
             self.eat_trivia();
             self.expect_ident(); // trait name
@@ -629,7 +624,7 @@ impl<'src> CstParser<'src> {
     fn parse_destructure_field(&mut self) {
         self.expect_ident_flex();
         self.eat_trivia();
-        if self.at(TokenKind::Colon) {
+        if self.at(&TokenKind::Colon) {
             self.bump(); // eat ':'
             self.eat_trivia();
             self.expect_ident_flex(); // alias
@@ -648,19 +643,18 @@ impl<'src> CstParser<'src> {
         });
     }
 
-    #[allow(clippy::needless_pass_by_value)]
-    fn parse_comma_separated(&mut self, parse_fn: fn(&mut Self), closing: TokenKind) {
-        if self.at(closing.clone()) {
+    fn parse_comma_separated(&mut self, parse_fn: fn(&mut Self), closing: &TokenKind) {
+        if self.at(closing) {
             return;
         }
 
         parse_fn(self);
         self.eat_trivia();
 
-        while self.at(TokenKind::Comma) {
+        while self.at(&TokenKind::Comma) {
             self.bump();
             self.eat_trivia();
-            if self.at(closing.clone()) {
+            if self.at(closing) {
                 break;
             }
             parse_fn(self);

--- a/crates/floe-core/src/cst/exprs.rs
+++ b/crates/floe-core/src/cst/exprs.rs
@@ -11,7 +11,7 @@ impl<'src> CstParser<'src> {
         let checkpoint = self.builder.checkpoint();
         self.parse_and_expr();
 
-        while self.at(TokenKind::PipePipe) {
+        while self.at(&TokenKind::PipePipe) {
             self.builder
                 .start_node_at(checkpoint, SyntaxKind::BINARY_EXPR.into());
             self.bump();
@@ -25,7 +25,7 @@ impl<'src> CstParser<'src> {
         let checkpoint = self.builder.checkpoint();
         self.parse_equality_expr();
 
-        while self.at(TokenKind::AmpAmp) {
+        while self.at(&TokenKind::AmpAmp) {
             self.builder
                 .start_node_at(checkpoint, SyntaxKind::BINARY_EXPR.into());
             self.bump();
@@ -39,7 +39,7 @@ impl<'src> CstParser<'src> {
         let checkpoint = self.builder.checkpoint();
         self.parse_pipe_expr();
 
-        while self.at(TokenKind::EqualEqual) || self.at(TokenKind::BangEqual) {
+        while self.at(&TokenKind::EqualEqual) || self.at(&TokenKind::BangEqual) {
             self.builder
                 .start_node_at(checkpoint, SyntaxKind::BINARY_EXPR.into());
             self.bump();
@@ -53,14 +53,14 @@ impl<'src> CstParser<'src> {
         let checkpoint = self.builder.checkpoint();
         self.parse_comparison_expr();
 
-        while self.at(TokenKind::Pipe) || self.at(TokenKind::PipeUnwrap) {
+        while self.at(&TokenKind::Pipe) || self.at(&TokenKind::PipeUnwrap) {
             self.builder
                 .start_node_at(checkpoint, SyntaxKind::PIPE_EXPR.into());
             self.bump(); // |> or |>?
             self.eat_trivia();
 
             // Pipe into match: `x |> match { ... }`
-            if self.at(TokenKind::Match) {
+            if self.at(&TokenKind::Match) {
                 self.parse_subjectless_match_expr();
             } else {
                 self.parse_comparison_expr();
@@ -74,10 +74,10 @@ impl<'src> CstParser<'src> {
         let checkpoint = self.builder.checkpoint();
         self.parse_additive_expr();
 
-        while (self.at(TokenKind::LessThan)
-            || self.at(TokenKind::GreaterThan)
-            || self.at(TokenKind::LessEqual)
-            || self.at(TokenKind::GreaterEqual))
+        while (self.at(&TokenKind::LessThan)
+            || self.at(&TokenKind::GreaterThan)
+            || self.at(&TokenKind::LessEqual)
+            || self.at(&TokenKind::GreaterEqual))
             && !self.preceded_by_newline()
         {
             self.builder
@@ -93,7 +93,7 @@ impl<'src> CstParser<'src> {
         let checkpoint = self.builder.checkpoint();
         self.parse_multiplicative_expr();
 
-        while self.at(TokenKind::Plus) || self.at(TokenKind::Minus) {
+        while self.at(&TokenKind::Plus) || self.at(&TokenKind::Minus) {
             self.builder
                 .start_node_at(checkpoint, SyntaxKind::BINARY_EXPR.into());
             self.bump();
@@ -107,7 +107,10 @@ impl<'src> CstParser<'src> {
         let checkpoint = self.builder.checkpoint();
         self.parse_unary_expr();
 
-        while self.at(TokenKind::Star) || self.at(TokenKind::Slash) || self.at(TokenKind::Percent) {
+        while self.at(&TokenKind::Star)
+            || self.at(&TokenKind::Slash)
+            || self.at(&TokenKind::Percent)
+        {
             self.builder
                 .start_node_at(checkpoint, SyntaxKind::BINARY_EXPR.into());
             self.bump();
@@ -151,7 +154,7 @@ impl<'src> CstParser<'src> {
                     self.eat_trivia();
                     self.parse_expr();
                     self.eat_trivia();
-                    self.expect(TokenKind::RightBracket);
+                    self.expect(&TokenKind::RightBracket);
                     self.builder.finish_node();
                 }
                 Some(TokenKind::LessThan) if self.is_generic_call() => {
@@ -168,8 +171,8 @@ impl<'src> CstParser<'src> {
                         .start_node_at(checkpoint, SyntaxKind::CALL_EXPR.into());
                     self.bump();
                     self.eat_trivia();
-                    self.parse_comma_separated(Self::parse_call_arg, TokenKind::RightParen);
-                    self.expect(TokenKind::RightParen);
+                    self.parse_comma_separated(Self::parse_call_arg, &TokenKind::RightParen);
+                    self.expect(&TokenKind::RightParen);
                     self.builder.finish_node();
                 }
                 Some(TokenKind::TemplateLiteral(_)) => {
@@ -238,13 +241,13 @@ impl<'src> CstParser<'src> {
             .start_node_at(checkpoint, SyntaxKind::CALL_EXPR.into());
         self.bump(); // <
         self.eat_trivia();
-        self.parse_comma_separated(Self::parse_type_expr, TokenKind::GreaterThan);
-        self.expect(TokenKind::GreaterThan);
+        self.parse_comma_separated(Self::parse_type_expr, &TokenKind::GreaterThan);
+        self.expect(&TokenKind::GreaterThan);
         self.eat_trivia();
-        self.expect(TokenKind::LeftParen);
+        self.expect(&TokenKind::LeftParen);
         self.eat_trivia();
-        self.parse_comma_separated(Self::parse_call_arg, TokenKind::RightParen);
-        self.expect(TokenKind::RightParen);
+        self.parse_comma_separated(Self::parse_call_arg, &TokenKind::RightParen);
+        self.expect(&TokenKind::RightParen);
         self.builder.finish_node();
     }
 
@@ -267,24 +270,24 @@ impl<'src> CstParser<'src> {
                 self.builder.start_node(SyntaxKind::VALUE_EXPR.into());
                 self.bump();
                 self.eat_trivia();
-                self.expect(TokenKind::LeftParen);
+                self.expect(&TokenKind::LeftParen);
                 self.eat_trivia();
                 self.parse_expr();
                 self.eat_trivia();
-                self.expect(TokenKind::RightParen);
+                self.expect(&TokenKind::RightParen);
                 self.builder.finish_node();
             }
 
-            Some(TokenKind::Parse) if self.peek_is(TokenKind::LessThan) => {
+            Some(TokenKind::Parse) if self.peek_is(&TokenKind::LessThan) => {
                 self.builder.start_node(SyntaxKind::PARSE_EXPR.into());
                 self.bump(); // parse
                 self.eat_trivia();
                 // parse<T> — type argument
-                self.expect(TokenKind::LessThan);
+                self.expect(&TokenKind::LessThan);
                 self.eat_trivia();
                 self.parse_type_expr();
                 self.eat_trivia();
-                self.expect(TokenKind::GreaterThan);
+                self.expect(&TokenKind::GreaterThan);
                 self.eat_trivia();
                 // Optional (value) — may be absent in pipe context
                 if self.current_kind() == Some(TokenKind::LeftParen) {
@@ -292,20 +295,20 @@ impl<'src> CstParser<'src> {
                     self.eat_trivia();
                     self.parse_expr();
                     self.eat_trivia();
-                    self.expect(TokenKind::RightParen);
+                    self.expect(&TokenKind::RightParen);
                 }
                 self.builder.finish_node();
             }
-            Some(TokenKind::Mock) if self.peek_is(TokenKind::LessThan) => {
+            Some(TokenKind::Mock) if self.peek_is(&TokenKind::LessThan) => {
                 self.builder.start_node(SyntaxKind::MOCK_EXPR.into());
                 self.bump(); // mock
                 self.eat_trivia();
                 // mock<T> — type argument
-                self.expect(TokenKind::LessThan);
+                self.expect(&TokenKind::LessThan);
                 self.eat_trivia();
                 self.parse_type_expr();
                 self.eat_trivia();
-                self.expect(TokenKind::GreaterThan);
+                self.expect(&TokenKind::GreaterThan);
                 self.eat_trivia();
                 // Optional (overrides) — named args for field overrides
                 if self.current_kind() == Some(TokenKind::LeftParen) {
@@ -321,13 +324,13 @@ impl<'src> CstParser<'src> {
                             self.eat_trivia();
                         }
                     }
-                    self.expect(TokenKind::RightParen);
+                    self.expect(&TokenKind::RightParen);
                 }
                 self.builder.finish_node();
             }
 
             Some(TokenKind::Match) => self.parse_match_expr(),
-            Some(TokenKind::Collect) if self.peek_is(TokenKind::LeftBrace) => {
+            Some(TokenKind::Collect) if self.peek_is(&TokenKind::LeftBrace) => {
                 self.builder.start_node(SyntaxKind::COLLECT_EXPR.into());
                 self.bump(); // collect
                 self.eat_trivia();
@@ -346,8 +349,8 @@ impl<'src> CstParser<'src> {
                 self.builder.start_node(SyntaxKind::ARRAY_EXPR.into());
                 self.bump();
                 self.eat_trivia();
-                self.parse_comma_separated(Self::parse_expr, TokenKind::RightBracket);
-                self.expect(TokenKind::RightBracket);
+                self.parse_comma_separated(Self::parse_expr, &TokenKind::RightBracket);
+                self.expect(&TokenKind::RightBracket);
                 self.builder.finish_node();
             }
 
@@ -355,7 +358,7 @@ impl<'src> CstParser<'src> {
                 if self.is_arrow_expr() {
                     // Arrow closure: `(params) => body`
                     self.parse_arrow_closure();
-                } else if self.peek_is(TokenKind::RightParen) {
+                } else if self.peek_is(&TokenKind::RightParen) {
                     // Unit value: ()
                     self.builder.start_node(SyntaxKind::TUPLE_EXPR.into());
                     self.bump(); // (
@@ -367,8 +370,8 @@ impl<'src> CstParser<'src> {
                     self.builder.start_node(SyntaxKind::TUPLE_EXPR.into());
                     self.bump(); // (
                     self.eat_trivia();
-                    self.parse_comma_separated(Self::parse_expr, TokenKind::RightParen);
-                    self.expect(TokenKind::RightParen);
+                    self.parse_comma_separated(Self::parse_expr, &TokenKind::RightParen);
+                    self.expect(&TokenKind::RightParen);
                     self.builder.finish_node();
                 } else {
                     self.builder.start_node(SyntaxKind::GROUPED_EXPR.into());
@@ -376,7 +379,7 @@ impl<'src> CstParser<'src> {
                     self.eat_trivia();
                     self.parse_expr();
                     self.eat_trivia();
-                    self.expect(TokenKind::RightParen);
+                    self.expect(&TokenKind::RightParen);
                     self.builder.finish_node();
                 }
             }
@@ -387,7 +390,7 @@ impl<'src> CstParser<'src> {
                 self.parse_dot_shorthand();
             }
 
-            Some(TokenKind::Fn) if self.peek_is(TokenKind::LeftParen) => {
+            Some(TokenKind::Fn) if self.peek_is(&TokenKind::LeftParen) => {
                 // `fn(params) expr` is the old syntax — emit error pointing to =>
                 self.builder.start_node(SyntaxKind::ERROR.into());
                 self.error("anonymous functions use arrow syntax: `(params) -> body` instead of `fn(params) body`");
@@ -415,14 +418,14 @@ impl<'src> CstParser<'src> {
                 let name = name.clone();
 
                 // Uppercase + ( → constructor
-                if name.starts_with(char::is_uppercase) && self.peek_is(TokenKind::LeftParen) {
+                if name.starts_with(char::is_uppercase) && self.peek_is(&TokenKind::LeftParen) {
                     self.parse_construct_expr();
                     return;
                 }
 
                 // Qualified variant: `Filter.All` or `Route.Profile(id: "123")`
                 if name.starts_with(char::is_uppercase)
-                    && self.peek_is(TokenKind::Dot)
+                    && self.peek_is(&TokenKind::Dot)
                     && let Some(TokenKind::Identifier(variant_name)) =
                         self.peek_nth_non_trivia_kind(2)
                     && variant_name.starts_with(char::is_uppercase)
@@ -441,10 +444,10 @@ impl<'src> CstParser<'src> {
                     self.eat_trivia();
 
                     if has_args {
-                        self.expect(TokenKind::LeftParen);
+                        self.expect(&TokenKind::LeftParen);
                         self.eat_trivia();
                         self.parse_constructor_args();
-                        self.expect(TokenKind::RightParen);
+                        self.expect(&TokenKind::RightParen);
                     }
 
                     self.builder.finish_node();
@@ -488,12 +491,12 @@ impl<'src> CstParser<'src> {
         self.builder.start_node(SyntaxKind::CONSTRUCT_EXPR.into());
         self.bump(); // TypeName
         self.eat_trivia();
-        self.expect(TokenKind::LeftParen);
+        self.expect(&TokenKind::LeftParen);
         self.eat_trivia();
 
         self.parse_constructor_args();
 
-        self.expect(TokenKind::RightParen);
+        self.expect(&TokenKind::RightParen);
         self.builder.finish_node();
     }
 
@@ -503,8 +506,8 @@ impl<'src> CstParser<'src> {
     /// diagnostic pointing at the bad position.
     fn parse_constructor_args(&mut self) {
         let mut saw_spread = false;
-        while !self.at(TokenKind::RightParen) && !self.at_end() {
-            if self.at(TokenKind::DotDot) {
+        while !self.at(&TokenKind::RightParen) && !self.at_end() {
+            if self.at(&TokenKind::DotDot) {
                 if saw_spread {
                     self.builder.start_node(SyntaxKind::ERROR.into());
                     self.error("only one spread `..base` is allowed per constructor");
@@ -534,7 +537,7 @@ impl<'src> CstParser<'src> {
                 }
             }
             self.eat_trivia();
-            if self.at(TokenKind::Comma) {
+            if self.at(&TokenKind::Comma) {
                 self.bump();
                 self.eat_trivia();
             } else {
@@ -549,7 +552,7 @@ impl<'src> CstParser<'src> {
         self.builder.start_node(SyntaxKind::ARG.into());
 
         // Named arg: `label: expr` or punned `label:`.
-        if self.is_ident_flex() && self.peek_is(TokenKind::Colon) {
+        if self.is_ident_flex() && self.peek_is(&TokenKind::Colon) {
             self.expect_ident_flex();
             self.eat_trivia();
             self.bump(); // :
@@ -573,25 +576,25 @@ impl<'src> CstParser<'src> {
     /// Parse `.field` or `.field op expr` dot shorthand expression.
     fn parse_dot_shorthand(&mut self) {
         self.builder.start_node(SyntaxKind::DOT_SHORTHAND.into());
-        self.expect(TokenKind::Dot);
+        self.expect(&TokenKind::Dot);
         self.eat_trivia();
         self.expect_ident();
         self.eat_trivia();
 
         // Check for optional binary operator predicate
-        if self.at(TokenKind::EqualEqual)
-            || self.at(TokenKind::BangEqual)
-            || self.at(TokenKind::LessThan)
-            || self.at(TokenKind::GreaterThan)
-            || self.at(TokenKind::LessEqual)
-            || self.at(TokenKind::GreaterEqual)
-            || self.at(TokenKind::AmpAmp)
-            || self.at(TokenKind::PipePipe)
-            || self.at(TokenKind::Plus)
-            || self.at(TokenKind::Minus)
-            || self.at(TokenKind::Star)
-            || self.at(TokenKind::Slash)
-            || self.at(TokenKind::Percent)
+        if self.at(&TokenKind::EqualEqual)
+            || self.at(&TokenKind::BangEqual)
+            || self.at(&TokenKind::LessThan)
+            || self.at(&TokenKind::GreaterThan)
+            || self.at(&TokenKind::LessEqual)
+            || self.at(&TokenKind::GreaterEqual)
+            || self.at(&TokenKind::AmpAmp)
+            || self.at(&TokenKind::PipePipe)
+            || self.at(&TokenKind::Plus)
+            || self.at(&TokenKind::Minus)
+            || self.at(&TokenKind::Star)
+            || self.at(&TokenKind::Slash)
+            || self.at(&TokenKind::Percent)
         {
             self.bump(); // operator
             self.eat_trivia();
@@ -607,12 +610,12 @@ impl<'src> CstParser<'src> {
     fn parse_arrow_closure(&mut self) {
         self.builder.start_node(SyntaxKind::ARROW_EXPR.into());
 
-        self.expect(TokenKind::LeftParen);
+        self.expect(&TokenKind::LeftParen);
         self.eat_trivia();
-        self.parse_comma_separated(Self::parse_param, TokenKind::RightParen);
-        self.expect(TokenKind::RightParen);
+        self.parse_comma_separated(Self::parse_param, &TokenKind::RightParen);
+        self.expect(&TokenKind::RightParen);
         self.eat_trivia();
-        self.expect(TokenKind::ThinArrow);
+        self.expect(&TokenKind::ThinArrow);
         self.eat_trivia();
         self.parse_expr();
 
@@ -623,18 +626,18 @@ impl<'src> CstParser<'src> {
 
     fn parse_match_expr(&mut self) {
         self.builder.start_node(SyntaxKind::MATCH_EXPR.into());
-        self.expect(TokenKind::Match);
+        self.expect(&TokenKind::Match);
         self.eat_trivia();
         self.parse_expr();
         self.eat_trivia();
-        self.expect(TokenKind::LeftBrace);
+        self.expect(&TokenKind::LeftBrace);
         self.eat_trivia();
 
-        while !self.at(TokenKind::RightBrace) && !self.at_end() {
+        while !self.at(&TokenKind::RightBrace) && !self.at_end() {
             let prev_pos = self.pos;
             self.parse_match_arm();
             self.eat_trivia();
-            if self.at(TokenKind::Comma) {
+            if self.at(&TokenKind::Comma) {
                 self.bump();
                 self.eat_trivia();
             }
@@ -643,23 +646,23 @@ impl<'src> CstParser<'src> {
             }
         }
 
-        self.expect(TokenKind::RightBrace);
+        self.expect(&TokenKind::RightBrace);
         self.builder.finish_node();
     }
 
     /// Parse `match { arms }` without a subject — used for `x |> match { ... }`.
     fn parse_subjectless_match_expr(&mut self) {
         self.builder.start_node(SyntaxKind::MATCH_EXPR.into());
-        self.expect(TokenKind::Match);
+        self.expect(&TokenKind::Match);
         self.eat_trivia();
-        self.expect(TokenKind::LeftBrace);
+        self.expect(&TokenKind::LeftBrace);
         self.eat_trivia();
 
-        while !self.at(TokenKind::RightBrace) && !self.at_end() {
+        while !self.at(&TokenKind::RightBrace) && !self.at_end() {
             let prev_pos = self.pos;
             self.parse_match_arm();
             self.eat_trivia();
-            if self.at(TokenKind::Comma) {
+            if self.at(&TokenKind::Comma) {
                 self.bump();
                 self.eat_trivia();
             }
@@ -668,7 +671,7 @@ impl<'src> CstParser<'src> {
             }
         }
 
-        self.expect(TokenKind::RightBrace);
+        self.expect(&TokenKind::RightBrace);
         self.builder.finish_node();
     }
 
@@ -678,7 +681,7 @@ impl<'src> CstParser<'src> {
         self.eat_trivia();
 
         // Optional guard: `when expr`
-        if self.at(TokenKind::When) {
+        if self.at(&TokenKind::When) {
             self.builder.start_node(SyntaxKind::MATCH_GUARD.into());
             self.bump(); // consume `when`
             self.eat_trivia();
@@ -687,7 +690,7 @@ impl<'src> CstParser<'src> {
             self.eat_trivia();
         }
 
-        self.expect(TokenKind::ThinArrow);
+        self.expect(&TokenKind::ThinArrow);
         self.eat_trivia();
         self.parse_expr();
         self.builder.finish_node();
@@ -716,7 +719,7 @@ impl<'src> CstParser<'src> {
             Some(TokenKind::Number(_)) => {
                 self.bump();
                 self.eat_trivia();
-                if self.at(TokenKind::DotDot) {
+                if self.at(&TokenKind::DotDot) {
                     self.bump();
                     self.eat_trivia();
                     // Expect number after ..
@@ -730,17 +733,20 @@ impl<'src> CstParser<'src> {
             Some(TokenKind::LeftBrace) => {
                 self.bump(); // {
                 self.eat_trivia();
-                self.parse_comma_separated(Self::parse_record_pattern_field, TokenKind::RightBrace);
-                self.expect(TokenKind::RightBrace);
+                self.parse_comma_separated(
+                    Self::parse_record_pattern_field,
+                    &TokenKind::RightBrace,
+                );
+                self.expect(&TokenKind::RightBrace);
             }
             Some(TokenKind::LeftBracket) => {
                 // Array pattern: [], [a, b], [first, ..rest]
                 self.bump(); // [
                 self.eat_trivia();
                 // Parse elements and optional rest pattern
-                while !self.at(TokenKind::RightBracket) && !self.at_end() {
+                while !self.at(&TokenKind::RightBracket) && !self.at_end() {
                     // Check for rest pattern: ..name
-                    if self.at(TokenKind::DotDot) {
+                    if self.at(&TokenKind::DotDot) {
                         self.bump(); // ..
                         self.eat_trivia();
                         // Expect identifier or _ after ..
@@ -753,7 +759,7 @@ impl<'src> CstParser<'src> {
                             self.error("expected identifier after '..' in array pattern");
                         }
                         self.eat_trivia();
-                        if self.at(TokenKind::Comma) {
+                        if self.at(&TokenKind::Comma) {
                             self.bump();
                             self.eat_trivia();
                         }
@@ -761,21 +767,21 @@ impl<'src> CstParser<'src> {
                     }
                     self.parse_pattern();
                     self.eat_trivia();
-                    if self.at(TokenKind::Comma) {
+                    if self.at(&TokenKind::Comma) {
                         self.bump();
                         self.eat_trivia();
                     } else {
                         break;
                     }
                 }
-                self.expect(TokenKind::RightBracket);
+                self.expect(&TokenKind::RightBracket);
             }
             Some(TokenKind::LeftParen) => {
                 // Tuple pattern: (x, y)
                 self.bump(); // (
                 self.eat_trivia();
-                self.parse_comma_separated(Self::parse_pattern, TokenKind::RightParen);
-                self.expect(TokenKind::RightParen);
+                self.parse_comma_separated(Self::parse_pattern, &TokenKind::RightParen);
+                self.expect(&TokenKind::RightParen);
             }
             // Implicit variant pattern: .Variant or .Variant(args)
             Some(TokenKind::Dot) if matches!(self.peek_nth_non_trivia_kind(1), Some(TokenKind::Identifier(n)) if n.starts_with(char::is_uppercase)) =>
@@ -784,11 +790,11 @@ impl<'src> CstParser<'src> {
                 self.eat_trivia();
                 self.bump(); // Variant name
                 self.eat_trivia();
-                if self.at(TokenKind::LeftParen) {
+                if self.at(&TokenKind::LeftParen) {
                     self.bump();
                     self.eat_trivia();
-                    self.parse_comma_separated(Self::parse_pattern, TokenKind::RightParen);
-                    self.expect(TokenKind::RightParen);
+                    self.parse_comma_separated(Self::parse_pattern, &TokenKind::RightParen);
+                    self.expect(&TokenKind::RightParen);
                 }
             }
             Some(TokenKind::Identifier(name)) => {
@@ -797,7 +803,7 @@ impl<'src> CstParser<'src> {
                     self.bump();
                     self.eat_trivia();
                     // Qualified variant pattern: `Type.Variant` or `Type.Variant(...)`
-                    if self.at(TokenKind::Dot) {
+                    if self.at(&TokenKind::Dot) {
                         self.bump(); // .
                         self.eat_trivia();
                         // Accept identifiers after dot
@@ -808,20 +814,20 @@ impl<'src> CstParser<'src> {
                         }
                         self.eat_trivia();
                     }
-                    if self.at(TokenKind::LeftParen) {
+                    if self.at(&TokenKind::LeftParen) {
                         self.bump();
                         self.eat_trivia();
-                        self.parse_comma_separated(Self::parse_pattern, TokenKind::RightParen);
-                        self.expect(TokenKind::RightParen);
-                    } else if self.at(TokenKind::LeftBrace) {
+                        self.parse_comma_separated(Self::parse_pattern, &TokenKind::RightParen);
+                        self.expect(&TokenKind::RightParen);
+                    } else if self.at(&TokenKind::LeftBrace) {
                         // Named-field variant pattern: `Rectangle { width, height: h }`
                         self.bump(); // {
                         self.eat_trivia();
                         self.parse_comma_separated(
                             Self::parse_named_variant_pattern_field,
-                            TokenKind::RightBrace,
+                            &TokenKind::RightBrace,
                         );
-                        self.expect(TokenKind::RightBrace);
+                        self.expect(&TokenKind::RightBrace);
                     }
                 } else {
                     self.bump();
@@ -844,7 +850,7 @@ impl<'src> CstParser<'src> {
     fn parse_record_pattern_field(&mut self) {
         self.expect_ident_flex();
         self.eat_trivia();
-        if self.at(TokenKind::Colon) {
+        if self.at(&TokenKind::Colon) {
             self.bump();
             self.eat_trivia();
             self.parse_pattern();
@@ -858,7 +864,7 @@ impl<'src> CstParser<'src> {
             .start_node(SyntaxKind::VARIANT_FIELD_PATTERN.into());
         self.expect_ident_flex();
         self.eat_trivia();
-        if self.at(TokenKind::Colon) {
+        if self.at(&TokenKind::Colon) {
             self.bump();
             self.eat_trivia();
             self.parse_pattern();
@@ -899,10 +905,10 @@ impl<'src> CstParser<'src> {
 
     fn parse_object_literal(&mut self) {
         self.builder.start_node(SyntaxKind::OBJECT_EXPR.into());
-        self.expect(TokenKind::LeftBrace);
+        self.expect(&TokenKind::LeftBrace);
         self.eat_trivia();
-        self.parse_comma_separated(Self::parse_object_field, TokenKind::RightBrace);
-        self.expect(TokenKind::RightBrace);
+        self.parse_comma_separated(Self::parse_object_field, &TokenKind::RightBrace);
+        self.expect(&TokenKind::RightBrace);
         self.builder.finish_node();
     }
 
@@ -910,7 +916,7 @@ impl<'src> CstParser<'src> {
         self.builder.start_node(SyntaxKind::OBJECT_FIELD.into());
         self.expect_ident_flex();
         self.eat_trivia();
-        if self.at(TokenKind::Colon) {
+        if self.at(&TokenKind::Colon) {
             self.bump(); // :
             self.eat_trivia();
             self.parse_expr();
@@ -923,10 +929,10 @@ impl<'src> CstParser<'src> {
 
     pub(super) fn parse_block_expr(&mut self) {
         self.builder.start_node(SyntaxKind::BLOCK_EXPR.into());
-        self.expect(TokenKind::LeftBrace);
+        self.expect(&TokenKind::LeftBrace);
         self.eat_trivia();
 
-        while !self.at(TokenKind::RightBrace) && !self.at_end() {
+        while !self.at(&TokenKind::RightBrace) && !self.at_end() {
             let prev_pos = self.pos;
             self.parse_item();
             self.eat_trivia();
@@ -935,7 +941,7 @@ impl<'src> CstParser<'src> {
             }
         }
 
-        self.expect(TokenKind::RightBrace);
+        self.expect(&TokenKind::RightBrace);
         self.builder.finish_node();
     }
 }

--- a/crates/floe-core/src/cst/items.rs
+++ b/crates/floe-core/src/cst/items.rs
@@ -9,7 +9,7 @@ impl<'src> CstParser<'src> {
         let checkpoint = self.builder.checkpoint();
 
         // Handle export prefix
-        let exported = self.at(TokenKind::Export);
+        let exported = self.at(&TokenKind::Export);
         if exported {
             self.bump(); // export
             self.eat_trivia();
@@ -149,23 +149,23 @@ impl<'src> CstParser<'src> {
 
     fn parse_import(&mut self) {
         self.builder.start_node(SyntaxKind::IMPORT_DECL.into());
-        self.expect(TokenKind::Import);
+        self.expect(&TokenKind::Import);
         self.eat_trivia();
 
         // `import trusted { ... }` — module-level trusted
-        if self.at(TokenKind::Trusted) {
+        if self.at(&TokenKind::Trusted) {
             self.bump(); // trusted
             self.eat_trivia();
         }
 
-        if self.at(TokenKind::LeftBrace) {
+        if self.at(&TokenKind::LeftBrace) {
             self.bump(); // {
             self.eat_trivia();
-            self.parse_comma_separated(Self::parse_import_specifier_or_for, TokenKind::RightBrace);
-            self.expect(TokenKind::RightBrace);
+            self.parse_comma_separated(Self::parse_import_specifier_or_for, &TokenKind::RightBrace);
+            self.expect(&TokenKind::RightBrace);
             self.eat_trivia();
         } else if matches!(self.current_kind(), Some(TokenKind::Identifier(_)))
-            && !self.at(TokenKind::From)
+            && !self.at(&TokenKind::From)
         {
             // Default import: `import [trusted] Ident from "..."`
             self.builder.start_node(SyntaxKind::IMPORT_SPECIFIER.into());
@@ -175,11 +175,11 @@ impl<'src> CstParser<'src> {
         }
 
         // `from` is required with specifiers, optional for bare imports
-        if self.at(TokenKind::From) {
+        if self.at(&TokenKind::From) {
             self.bump();
             self.eat_trivia();
         }
-        self.expect_kind(TokenKind::String(String::new()));
+        self.expect_kind(&TokenKind::String(String::new()));
 
         self.builder.finish_node();
     }
@@ -188,15 +188,15 @@ impl<'src> CstParser<'src> {
 
     fn parse_reexport(&mut self) {
         self.builder.start_node(SyntaxKind::REEXPORT_DECL.into());
-        self.expect(TokenKind::LeftBrace);
+        self.expect(&TokenKind::LeftBrace);
         self.eat_trivia();
-        self.parse_comma_separated(Self::parse_reexport_specifier, TokenKind::RightBrace);
-        self.expect(TokenKind::RightBrace);
+        self.parse_comma_separated(Self::parse_reexport_specifier, &TokenKind::RightBrace);
+        self.expect(&TokenKind::RightBrace);
         self.eat_trivia();
 
-        self.expect(TokenKind::From);
+        self.expect(&TokenKind::From);
         self.eat_trivia();
-        self.expect_kind(TokenKind::String(String::new()));
+        self.expect_kind(&TokenKind::String(String::new()));
 
         self.builder.finish_node();
     }
@@ -225,7 +225,7 @@ impl<'src> CstParser<'src> {
 
         // Check for `as alias`
         if self.at_identifier("as")
-            || self.at(TokenKind::Banned(crate::lexer::token::BannedKeyword::As))
+            || self.at(&TokenKind::Banned(crate::lexer::token::BannedKeyword::As))
         {
             self.bump();
             self.eat_trivia();
@@ -240,7 +240,7 @@ impl<'src> CstParser<'src> {
     /// - `{ for Type }` — import the for-block extension methods for Type
     ///   (needed for foreign-type inherent like `for Array<T>` or `for string`)
     fn parse_import_specifier_or_for(&mut self) {
-        if self.at(TokenKind::For) {
+        if self.at(&TokenKind::For) {
             self.builder
                 .start_node(SyntaxKind::IMPORT_FOR_SPECIFIER.into());
             self.bump(); // `for`
@@ -255,7 +255,7 @@ impl<'src> CstParser<'src> {
     fn parse_import_specifier(&mut self) {
         self.builder.start_node(SyntaxKind::IMPORT_SPECIFIER.into());
         // `trusted foo` — per-specifier trusted
-        if self.at(TokenKind::Trusted) && self.peek_is_ident() {
+        if self.at(&TokenKind::Trusted) && self.peek_is_ident() {
             self.bump(); // trusted
             self.eat_trivia();
         }
@@ -264,7 +264,7 @@ impl<'src> CstParser<'src> {
 
         // Check for `as alias` — "as" is a banned keyword but used contextually here
         if self.at_identifier("as")
-            || self.at(TokenKind::Banned(crate::lexer::token::BannedKeyword::As))
+            || self.at(&TokenKind::Banned(crate::lexer::token::BannedKeyword::As))
         {
             self.bump();
             self.eat_trivia();
@@ -284,11 +284,11 @@ impl<'src> CstParser<'src> {
         let checkpoint = self.builder.checkpoint();
         // Optional `async` prefix — only legal when the RHS is a function
         // binding; the checkpoint-replay below drops it into FUNCTION_DECL.
-        if self.at(TokenKind::Async) {
+        if self.at(&TokenKind::Async) {
             self.bump();
             self.eat_trivia();
         }
-        self.expect(TokenKind::Let);
+        self.expect(&TokenKind::Let);
         self.eat_trivia();
 
         if self.looks_like_let_function_binding() {
@@ -304,7 +304,7 @@ impl<'src> CstParser<'src> {
         self.builder
             .start_node_at(checkpoint, SyntaxKind::CONST_DECL.into());
 
-        if self.at(TokenKind::LeftBracket) {
+        if self.at(&TokenKind::LeftBracket) {
             // Array destructure `[a, b]` is not a valid const binding: on
             // arrays the runtime length isn't in the type, and on tuples it
             // hides the real shape. Use `(a, b)` for tuples or `Array.get` /
@@ -312,31 +312,31 @@ impl<'src> CstParser<'src> {
             self.error("expected identifier, `{`, or `(`");
             self.bump();
             self.eat_trivia();
-            self.parse_comma_separated(Self::expect_ident_flex_item, TokenKind::RightBracket);
-            self.expect(TokenKind::RightBracket);
-        } else if self.at(TokenKind::LeftBrace) {
+            self.parse_comma_separated(Self::expect_ident_flex_item, &TokenKind::RightBracket);
+            self.expect(&TokenKind::RightBracket);
+        } else if self.at(&TokenKind::LeftBrace) {
             self.bump();
             self.eat_trivia();
-            self.parse_comma_separated(Self::parse_destructure_field, TokenKind::RightBrace);
-            self.expect(TokenKind::RightBrace);
-        } else if self.at(TokenKind::LeftParen) && self.is_const_tuple_destructuring() {
+            self.parse_comma_separated(Self::parse_destructure_field, &TokenKind::RightBrace);
+            self.expect(&TokenKind::RightBrace);
+        } else if self.at(&TokenKind::LeftParen) && self.is_const_tuple_destructuring() {
             self.bump();
             self.eat_trivia();
-            self.parse_comma_separated(Self::expect_ident_flex_item, TokenKind::RightParen);
-            self.expect(TokenKind::RightParen);
+            self.parse_comma_separated(Self::expect_ident_flex_item, &TokenKind::RightParen);
+            self.expect(&TokenKind::RightParen);
         } else {
             self.expect_ident_flex();
         }
         self.eat_trivia();
 
-        if self.at(TokenKind::Colon) {
+        if self.at(&TokenKind::Colon) {
             self.bump();
             self.eat_trivia();
             self.parse_type_expr();
             self.eat_trivia();
         }
 
-        self.expect(TokenKind::Equal);
+        self.expect(&TokenKind::Equal);
         self.eat_trivia();
         self.parse_expr();
 
@@ -378,32 +378,32 @@ impl<'src> CstParser<'src> {
     /// Parse def-form body: `[<generics>] (params) [-> Ret] = body`.
     fn parse_let_function_body(&mut self) {
         // Optional `<generics>`
-        if self.at(TokenKind::LessThan) {
+        if self.at(&TokenKind::LessThan) {
             self.bump(); // <
             self.eat_trivia();
-            self.parse_comma_separated(Self::parse_type_param, TokenKind::GreaterThan);
-            self.expect(TokenKind::GreaterThan);
+            self.parse_comma_separated(Self::parse_type_param, &TokenKind::GreaterThan);
+            self.expect(&TokenKind::GreaterThan);
             self.eat_trivia();
         }
 
-        self.expect(TokenKind::LeftParen);
+        self.expect(&TokenKind::LeftParen);
         self.eat_trivia();
-        self.parse_comma_separated(Self::parse_param, TokenKind::RightParen);
-        self.expect(TokenKind::RightParen);
+        self.parse_comma_separated(Self::parse_param, &TokenKind::RightParen);
+        self.expect(&TokenKind::RightParen);
         self.eat_trivia();
 
         // Optional `-> ReturnType`.
-        if self.at(TokenKind::ThinArrow) {
+        if self.at(&TokenKind::ThinArrow) {
             self.bump();
             self.eat_trivia();
             self.parse_type_expr();
             self.eat_trivia();
         }
 
-        self.expect(TokenKind::Equal);
+        self.expect(&TokenKind::Equal);
         self.eat_trivia();
 
-        if self.at(TokenKind::LeftBrace) {
+        if self.at(&TokenKind::LeftBrace) {
             self.parse_block_expr();
         } else {
             // Expression body — wrap into a synthetic BLOCK_EXPR { EXPR_ITEM }
@@ -423,24 +423,24 @@ impl<'src> CstParser<'src> {
         self.bump_remap(SyntaxKind::KW_USE);
         self.eat_trivia();
 
-        if !self.at(TokenKind::LeftArrow) {
-            if self.at(TokenKind::LeftParen) {
+        if !self.at(&TokenKind::LeftArrow) {
+            if self.at(&TokenKind::LeftParen) {
                 self.bump();
                 self.eat_trivia();
-                self.parse_comma_separated(Self::expect_ident_item, TokenKind::RightParen);
-                self.expect(TokenKind::RightParen);
-            } else if self.at(TokenKind::LeftBrace) {
+                self.parse_comma_separated(Self::expect_ident_item, &TokenKind::RightParen);
+                self.expect(&TokenKind::RightParen);
+            } else if self.at(&TokenKind::LeftBrace) {
                 self.bump();
                 self.eat_trivia();
-                self.parse_comma_separated(Self::parse_destructure_field, TokenKind::RightBrace);
-                self.expect(TokenKind::RightBrace);
+                self.parse_comma_separated(Self::parse_destructure_field, &TokenKind::RightBrace);
+                self.expect(&TokenKind::RightBrace);
             } else {
                 self.expect_ident();
             }
             self.eat_trivia();
         }
 
-        self.expect(TokenKind::LeftArrow);
+        self.expect(&TokenKind::LeftArrow);
         self.eat_trivia();
         self.parse_expr();
 
@@ -450,24 +450,24 @@ impl<'src> CstParser<'src> {
     pub(super) fn parse_param(&mut self) {
         self.builder.start_node(SyntaxKind::PARAM.into());
 
-        if self.at(TokenKind::LeftBrace) {
+        if self.at(&TokenKind::LeftBrace) {
             // Destructured param: { name, age } or { name: n, age: a }
             self.bump(); // {
             self.eat_trivia();
-            self.parse_comma_separated(Self::parse_destructure_field, TokenKind::RightBrace);
-            self.expect(TokenKind::RightBrace);
+            self.parse_comma_separated(Self::parse_destructure_field, &TokenKind::RightBrace);
+            self.expect(&TokenKind::RightBrace);
             self.eat_trivia();
-        } else if self.at(TokenKind::LeftParen) {
+        } else if self.at(&TokenKind::LeftParen) {
             // Tuple destructured param: (a, b)
             self.bump(); // (
             self.eat_trivia();
-            self.parse_comma_separated(Self::expect_ident_flex_item, TokenKind::RightParen);
-            self.expect(TokenKind::RightParen);
+            self.parse_comma_separated(Self::expect_ident_flex_item, &TokenKind::RightParen);
+            self.expect(&TokenKind::RightParen);
             self.eat_trivia();
-        } else if self.at(TokenKind::SelfKw) {
+        } else if self.at(&TokenKind::SelfKw) {
             self.bump(); // self
             self.eat_trivia();
-        } else if self.at(TokenKind::Underscore) {
+        } else if self.at(&TokenKind::Underscore) {
             self.bump(); // _
             self.eat_trivia();
         } else {
@@ -475,14 +475,14 @@ impl<'src> CstParser<'src> {
             self.eat_trivia();
         }
 
-        if self.at(TokenKind::Colon) {
+        if self.at(&TokenKind::Colon) {
             self.bump();
             self.eat_trivia();
             self.parse_type_expr();
             self.eat_trivia();
         }
 
-        if self.at(TokenKind::Equal) {
+        if self.at(&TokenKind::Equal) {
             self.bump();
             self.eat_trivia();
             self.parse_expr();
@@ -496,13 +496,13 @@ impl<'src> CstParser<'src> {
     fn parse_type_decl(&mut self) {
         self.builder.start_node(SyntaxKind::TYPE_DECL.into());
 
-        let is_opaque = self.at(TokenKind::Opaque);
+        let is_opaque = self.at(&TokenKind::Opaque);
         if is_opaque {
             self.bump();
             self.eat_trivia();
         }
 
-        let is_typealias = self.at(TokenKind::Typealias);
+        let is_typealias = self.at(&TokenKind::Typealias);
         if is_typealias {
             if is_opaque {
                 self.error(
@@ -512,22 +512,22 @@ impl<'src> CstParser<'src> {
             }
             self.bump(); // typealias
         } else {
-            self.expect(TokenKind::Type);
+            self.expect(&TokenKind::Type);
         }
         self.eat_trivia();
         self.expect_ident();
         self.eat_trivia();
 
         // Optional type parameters: <T, U>
-        if self.at(TokenKind::LessThan) {
+        if self.at(&TokenKind::LessThan) {
             self.bump();
             self.eat_trivia();
-            self.parse_comma_separated(Self::expect_ident_item, TokenKind::GreaterThan);
-            self.expect(TokenKind::GreaterThan);
+            self.parse_comma_separated(Self::expect_ident_item, &TokenKind::GreaterThan);
+            self.expect(&TokenKind::GreaterThan);
             self.eat_trivia();
         }
 
-        self.expect(TokenKind::Equal);
+        self.expect(&TokenKind::Equal);
         self.eat_trivia();
         let def_kind = self.parse_type_def_after_eq();
 
@@ -551,14 +551,14 @@ impl<'src> CstParser<'src> {
     }
 
     fn parse_type_def_after_eq(&mut self) -> SyntaxKind {
-        if self.at(TokenKind::LeftBrace) {
+        if self.at(&TokenKind::LeftBrace) {
             self.builder.start_node(SyntaxKind::TYPE_DEF_RECORD.into());
             self.parse_record_fields();
             self.builder.finish_node();
             return SyntaxKind::TYPE_DEF_RECORD;
         }
 
-        if self.at(TokenKind::VerticalBar) {
+        if self.at(&TokenKind::VerticalBar) {
             self.builder.start_node(SyntaxKind::TYPE_DEF_UNION.into());
             self.parse_union_variants_inner();
             self.builder.finish_node();
@@ -655,17 +655,20 @@ impl<'src> CstParser<'src> {
         // Variant fields: `{ name: Type, ... }` (named) or `(Type, ...)` (positional).
         // Each bracket style accepts exactly one field form — mixing them is a
         // parse error so there is a single canonical way to write each variant.
-        if self.at(TokenKind::LeftBrace) {
+        if self.at(&TokenKind::LeftBrace) {
             self.bump(); // {
             self.eat_trivia();
-            self.parse_comma_separated(Self::parse_named_variant_field, TokenKind::RightBrace);
-            self.expect(TokenKind::RightBrace);
+            self.parse_comma_separated(Self::parse_named_variant_field, &TokenKind::RightBrace);
+            self.expect(&TokenKind::RightBrace);
             self.eat_trivia();
-        } else if self.at(TokenKind::LeftParen) {
+        } else if self.at(&TokenKind::LeftParen) {
             self.bump(); // (
             self.eat_trivia();
-            self.parse_comma_separated(Self::parse_positional_variant_field, TokenKind::RightParen);
-            self.expect(TokenKind::RightParen);
+            self.parse_comma_separated(
+                Self::parse_positional_variant_field,
+                &TokenKind::RightParen,
+            );
+            self.expect(&TokenKind::RightParen);
             self.eat_trivia();
         }
     }
@@ -679,10 +682,10 @@ impl<'src> CstParser<'src> {
         self.eat_trivia();
 
         // Parse remaining `| "string"` pairs
-        while self.at(TokenKind::VerticalBar) {
+        while self.at(&TokenKind::VerticalBar) {
             self.bump(); // |
             self.eat_trivia();
-            if self.at(TokenKind::String(String::new())) {
+            if self.at(&TokenKind::String(String::new())) {
                 self.bump(); // string
                 self.eat_trivia();
             } else {
@@ -701,7 +704,7 @@ impl<'src> CstParser<'src> {
     fn parse_positional_variant_field(&mut self) {
         self.builder.start_node(SyntaxKind::VARIANT_FIELD.into());
 
-        if self.is_ident() && self.peek_is(TokenKind::Colon) {
+        if self.is_ident() && self.peek_is(&TokenKind::Colon) {
             self.error(
                 "named fields are not allowed in `(...)` variants; \
                  use `(Type)` for positional fields or `{ name: Type }` for named fields",
@@ -722,7 +725,7 @@ impl<'src> CstParser<'src> {
     fn parse_named_variant_field(&mut self) {
         self.builder.start_node(SyntaxKind::VARIANT_FIELD.into());
 
-        if self.is_ident() && self.peek_is(TokenKind::Colon) {
+        if self.is_ident() && self.peek_is(&TokenKind::Colon) {
             self.bump(); // name
             self.eat_trivia();
             self.bump(); // :
@@ -739,15 +742,15 @@ impl<'src> CstParser<'src> {
     }
 
     pub(super) fn parse_record_fields(&mut self) {
-        self.expect(TokenKind::LeftBrace);
+        self.expect(&TokenKind::LeftBrace);
         self.eat_trivia();
-        self.parse_comma_separated(Self::parse_record_entry, TokenKind::RightBrace);
-        self.expect(TokenKind::RightBrace);
+        self.parse_comma_separated(Self::parse_record_entry, &TokenKind::RightBrace);
+        self.expect(&TokenKind::RightBrace);
     }
 
     fn parse_record_entry(&mut self) {
         // Check for spread: `...TypeName` or `...Generic<T>`
-        if self.at(TokenKind::DotDotDot) {
+        if self.at(&TokenKind::DotDotDot) {
             self.builder.start_node(SyntaxKind::RECORD_SPREAD.into());
             self.bump(); // consume `...`
             self.eat_trivia();
@@ -763,12 +766,12 @@ impl<'src> CstParser<'src> {
         self.builder.start_node(SyntaxKind::RECORD_FIELD.into());
         self.expect_ident_flex();
         self.eat_trivia();
-        self.expect(TokenKind::Colon);
+        self.expect(&TokenKind::Colon);
         self.eat_trivia();
         self.parse_type_expr();
         self.eat_trivia();
 
-        if self.at(TokenKind::Equal) {
+        if self.at(&TokenKind::Equal) {
             self.bump();
             self.eat_trivia();
             self.parse_expr();
@@ -785,7 +788,7 @@ impl<'src> CstParser<'src> {
     fn parse_for_block(&mut self) {
         self.builder.start_node(SyntaxKind::FOR_BLOCK.into());
 
-        self.expect(TokenKind::For);
+        self.expect(&TokenKind::For);
         self.eat_trivia();
 
         // Parse the type name (e.g., `User`, `Array<T>`)
@@ -795,7 +798,7 @@ impl<'src> CstParser<'src> {
         // `for Type: Trait { ... }` was the old trait-impl form. It's now
         // written as `impl Trait for Type { ... }`. Reject with a clear
         // migration hint rather than silently accepting.
-        if self.at(TokenKind::Colon) {
+        if self.at(&TokenKind::Colon) {
             self.error(
                 "`for Type: Trait { ... }` is no longer valid. \
                  Use `impl Trait for Type { ... }` for trait impls; \
@@ -807,16 +810,16 @@ impl<'src> CstParser<'src> {
             self.eat_trivia();
         }
 
-        self.expect(TokenKind::LeftBrace);
+        self.expect(&TokenKind::LeftBrace);
         self.eat_trivia();
 
         // Parse function declarations inside the block (with optional export)
-        while !self.at(TokenKind::RightBrace) && !self.at_end() {
-            if self.at(TokenKind::Export) {
+        while !self.at(&TokenKind::RightBrace) && !self.at_end() {
+            if self.at(&TokenKind::Export) {
                 self.bump();
                 self.eat_trivia();
             }
-            if self.at(TokenKind::Let) || self.at(TokenKind::Async) {
+            if self.at(&TokenKind::Let) || self.at(&TokenKind::Async) {
                 self.parse_for_block_function();
                 self.eat_trivia();
             } else {
@@ -826,7 +829,7 @@ impl<'src> CstParser<'src> {
             }
         }
 
-        self.expect(TokenKind::RightBrace);
+        self.expect(&TokenKind::RightBrace);
 
         self.builder.finish_node();
     }
@@ -836,7 +839,7 @@ impl<'src> CstParser<'src> {
     fn parse_impl_block(&mut self) {
         self.builder.start_node(SyntaxKind::IMPL_BLOCK.into());
 
-        self.expect(TokenKind::Impl);
+        self.expect(&TokenKind::Impl);
         self.eat_trivia();
 
         // Trait name (identifier). Placed first so the node order is
@@ -844,7 +847,7 @@ impl<'src> CstParser<'src> {
         self.expect_ident();
         self.eat_trivia();
 
-        self.expect(TokenKind::For);
+        self.expect(&TokenKind::For);
         self.eat_trivia();
 
         // Target type (e.g., `User`, `Array<number>`)
@@ -852,16 +855,16 @@ impl<'src> CstParser<'src> {
         self.eat_trivia();
 
         // Optional body. Absence = empty impl (trait defaults).
-        if self.at(TokenKind::LeftBrace) {
+        if self.at(&TokenKind::LeftBrace) {
             self.bump();
             self.eat_trivia();
 
-            while !self.at(TokenKind::RightBrace) && !self.at_end() {
-                if self.at(TokenKind::Export) {
+            while !self.at(&TokenKind::RightBrace) && !self.at_end() {
+                if self.at(&TokenKind::Export) {
                     self.bump();
                     self.eat_trivia();
                 }
-                if self.at(TokenKind::Let) || self.at(TokenKind::Async) {
+                if self.at(&TokenKind::Let) || self.at(&TokenKind::Async) {
                     self.parse_for_block_function();
                     self.eat_trivia();
                 } else {
@@ -871,7 +874,7 @@ impl<'src> CstParser<'src> {
                 }
             }
 
-            self.expect(TokenKind::RightBrace);
+            self.expect(&TokenKind::RightBrace);
         }
 
         self.builder.finish_node();
@@ -882,18 +885,18 @@ impl<'src> CstParser<'src> {
     fn parse_trait_decl(&mut self) {
         self.builder.start_node(SyntaxKind::TRAIT_DECL.into());
 
-        self.expect(TokenKind::Trait);
+        self.expect(&TokenKind::Trait);
         self.eat_trivia();
 
         self.expect_ident(); // trait name
         self.eat_trivia();
 
-        self.expect(TokenKind::LeftBrace);
+        self.expect(&TokenKind::LeftBrace);
         self.eat_trivia();
 
         // Parse method declarations inside the trait
-        while !self.at(TokenKind::RightBrace) && !self.at_end() {
-            if self.at(TokenKind::Let) {
+        while !self.at(&TokenKind::RightBrace) && !self.at_end() {
+            if self.at(&TokenKind::Let) {
                 self.parse_trait_method();
                 self.eat_trivia();
             } else {
@@ -903,7 +906,7 @@ impl<'src> CstParser<'src> {
             }
         }
 
-        self.expect(TokenKind::RightBrace);
+        self.expect(&TokenKind::RightBrace);
 
         self.builder.finish_node();
     }
@@ -911,19 +914,19 @@ impl<'src> CstParser<'src> {
     fn parse_trait_method(&mut self) {
         self.builder.start_node(SyntaxKind::FUNCTION_DECL.into());
 
-        self.expect(TokenKind::Let);
+        self.expect(&TokenKind::Let);
         self.eat_trivia();
         self.expect_ident();
         self.eat_trivia();
 
-        self.expect(TokenKind::LeftParen);
+        self.expect(&TokenKind::LeftParen);
         self.eat_trivia();
-        self.parse_comma_separated(Self::parse_for_block_param, TokenKind::RightParen);
-        self.expect(TokenKind::RightParen);
+        self.parse_comma_separated(Self::parse_for_block_param, &TokenKind::RightParen);
+        self.expect(&TokenKind::RightParen);
         self.eat_trivia();
 
         // Optional return type
-        if self.at(TokenKind::ThinArrow) {
+        if self.at(&TokenKind::ThinArrow) {
             self.bump();
             self.eat_trivia();
             self.parse_type_expr();
@@ -931,7 +934,7 @@ impl<'src> CstParser<'src> {
         }
 
         // Optional body (default implementation): `= { ... }`
-        if self.at(TokenKind::Equal) {
+        if self.at(&TokenKind::Equal) {
             self.bump();
             self.eat_trivia();
             self.parse_block_expr();
@@ -944,31 +947,31 @@ impl<'src> CstParser<'src> {
         self.builder.start_node(SyntaxKind::FUNCTION_DECL.into());
 
         // Optional `async` prefix
-        if self.at(TokenKind::Async) {
+        if self.at(&TokenKind::Async) {
             self.bump(); // async
             self.eat_trivia();
         }
 
-        self.expect(TokenKind::Let);
+        self.expect(&TokenKind::Let);
         self.eat_trivia();
         self.expect_ident();
         self.eat_trivia();
 
-        self.expect(TokenKind::LeftParen);
+        self.expect(&TokenKind::LeftParen);
         self.eat_trivia();
-        self.parse_comma_separated(Self::parse_for_block_param, TokenKind::RightParen);
-        self.expect(TokenKind::RightParen);
+        self.parse_comma_separated(Self::parse_for_block_param, &TokenKind::RightParen);
+        self.expect(&TokenKind::RightParen);
         self.eat_trivia();
 
         // Optional return type
-        if self.at(TokenKind::ThinArrow) {
+        if self.at(&TokenKind::ThinArrow) {
             self.bump();
             self.eat_trivia();
             self.parse_type_expr();
             self.eat_trivia();
         }
 
-        self.expect(TokenKind::Equal);
+        self.expect(&TokenKind::Equal);
         self.eat_trivia();
         self.parse_block_expr();
 
@@ -978,21 +981,21 @@ impl<'src> CstParser<'src> {
     fn parse_for_block_param(&mut self) {
         self.builder.start_node(SyntaxKind::PARAM.into());
 
-        if self.at(TokenKind::SelfKw) {
+        if self.at(&TokenKind::SelfKw) {
             // `self` parameter — bump as an ident-like token
             self.bump();
         } else {
             self.expect_ident();
             self.eat_trivia();
 
-            if self.at(TokenKind::Colon) {
+            if self.at(&TokenKind::Colon) {
                 self.bump();
                 self.eat_trivia();
                 self.parse_type_expr();
                 self.eat_trivia();
             }
 
-            if self.at(TokenKind::Equal) {
+            if self.at(&TokenKind::Equal) {
                 self.bump();
                 self.eat_trivia();
                 self.parse_expr();
@@ -1012,22 +1015,22 @@ impl<'src> CstParser<'src> {
         self.eat_trivia();
 
         // Test name (string literal)
-        self.expect_kind(TokenKind::String(String::new()));
+        self.expect_kind(&TokenKind::String(String::new()));
         self.eat_trivia();
 
-        self.expect(TokenKind::LeftBrace);
+        self.expect(&TokenKind::LeftBrace);
         self.eat_trivia();
 
         // Parse test body: let bindings, assert statements, and expressions
-        while !self.at(TokenKind::RightBrace) && !self.at_end() {
+        while !self.at(&TokenKind::RightBrace) && !self.at_end() {
             let prev_pos = self.pos;
-            if self.at(TokenKind::Let) {
+            if self.at(&TokenKind::Let) {
                 let checkpoint = self.builder.checkpoint();
                 self.builder
                     .start_node_at(checkpoint, SyntaxKind::ITEM.into());
                 self.parse_const_decl();
                 self.builder.finish_node();
-            } else if self.at(TokenKind::Assert) {
+            } else if self.at(&TokenKind::Assert) {
                 self.parse_assert_stmt();
             } else {
                 self.parse_expr();
@@ -1038,7 +1041,7 @@ impl<'src> CstParser<'src> {
             }
         }
 
-        self.expect(TokenKind::RightBrace);
+        self.expect(&TokenKind::RightBrace);
 
         self.builder.finish_node();
     }
@@ -1046,7 +1049,7 @@ impl<'src> CstParser<'src> {
     fn parse_assert_stmt(&mut self) {
         self.builder.start_node(SyntaxKind::ASSERT_EXPR.into());
 
-        self.expect(TokenKind::Assert);
+        self.expect(&TokenKind::Assert);
         self.eat_trivia();
         self.parse_expr();
 

--- a/crates/floe-core/src/cst/jsx.rs
+++ b/crates/floe-core/src/cst/jsx.rs
@@ -5,17 +5,17 @@ impl<'src> CstParser<'src> {
 
     pub(super) fn parse_jsx_element(&mut self) {
         self.builder.start_node(SyntaxKind::JSX_ELEMENT.into());
-        self.expect(TokenKind::LessThan);
+        self.expect(&TokenKind::LessThan);
         self.eat_trivia();
 
         // Fragment: <>
-        if self.at(TokenKind::GreaterThan) {
+        if self.at(&TokenKind::GreaterThan) {
             self.bump(); // >
             self.parse_jsx_children();
             // Expect </>
-            self.expect(TokenKind::LessThan);
-            self.expect(TokenKind::Slash);
-            self.expect(TokenKind::GreaterThan);
+            self.expect(&TokenKind::LessThan);
+            self.expect(&TokenKind::Slash);
+            self.expect(&TokenKind::GreaterThan);
             self.builder.finish_node();
             return;
         }
@@ -25,7 +25,7 @@ impl<'src> CstParser<'src> {
         self.eat_trivia();
 
         // Props
-        while !self.at(TokenKind::GreaterThan) && !self.at(TokenKind::Slash) && !self.at_end() {
+        while !self.at(&TokenKind::GreaterThan) && !self.at(&TokenKind::Slash) && !self.at_end() {
             let prev_pos = self.pos;
             self.parse_jsx_prop();
             self.eat_trivia();
@@ -40,30 +40,30 @@ impl<'src> CstParser<'src> {
         }
 
         // Self-closing: />
-        if self.at(TokenKind::Slash) {
+        if self.at(&TokenKind::Slash) {
             self.bump();
-            self.expect(TokenKind::GreaterThan);
+            self.expect(&TokenKind::GreaterThan);
             self.builder.finish_node();
             return;
         }
 
-        self.expect(TokenKind::GreaterThan);
+        self.expect(&TokenKind::GreaterThan);
         self.parse_jsx_children();
 
         // Closing tag: </Tag> or </Tag.Member>
-        self.expect(TokenKind::LessThan);
-        self.expect(TokenKind::Slash);
+        self.expect(&TokenKind::LessThan);
+        self.expect(&TokenKind::Slash);
         self.eat_trivia();
         self.expect_ident();
         self.parse_jsx_member_segments();
-        self.expect(TokenKind::GreaterThan);
+        self.expect(&TokenKind::GreaterThan);
 
         self.builder.finish_node();
     }
 
     /// Parse `.Member` segments after a JSX tag name (e.g., `.Trigger` in `Select.Trigger`).
     fn parse_jsx_member_segments(&mut self) {
-        while self.at(TokenKind::Dot) {
+        while self.at(&TokenKind::Dot) {
             self.bump();
             if self.is_member_name_token() {
                 self.bump();
@@ -75,7 +75,7 @@ impl<'src> CstParser<'src> {
 
     fn parse_jsx_prop(&mut self) {
         // JSX spread: {...expr}
-        if self.at(TokenKind::LeftBrace) && self.peek_is(TokenKind::DotDotDot) {
+        if self.at(&TokenKind::LeftBrace) && self.peek_is(&TokenKind::DotDotDot) {
             self.builder.start_node(SyntaxKind::JSX_SPREAD_PROP.into());
             self.bump(); // {
             self.eat_trivia();
@@ -83,7 +83,7 @@ impl<'src> CstParser<'src> {
             self.eat_trivia();
             self.parse_expr();
             self.eat_trivia();
-            self.expect(TokenKind::RightBrace);
+            self.expect(&TokenKind::RightBrace);
             self.builder.finish_node();
             return;
         }
@@ -97,7 +97,7 @@ impl<'src> CstParser<'src> {
             self.expect_ident();
         }
         // Continue consuming -ident sequences for hyphenated attribute names
-        while self.at(TokenKind::Minus) {
+        while self.at(&TokenKind::Minus) {
             self.bump(); // -
             if self.is_ident() || self.is_keyword() {
                 self.bump();
@@ -108,15 +108,15 @@ impl<'src> CstParser<'src> {
         }
         self.eat_trivia();
 
-        if self.at(TokenKind::Equal) {
+        if self.at(&TokenKind::Equal) {
             self.bump();
             self.eat_trivia();
-            if self.at(TokenKind::LeftBrace) {
+            if self.at(&TokenKind::LeftBrace) {
                 self.bump();
                 self.eat_trivia();
                 self.parse_expr();
                 self.eat_trivia();
-                self.expect(TokenKind::RightBrace);
+                self.expect(&TokenKind::RightBrace);
             } else if matches!(self.current_kind(), Some(TokenKind::String(_))) {
                 self.bump();
             } else {
@@ -130,7 +130,7 @@ impl<'src> CstParser<'src> {
     fn parse_jsx_children(&mut self) {
         loop {
             // Check for closing tag
-            if self.at(TokenKind::LessThan) && self.peek_is(TokenKind::Slash) {
+            if self.at(&TokenKind::LessThan) && self.peek_is(&TokenKind::Slash) {
                 break;
             }
             if self.at_end() {
@@ -145,11 +145,11 @@ impl<'src> CstParser<'src> {
                     self.eat_trivia();
                     // {/* comment */} — block comment already eaten as trivia,
                     // so if the next token is `}` there's no expr to parse.
-                    if !self.at(TokenKind::RightBrace) {
+                    if !self.at(&TokenKind::RightBrace) {
                         self.parse_expr();
                         self.eat_trivia();
                     }
-                    self.expect(TokenKind::RightBrace);
+                    self.expect(&TokenKind::RightBrace);
                     self.builder.finish_node();
                 }
                 Some(TokenKind::LessThan) => {
@@ -160,8 +160,8 @@ impl<'src> CstParser<'src> {
                         self.builder.start_node(SyntaxKind::JSX_TEXT.into());
                         self.bump();
                         while !self.at_end()
-                            && !self.at(TokenKind::LeftBrace)
-                            && !self.at(TokenKind::LessThan)
+                            && !self.at(&TokenKind::LeftBrace)
+                            && !self.at(&TokenKind::LessThan)
                             && self.is_jsx_text_token()
                         {
                             self.bump();

--- a/crates/floe-core/src/cst/types.rs
+++ b/crates/floe-core/src/cst/types.rs
@@ -7,51 +7,51 @@ impl<'src> CstParser<'src> {
         self.builder.start_node(SyntaxKind::TYPE_EXPR.into());
 
         // Function type: (params) -> ReturnType or () -> ReturnType
-        if self.at(TokenKind::LeftParen) && self.is_paren_function_type() {
+        if self.at(&TokenKind::LeftParen) && self.is_paren_function_type() {
             self.parse_function_type();
         }
         // Unit type: ()
-        else if self.at(TokenKind::LeftParen) && self.peek_is(TokenKind::RightParen) {
+        else if self.at(&TokenKind::LeftParen) && self.peek_is(&TokenKind::RightParen) {
             self.bump(); // (
             self.eat_trivia();
             self.bump(); // )
         }
         // Function type: fn(params) -> ReturnType (old syntax — error)
-        else if self.at(TokenKind::Fn) && self.peek_is(TokenKind::LeftParen) {
+        else if self.at(&TokenKind::Fn) && self.peek_is(&TokenKind::LeftParen) {
             self.builder.start_node(SyntaxKind::ERROR.into());
             self.error("function types use arrow syntax: `(T) -> U` instead of `fn(T) -> U`");
             self.bump(); // fn
             self.builder.finish_node();
         }
         // Tuple type: (T, U) — paren with comma, no `->` after `)`
-        else if self.at(TokenKind::LeftParen) && self.is_paren_tuple_type() {
+        else if self.at(&TokenKind::LeftParen) && self.is_paren_tuple_type() {
             self.bump(); // (
             self.eat_trivia();
-            self.parse_comma_separated(Self::parse_type_expr, TokenKind::RightParen);
-            self.expect(TokenKind::RightParen);
+            self.parse_comma_separated(Self::parse_type_expr, &TokenKind::RightParen);
+            self.expect(&TokenKind::RightParen);
         }
         // Tuple: [T, U]
-        else if self.at(TokenKind::LeftBracket) {
+        else if self.at(&TokenKind::LeftBracket) {
             self.bump();
             self.eat_trivia();
-            self.parse_comma_separated(Self::parse_type_expr, TokenKind::RightBracket);
-            self.expect(TokenKind::RightBracket);
+            self.parse_comma_separated(Self::parse_type_expr, &TokenKind::RightBracket);
+            self.expect(&TokenKind::RightBracket);
         }
         // Record type: { ... }
-        else if self.at(TokenKind::LeftBrace) {
+        else if self.at(&TokenKind::LeftBrace) {
             self.parse_record_fields();
         }
         // String literal type (e.g. ComponentProps<"div">)
-        else if self.at(TokenKind::String(String::new())) {
+        else if self.at(&TokenKind::String(String::new())) {
             self.bump();
         }
         // typeof <ident> or typeof Module.value
-        else if self.at(TokenKind::Typeof) {
+        else if self.at(&TokenKind::Typeof) {
             self.bump();
             self.eat_trivia();
             self.expect_ident();
             self.eat_trivia();
-            while self.at(TokenKind::Dot) {
+            while self.at(&TokenKind::Dot) {
                 self.bump();
                 self.eat_trivia();
                 self.expect_ident();
@@ -64,7 +64,7 @@ impl<'src> CstParser<'src> {
             self.eat_trivia();
 
             // Dotted names (e.g. JSX.Element)
-            while self.at(TokenKind::Dot) {
+            while self.at(&TokenKind::Dot) {
                 self.bump();
                 self.eat_trivia();
                 self.expect_ident();
@@ -72,17 +72,17 @@ impl<'src> CstParser<'src> {
             }
 
             // Type arguments: <T, U>
-            if self.at(TokenKind::LessThan) {
+            if self.at(&TokenKind::LessThan) {
                 self.bump();
                 self.eat_trivia();
-                self.parse_comma_separated(Self::parse_type_expr, TokenKind::GreaterThan);
-                self.expect(TokenKind::GreaterThan);
+                self.parse_comma_separated(Self::parse_type_expr, &TokenKind::GreaterThan);
+                self.expect(&TokenKind::GreaterThan);
                 self.eat_trivia();
             }
         }
 
         // Intersection: A & B & C — parse as flat list within this TYPE_EXPR node
-        while self.at(TokenKind::Amp) {
+        while self.at(&TokenKind::Amp) {
             self.bump(); // &
             self.eat_trivia();
             self.parse_type_expr();
@@ -92,12 +92,12 @@ impl<'src> CstParser<'src> {
     }
 
     fn parse_function_type(&mut self) {
-        self.expect(TokenKind::LeftParen);
+        self.expect(&TokenKind::LeftParen);
         self.eat_trivia();
-        self.parse_comma_separated(Self::parse_fn_type_param, TokenKind::RightParen);
-        self.expect(TokenKind::RightParen);
+        self.parse_comma_separated(Self::parse_fn_type_param, &TokenKind::RightParen);
+        self.expect(&TokenKind::RightParen);
         self.eat_trivia();
-        self.expect(TokenKind::ThinArrow);
+        self.expect(&TokenKind::ThinArrow);
         self.eat_trivia();
         self.parse_type_expr();
     }
@@ -106,7 +106,7 @@ impl<'src> CstParser<'src> {
     ///   `IDENT ':' TYPE_EXPR` (labelled) or `TYPE_EXPR` (bare).
     fn parse_fn_type_param(&mut self) {
         self.builder.start_node(SyntaxKind::FN_TYPE_PARAM.into());
-        if self.is_ident() && self.peek_is(TokenKind::Colon) {
+        if self.is_ident() && self.peek_is(&TokenKind::Colon) {
             self.bump(); // ident
             self.eat_trivia();
             self.bump(); // :


### PR DESCRIPTION
closes #1407

Changes 6 CST parser functions to take `&TokenKind` instead of owned `TokenKind`, removing all `#[allow(clippy::needless_pass_by_value)]` suppressions added in #1405. Updates ~300 call sites across `cst.rs`, `cst/exprs.rs`, `cst/items.rs`, `cst/jsx.rs`, and `cst/types.rs`.

## Test plan

- [x] `cargo clippy --profile ci --workspace -- -D warnings` — zero errors
- [x] `cargo test --workspace` — all 1813 tests pass