### PR TITLE
chore: [#1414] extract Result/try-catch helpers in stdlib codegen

### DIFF
--- a/crates/floe-core/src/stdlib/http.rs
+++ b/crates/floe-core/src/stdlib/http.rs
@@ -1,4 +1,4 @@
-use super::{StdlibFn, Type, promise_of, result_of, stdlib_fn};
+use super::{StdlibFn, Type, promise_of, result_of, stdlib_fn, try_catch_async_result};
 
 #[rustfmt::skip]
 pub fn register(fns: &mut Vec<StdlibFn>) {
@@ -6,11 +6,11 @@ pub fn register(fns: &mut Vec<StdlibFn>) {
     let error = Type::Named("Error".to_string());
 
     fns.extend([
-        stdlib_fn!("Http", "get", [Type::String], promise_of(result_of(response.clone(), error.clone())), "(async () => { try { const _r = await fetch($0); return { ok: true as const, value: _r }; } catch (_e) { return { ok: false as const, error: _e instanceof Error ? _e : new Error(String(_e)) }; } })()"),
-        stdlib_fn!("Http", "post", [Type::String, Type::Unknown], promise_of(result_of(response.clone(), error.clone())), "(async () => { try { const _r = await fetch($0, { method: \"POST\", body: JSON.stringify($1), headers: { \"Content-Type\": \"application/json\" } }); return { ok: true as const, value: _r }; } catch (_e) { return { ok: false as const, error: _e instanceof Error ? _e : new Error(String(_e)) }; } })()"),
-        stdlib_fn!("Http", "put", [Type::String, Type::Unknown], promise_of(result_of(response.clone(), error.clone())), "(async () => { try { const _r = await fetch($0, { method: \"PUT\", body: JSON.stringify($1), headers: { \"Content-Type\": \"application/json\" } }); return { ok: true as const, value: _r }; } catch (_e) { return { ok: false as const, error: _e instanceof Error ? _e : new Error(String(_e)) }; } })()"),
-        stdlib_fn!("Http", "delete", [Type::String], promise_of(result_of(response.clone(), error.clone())), "(async () => { try { const _r = await fetch($0, { method: \"DELETE\" }); return { ok: true as const, value: _r }; } catch (_e) { return { ok: false as const, error: _e instanceof Error ? _e : new Error(String(_e)) }; } })()"),
-        stdlib_fn!("Http", "json", [Type::Named("Response".to_string())], promise_of(result_of(Type::Unknown, error.clone())), "(async () => { try { const _r = await $0.json(); return { ok: true as const, value: _r }; } catch (_e) { return { ok: false as const, error: _e instanceof Error ? _e : new Error(String(_e)) }; } })()"),
-        stdlib_fn!("Http", "text", [Type::Named("Response".to_string())], promise_of(result_of(Type::String, error.clone())), "(async () => { try { const _r = await $0.text(); return { ok: true as const, value: _r }; } catch (_e) { return { ok: false as const, error: _e instanceof Error ? _e : new Error(String(_e)) }; } })()"),
+        stdlib_fn!("Http", "get",    [Type::String],                            promise_of(result_of(response.clone(), error.clone())), try_catch_async_result!("await fetch($0)")),
+        stdlib_fn!("Http", "post",   [Type::String, Type::Unknown],             promise_of(result_of(response.clone(), error.clone())), try_catch_async_result!("await fetch($0, { method: \"POST\", body: JSON.stringify($1), headers: { \"Content-Type\": \"application/json\" } })")),
+        stdlib_fn!("Http", "put",    [Type::String, Type::Unknown],             promise_of(result_of(response.clone(), error.clone())), try_catch_async_result!("await fetch($0, { method: \"PUT\", body: JSON.stringify($1), headers: { \"Content-Type\": \"application/json\" } })")),
+        stdlib_fn!("Http", "delete", [Type::String],                            promise_of(result_of(response.clone(), error.clone())), try_catch_async_result!("await fetch($0, { method: \"DELETE\" })")),
+        stdlib_fn!("Http", "json",   [Type::Named("Response".to_string())],     promise_of(result_of(Type::Unknown, error.clone())),    try_catch_async_result!("await $0.json()")),
+        stdlib_fn!("Http", "text",   [Type::Named("Response".to_string())],     promise_of(result_of(Type::String, error.clone())),     try_catch_async_result!("await $0.text()")),
     ]);
 }

--- a/crates/floe-core/src/stdlib/json.rs
+++ b/crates/floe-core/src/stdlib/json.rs
@@ -1,4 +1,4 @@
-use super::{StdlibFn, Type, result_of, stdlib_fn, tv};
+use super::{StdlibFn, Type, err_value, ok_value, result_of, stdlib_fn, tv};
 
 #[rustfmt::skip]
 pub fn register(fns: &mut Vec<StdlibFn>) {
@@ -6,6 +6,15 @@ pub fn register(fns: &mut Vec<StdlibFn>) {
 
     fns.extend([
         stdlib_fn!("JSON", "stringify", [t.clone()], Type::String, "JSON.stringify($0)"),
-        stdlib_fn!("JSON", "parse", [Type::String], result_of(t.clone(), Type::Named("ParseError".to_string())), "(() => { try { return { ok: true as const, value: JSON.parse($0) }; } catch (e) { return { ok: false as const, error: { message: String(e) } }; } })()"),
+        stdlib_fn!(
+            "JSON", "parse",
+            [Type::String],
+            result_of(t.clone(), Type::Named("ParseError".to_string())),
+            concat!(
+                "(() => { try { return ", ok_value!("JSON.parse($0)"), "; ",
+                "} catch (e) { return ", err_value!("{ message: String(e) }"), "; ",
+                "} })()"
+            )
+        ),
     ]);
 }

--- a/crates/floe-core/src/stdlib/mod.rs
+++ b/crates/floe-core/src/stdlib/mod.rs
@@ -162,8 +162,38 @@ macro_rules! stdlib_fn {
     };
 }
 
-// Make the macro available to submodules.
-use stdlib_fn;
+/// Emit `{ ok: true as const, value: <expr> }` — a successful Result literal.
+macro_rules! ok_value {
+    ($expr:expr) => {
+        concat!("{ ok: true as const, value: ", $expr, " }")
+    };
+}
+
+/// Emit `{ ok: false as const, error: <expr> }` — a failed Result literal.
+macro_rules! err_value {
+    ($expr:expr) => {
+        concat!("{ ok: false as const, error: ", $expr, " }")
+    };
+}
+
+/// Wrap an async expression in the canonical try/catch IIFE that
+/// normalizes the caught error to an `Error` instance and returns a
+/// Result literal. The body is bound to `_r` inside `try`.
+macro_rules! try_catch_async_result {
+    ($body:expr) => {
+        concat!(
+            "(async () => { try { const _r = ",
+            $body,
+            "; return { ok: true as const, value: _r };",
+            " } catch (_e) { return { ok: false as const, ",
+            "error: _e instanceof Error ? _e : new Error(String(_e)) };",
+            " } })()"
+        )
+    };
+}
+
+// Make the macros available to submodules.
+use {err_value, ok_value, stdlib_fn, try_catch_async_result};
 
 /// Build the full stdlib registry.
 fn build_stdlib() -> Vec<StdlibFn> {

--- a/crates/floe-core/src/stdlib/number.rs
+++ b/crates/floe-core/src/stdlib/number.rs
@@ -1,9 +1,20 @@
-use super::{StdlibFn, Type, result_of, stdlib_fn};
+use super::{StdlibFn, Type, err_value, ok_value, result_of, stdlib_fn};
 
 #[rustfmt::skip]
 pub fn register(fns: &mut Vec<StdlibFn>) {
     fns.extend([
-        stdlib_fn!("Number", "parse", [Type::String], result_of(Type::Number, Type::Named("ParseError".to_string())), "(() => { const _n = Number($0); return Number.isNaN(_n) || $0.trim() === \"\" ? { ok: false as const, error: { message: `Failed to parse \"${$0}\" as number` } } : { ok: true as const, value: _n }; })()"),
+        stdlib_fn!(
+            "Number", "parse",
+            [Type::String],
+            result_of(Type::Number, Type::Named("ParseError".to_string())),
+            concat!(
+                "(() => { const _n = Number($0); return Number.isNaN(_n) || $0.trim() === \"\" ? ",
+                err_value!("{ message: `Failed to parse \"${$0}\" as number` }"),
+                " : ",
+                ok_value!("_n"),
+                "; })()"
+            )
+        ),
         stdlib_fn!("Number", "clamp", [Type::Number, Type::Number, Type::Number], Type::Number, "Math.min(Math.max($0, $1), $2)"),
         stdlib_fn!("Number", "isFinite", [Type::Number], Type::Bool, "Number.isFinite($0)"),
         stdlib_fn!("Number", "isInteger", [Type::Number], Type::Bool, "Number.isInteger($0)"),

--- a/crates/floe-core/src/stdlib/promise.rs
+++ b/crates/floe-core/src/stdlib/promise.rs
@@ -1,4 +1,4 @@
-use super::{StdlibFn, Type, array_of, promise_of, result_of, stdlib_fn, tv};
+use super::{StdlibFn, Type, array_of, err_value, ok_value, promise_of, result_of, stdlib_fn, tv};
 
 #[rustfmt::skip]
 pub fn register(fns: &mut Vec<StdlibFn>) {
@@ -10,7 +10,18 @@ pub fn register(fns: &mut Vec<StdlibFn>) {
         stdlib_fn!("Promise", "all", [array_of(promise_of(t.clone()))], promise_of(array_of(t.clone())), "Promise.all($0)"),
         stdlib_fn!("Promise", "race", [array_of(promise_of(t.clone()))], promise_of(t.clone()), "Promise.race($0)"),
         stdlib_fn!("Promise", "any", [array_of(promise_of(t.clone()))], promise_of(t.clone()), "Promise.any($0)"),
-        stdlib_fn!("Promise", "allSettled", [array_of(promise_of(t.clone()))], promise_of(array_of(result_of(t.clone(), Type::Named("Error".to_string())))), "Promise.allSettled($0).then(_a => _a.map(_v => _v.status === \"fulfilled\" ? { ok: true as const, value: _v.value } : { ok: false as const, error: _v.reason instanceof Error ? _v.reason : new Error(String(_v.reason)) }))"),
+        stdlib_fn!(
+            "Promise", "allSettled",
+            [array_of(promise_of(t.clone()))],
+            promise_of(array_of(result_of(t.clone(), Type::Named("Error".to_string())))),
+            concat!(
+                "Promise.allSettled($0).then(_a => _a.map(_v => _v.status === \"fulfilled\" ? ",
+                ok_value!("_v.value"),
+                " : ",
+                err_value!("_v.reason instanceof Error ? _v.reason : new Error(String(_v.reason))"),
+                "))"
+            )
+        ),
         stdlib_fn!("Promise", "resolve", [t.clone()], promise_of(t.clone()), "Promise.resolve($0)"),
         stdlib_fn!("Promise", "reject", [u.clone()], promise_of(t.clone()), "Promise.reject($0)"),
         stdlib_fn!("Promise", "delay", [Type::Number], promise_of(Type::Unit), "new Promise(_r => setTimeout(_r, $0))"),


### PR DESCRIPTION
closes #1414

Sub-task of #1412.

Adds three codegen-template macros in `stdlib/mod.rs` next to `stdlib_fn!` and uses them across the stdlib codegen modules:

- \`ok_value!(expr)\` → \`{ ok: true as const, value: <expr> }\`
- \`err_value!(expr)\` → \`{ ok: false as const, error: <expr> }\`
- \`try_catch_async_result!(body)\` → async IIFE that wraps the body in try/catch, normalizes caught errors to \`Error\` instances, and returns a Result literal

## Hits

- **http.rs**: 6 functions (\`get\`, \`post\`, \`put\`, \`delete\`, \`json\`, \`text\`) all switch from inlining the full async-IIFE template to \`try_catch_async_result!\`. The \`_e instanceof Error ? _e : new Error(String(_e))\` substring no longer appears 6 times — it lives once in the macro.
- **json.rs**: \`JSON.parse\` uses \`ok_value!\`/\`err_value!\`.
- **number.rs**: \`Number.parse\` same.
- **promise.rs**: \`Promise.allSettled\` same.

## Codegen identity

Output is byte-for-byte identical. All 1615 \`floe-core\` lib tests pass without snapshot changes.

## Test plan

- [x] \`cargo test -p floe-core --lib\` — 1615 pass, 0 fail
- [x] \`cargo clippy --profile ci --workspace -- -D warnings\` — zero errors
- [x] All existing http/json/number/promise codegen snapshots unchanged