### PR TITLE
chore: [#1413] deduplicate npm integration plugins

### DIFF
--- a/integrations/core/src/index.ts
+++ b/integrations/core/src/index.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 
 export interface CompileResult {
@@ -7,7 +7,7 @@ export interface CompileResult {
   map: string | null;
 }
 
-export interface CompileOptions {
+export interface FloeOptions {
   /** Path to the floe binary. Defaults to "floe". */
   compiler?: string;
 }
@@ -22,15 +22,9 @@ export function findProjectRoot(start: string): string {
   let dir = start;
   let packageJsonDir: string | null = null;
   while (true) {
-    try {
-      statSync(join(dir, "node_modules"));
-      return dir;
-    } catch {}
-    if (packageJsonDir === null) {
-      try {
-        statSync(join(dir, "package.json"));
-        packageJsonDir = dir;
-      } catch {}
+    if (existsSync(join(dir, "node_modules"))) return dir;
+    if (packageJsonDir === null && existsSync(join(dir, "package.json"))) {
+      packageJsonDir = dir;
     }
     const parent = dirname(dir);
     if (parent === dir) return packageJsonDir ?? start;
@@ -62,9 +56,7 @@ export function readCompiledOutput(
       if (statSync(outPath).mtimeMs >= sourceMtime) {
         return readFileSync(outPath, "utf-8");
       }
-    } catch {
-      // File doesn't exist, try next extension
-    }
+    } catch {}
   }
 
   return null;
@@ -105,7 +97,7 @@ export function compileFloe(
 export function resolveFloeFile(
   flFile: string,
   projectRoot: string,
-  options: CompileOptions = {},
+  options: FloeOptions = {},
 ): string {
   const cached = readCompiledOutput(flFile, projectRoot);
   if (cached) return cached;

--- a/integrations/core/src/index.ts
+++ b/integrations/core/src/index.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync, statSync } from "node:fs";
-import { join, relative } from "node:path";
+import { dirname, join, relative } from "node:path";
 
 export interface CompileResult {
   code: string;
@@ -10,6 +10,32 @@ export interface CompileResult {
 export interface CompileOptions {
   /** Path to the floe binary. Defaults to "floe". */
   compiler?: string;
+}
+
+/**
+ * Walk up from `start` to find the project root. Matches the Floe
+ * compiler's `find_project_dir` logic: prefers the nearest ancestor
+ * containing `node_modules`, falling back to the nearest containing
+ * `package.json`, and finally to `start` itself.
+ */
+export function findProjectRoot(start: string): string {
+  let dir = start;
+  let packageJsonDir: string | null = null;
+  while (true) {
+    try {
+      statSync(join(dir, "node_modules"));
+      return dir;
+    } catch {}
+    if (packageJsonDir === null) {
+      try {
+        statSync(join(dir, "package.json"));
+        packageJsonDir = dir;
+      } catch {}
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return packageJsonDir ?? start;
+    dir = parent;
+  }
 }
 
 /**

--- a/integrations/esbuild-plugin/package.json
+++ b/integrations/esbuild-plugin/package.json
@@ -34,6 +34,9 @@
   "peerDependencies": {
     "esbuild": ">=0.17.0"
   },
+  "dependencies": {
+    "@floeorg/core": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^25.5.2",
     "esbuild": "^0.27.3",

--- a/integrations/esbuild-plugin/src/index.ts
+++ b/integrations/esbuild-plugin/src/index.ts
@@ -1,6 +1,6 @@
-import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, statSync } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { compileFloe, findProjectRoot, readCompiledOutput } from "@floeorg/core";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import type { Plugin } from "esbuild";
 
 export interface FloeOptions {
@@ -9,7 +9,6 @@ export interface FloeOptions {
 }
 
 const JS_TS_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"] as const;
-const COMPILED_EXTENSIONS = ["tsx", "ts"] as const;
 
 /**
  * esbuild plugin for Floe.
@@ -39,12 +38,12 @@ export default function floe(options: FloeOptions = {}): Plugin {
   return {
     name: "floe",
     setup(build) {
-      const rootCache = new Map<string, string | null>();
-      const findRoot = (flFile: string): string | null => {
+      const rootCache = new Map<string, string>();
+      const findRoot = (flFile: string): string => {
         const key = dirname(flFile);
         const cached = rootCache.get(key);
         if (cached !== undefined) return cached;
-        const found = findProjectRoot(flFile);
+        const found = findProjectRoot(key);
         rootCache.set(key, found);
         return found;
       };
@@ -71,13 +70,14 @@ export default function floe(options: FloeOptions = {}): Plugin {
       build.onLoad({ filter: /\.fl$/ }, (args) => {
         const resolveDir = dirname(args.path);
         const projectRoot = findRoot(args.path);
-        const cached = projectRoot ? readCachedOutput(args.path, projectRoot) : null;
+        const cached = readCompiledOutput(args.path, projectRoot);
         if (cached !== null) {
           return { contents: cached, loader: "ts", resolveDir };
         }
 
         try {
-          return { contents: compileFloe(compiler, args.path), loader: "ts", resolveDir };
+          const { code } = compileFloe(compiler, args.path);
+          return { contents: code, loader: "ts", resolveDir };
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           return {
@@ -92,60 +92,4 @@ export default function floe(options: FloeOptions = {}): Plugin {
       });
     },
   };
-}
-
-/**
- * Read pre-compiled `.ts`/`.tsx` output from the `.floe/` mirror if it's
- * fresher than the source `.fl`. Returns null if the mirror is missing
- * or stale.
- */
-function readCachedOutput(flFile: string, projectRoot: string): string | null {
-  let sourceMtime: number;
-  try {
-    sourceMtime = statSync(flFile).mtimeMs;
-  } catch {
-    return null;
-  }
-
-  const rel = relative(projectRoot, flFile);
-  const floeDir = join(projectRoot, ".floe");
-
-  for (const ext of COMPILED_EXTENSIONS) {
-    const outPath = join(floeDir, rel).replace(/\.fl$/, `.${ext}`);
-    try {
-      if (statSync(outPath).mtimeMs >= sourceMtime) {
-        return readFileSync(outPath, "utf-8");
-      }
-    } catch {
-      // try next extension
-    }
-  }
-
-  return null;
-}
-
-function findProjectRoot(start: string): string | null {
-  let dir = isAbsolute(start) ? dirname(start) : resolve(start);
-  while (true) {
-    if (existsSync(join(dir, "package.json"))) return dir;
-    const parent = dirname(dir);
-    if (parent === dir) return null;
-    dir = parent;
-  }
-}
-
-function compileFloe(compiler: string, filename: string): string {
-  try {
-    return execFileSync(compiler, ["build", "--emit-stdout", filename], {
-      encoding: "utf-8",
-      timeout: 30_000,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-  } catch (error) {
-    if (error && typeof error === "object" && "stderr" in error) {
-      const stderr = (error as { stderr: string | Buffer }).stderr;
-      throw new Error(String(stderr));
-    }
-    throw error;
-  }
 }

--- a/integrations/esbuild-plugin/src/index.ts
+++ b/integrations/esbuild-plugin/src/index.ts
@@ -1,12 +1,14 @@
-import { compileFloe, findProjectRoot, readCompiledOutput } from "@floeorg/core";
+import {
+  compileFloe,
+  findProjectRoot,
+  readCompiledOutput,
+  type FloeOptions,
+} from "@floeorg/core";
 import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import type { Plugin } from "esbuild";
 
-export interface FloeOptions {
-  /** Path to the `floe` binary. Defaults to `"floe"`. */
-  compiler?: string;
-}
+export type { FloeOptions };
 
 const JS_TS_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"] as const;
 

--- a/integrations/register/package.json
+++ b/integrations/register/package.json
@@ -31,6 +31,9 @@
   "engines": {
     "node": ">=22.14.0"
   },
+  "dependencies": {
+    "@floeorg/core": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^25.6.0",
     "typescript": "^6.0.3"

--- a/integrations/register/src/index.ts
+++ b/integrations/register/src/index.ts
@@ -1,31 +1,8 @@
+import { findProjectRoot } from "@floeorg/core";
 import { registerHooks } from "node:module";
 import { statSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-
-/**
- * Find the project root by walking up to find node_modules or package.json.
- * Matches the Floe compiler's `find_project_dir` logic.
- */
-function findProjectRoot(start: string): string {
-  let dir = start;
-  let packageJsonDir: string | null = null;
-  while (true) {
-    try {
-      statSync(join(dir, "node_modules"));
-      return dir;
-    } catch {}
-    if (packageJsonDir === null) {
-      try {
-        statSync(join(dir, "package.json"));
-        packageJsonDir = dir;
-      } catch {}
-    }
-    const parent = dirname(dir);
-    if (parent === dir) return packageJsonDir ?? start;
-    dir = parent;
-  }
-}
 
 /**
  * Find the compiled .ts/.tsx output in .floe/ for a given .fl file.

--- a/integrations/vite-plugin/package.json
+++ b/integrations/vite-plugin/package.json
@@ -30,6 +30,9 @@
   "peerDependencies": {
     "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
+  "dependencies": {
+    "@floeorg/core": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^25.6.0",
     "typescript": "^6.0.3",

--- a/integrations/vite-plugin/src/index.ts
+++ b/integrations/vite-plugin/src/index.ts
@@ -1,10 +1,7 @@
-import { compileFloe, readCompiledOutput } from "@floeorg/core";
+import { compileFloe, readCompiledOutput, type FloeOptions } from "@floeorg/core";
 import * as vite from "vite";
 
-export interface FloeOptions {
-  /** Path to the floe binary. Defaults to "floe". */
-  compiler?: string;
-}
+export type { FloeOptions };
 
 /**
  * Vite plugin for Floe.
@@ -54,7 +51,7 @@ export default function floe(options: FloeOptions = {}): import("vite").Plugin {
       if (!cleanId.endsWith(".fl")) return null;
 
       try {
-        // Try reading pre-compiled output from .floe/ (kept fresh by `floe watch`)
+        // .floe/ output is kept fresh by `floe watch`.
         const cached = readCompiledOutput(cleanId, projectRoot);
         if (cached) {
           return transformTsx(cached, cleanId);

--- a/integrations/vite-plugin/src/index.ts
+++ b/integrations/vite-plugin/src/index.ts
@@ -1,6 +1,4 @@
-import { execFileSync } from "node:child_process";
-import { readFileSync, statSync } from "node:fs";
-import { join, relative } from "node:path";
+import { compileFloe, readCompiledOutput } from "@floeorg/core";
 import * as vite from "vite";
 
 export interface FloeOptions {
@@ -62,7 +60,7 @@ export default function floe(options: FloeOptions = {}): import("vite").Plugin {
           return transformTsx(cached, cleanId);
         }
 
-        const compiled = compileFloe(compiler, code, id);
+        const compiled = compileFloe(compiler, id);
         return transformTsx(compiled.code, cleanId);
       } catch (error) {
         const message =
@@ -80,38 +78,6 @@ export default function floe(options: FloeOptions = {}): import("vite").Plugin {
       }
     },
   };
-}
-
-/**
- * Read compiled .ts/.tsx output from .floe/ if it exists and is fresh
- * (newer than the source .fl file). Returns null if missing or stale.
- */
-function readCompiledOutput(
-  flFile: string,
-  projectRoot: string,
-): string | null {
-  const rel = relative(projectRoot, flFile);
-  const floeDir = join(projectRoot, ".floe");
-
-  let sourceMtime: number;
-  try {
-    sourceMtime = statSync(flFile).mtimeMs;
-  } catch {
-    return null;
-  }
-
-  for (const ext of ["tsx", "ts"]) {
-    const outPath = join(floeDir, rel).replace(/\.fl$/, `.${ext}`);
-    try {
-      if (statSync(outPath).mtimeMs >= sourceMtime) {
-        return readFileSync(outPath, "utf-8");
-      }
-    } catch {
-      // File doesn't exist, try next extension
-    }
-  }
-
-  return null;
 }
 
 // Vite 6+ has transformWithOxc, Vite 5 has transformWithEsbuild.
@@ -139,32 +105,3 @@ function transformTsx(code: string, id: string) {
   );
 }
 
-interface CompileResult {
-  code: string;
-  map: string | null;
-}
-
-function compileFloe(
-  compiler: string,
-  _source: string,
-  filename: string,
-): CompileResult {
-  try {
-    const output = execFileSync(compiler, ["build", "--emit-stdout", filename], {
-      encoding: "utf-8",
-      timeout: 30_000,
-      stdio: ["pipe", "pipe", "pipe"], // capture stderr instead of printing
-    });
-
-    return {
-      code: output,
-      map: null,
-    };
-  } catch (error) {
-    if (error && typeof error === "object" && "stderr" in error) {
-      const stderr = (error as { stderr: string | Buffer }).stderr;
-      throw new Error(String(stderr));
-    }
-    throw error;
-  }
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,10 @@ importers:
         version: 6.0.3
 
   integrations/esbuild-plugin:
+    dependencies:
+      '@floeorg/core':
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       '@types/node':
         specifier: ^25.5.2
@@ -230,6 +234,10 @@ importers:
         version: 6.0.3
 
   integrations/register:
+    dependencies:
+      '@floeorg/core':
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
@@ -239,6 +247,10 @@ importers:
         version: 6.0.3
 
   integrations/vite-plugin:
+    dependencies:
+      '@floeorg/core':
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       '@types/node':
         specifier: ^25.6.0


### PR DESCRIPTION
closes #1413

Sub-task of #1412.

`@floeorg/core` already exported `compileFloe`, `readCompiledOutput`, and `resolveFloeFile`, but `vite-plugin`, `esbuild-plugin`, and `register` had hand-rolled their own copies. This PR makes the three plugins depend on core and import from it.

## Changes

- Adds \`findProjectRoot\` to \`@floeorg/core\` (using register's algorithm — node_modules first, falls back to package.json, then to start dir; matches the Floe compiler's \`find_project_dir\`).
- Renames \`CompileOptions\` → \`FloeOptions\` in core (the only consumer is plugin code that already calls it that), and exports it for re-use.
- Adds \`@floeorg/core\` as a workspace dependency in vite-plugin, esbuild-plugin, register.
- Removes duplicated \`readCompiledOutput\` / \`compileFloe\` / \`findProjectRoot\` / \`FloeOptions\` from each plugin.
- Drops the dead \`_source\` param from vite-plugin's \`compileFloe\` call site.
- Replaces \`try { statSync(...) } catch {}\` existence checks in \`findProjectRoot\` with \`existsSync\` (control-flow-via-exception → idiomatic).

## Net diff

-95 lines across the four packages.

## Test plan

- [x] \`pnpm --filter '@floeorg/*' build\` — succeeds
- [x] \`pnpm --filter '@floeorg/*' test\` — all 20 tests pass (esbuild × 2, register × 1, hono × 17)
- [x] \`cargo build --release -p floe\` — succeeds (used by integration tests)