### PR TITLE
feat: [#1426] URL, URLSearchParams, RegExp stdlib modules

### DIFF
--- a/crates/floe-core/src/codegen/tests.rs
+++ b/crates/floe-core/src/codegen/tests.rs
@@ -2687,3 +2687,142 @@ let u = User { id, name }
         "expected punning to expand to `id: id`, got:\n{output}"
     );
 }
+
+// ── URL Stdlib (#1426) ───────────────────────────────────────
+
+#[test]
+fn stdlib_url_parse() {
+    let result = emit(r#"URL.parse("http://example.com")"#);
+    assert!(
+        result.contains("new URL(\"http://example.com\")"),
+        "expected `new URL(...)`, got: {result}"
+    );
+    assert!(
+        result.contains("try") && result.contains("catch"),
+        "expected try/catch wrapper, got: {result}"
+    );
+    assert!(
+        result.contains("ok: true as const") && result.contains("ok: false as const"),
+        "expected Result literal, got: {result}"
+    );
+}
+
+#[test]
+fn stdlib_url_field_accessors_pipe() {
+    let result = emit_typed(
+        r#"
+let host = match URL.parse("http://example.com") {
+    Ok(u) -> u |> URL.host,
+    Err(_) -> "",
+}
+"#,
+    );
+    assert!(
+        result.contains("u.host"),
+        "expected `u.host` for `URL.host` accessor, got: {result}"
+    );
+}
+
+#[test]
+fn stdlib_url_to_string() {
+    let result = emit_typed(
+        r#"
+let s = match URL.parse("http://example.com") {
+    Ok(u) -> u |> URL.toString,
+    Err(_) -> "",
+}
+"#,
+    );
+    assert!(
+        result.contains("u.toString()"),
+        "expected `u.toString()`, got: {result}"
+    );
+}
+
+// ── URLSearchParams Stdlib (#1426) ───────────────────────────
+
+#[test]
+fn stdlib_url_search_params_parse() {
+    let result = emit(r#"URLSearchParams.parse("a=1&b=2")"#);
+    assert!(
+        result.contains("new URLSearchParams(\"a=1&b=2\")"),
+        "expected `new URLSearchParams(...)`, got: {result}"
+    );
+}
+
+#[test]
+fn stdlib_url_search_params_get_coerces_null() {
+    let result = emit_typed(
+        r#"
+let p = URLSearchParams.parse("a=1")
+let v = p |> URLSearchParams.get("a")
+"#,
+    );
+    assert!(
+        result.contains("?? undefined"),
+        "expected `?? undefined` null coercion, got: {result}"
+    );
+}
+
+#[test]
+fn stdlib_url_searchparams_from_url() {
+    let result = emit_typed(
+        r#"
+let p = match URL.parse("http://x.com?a=1") {
+    Ok(u) -> u |> URL.searchParams,
+    Err(_) -> URLSearchParams.parse(""),
+}
+"#,
+    );
+    assert!(
+        result.contains("u.searchParams"),
+        "expected `u.searchParams` accessor, got: {result}"
+    );
+}
+
+// ── RegExp Stdlib (#1426) ────────────────────────────────────
+
+#[test]
+fn stdlib_regexp_compile() {
+    let result = emit(r#"RegExp.compile("^foo", "i")"#);
+    assert!(
+        result.contains("new RegExp(\"^foo\", \"i\")"),
+        "expected `new RegExp(pattern, flags)`, got: {result}"
+    );
+    assert!(
+        result.contains("try") && result.contains("catch"),
+        "expected try/catch wrapper, got: {result}"
+    );
+}
+
+#[test]
+fn stdlib_regexp_test() {
+    let result = emit_typed(
+        r#"
+let isMatch = match RegExp.compile("^[a-z]", "") {
+    Ok(r) -> r |> RegExp.test("foo"),
+    Err(_) -> false,
+}
+"#,
+    );
+    assert!(
+        result.contains("r.test(\"foo\")"),
+        "expected `r.test(\"foo\")`, got: {result}"
+    );
+}
+
+#[test]
+fn stdlib_regexp_match_coerces_null() {
+    let result = emit_typed(
+        r#"
+let captures = match RegExp.compile("(\\d+)", "") {
+    Ok(r) -> r |> RegExp.match("abc 123"),
+    Err(_) -> None,
+}
+"#,
+    );
+    assert!(
+        result.contains("?? undefined"),
+        "expected `?? undefined` null coercion, got: {result}"
+    );
+}

--- a/crates/floe-core/src/codegen/tests.rs
+++ b/crates/floe-core/src/codegen/tests.rs
@@ -2812,11 +2812,11 @@ let isMatch = match RegExp.compile("^[a-z]", "") {
 }
 
 #[test]
-fn stdlib_regexp_match_coerces_null() {
+fn stdlib_regexp_exec_coerces_null() {
     let result = emit_typed(
         r#"
 let captures = match RegExp.compile("(\\d+)", "") {
-    Ok(r) -> r |> RegExp.match("abc 123"),
+    Ok(r) -> r |> RegExp.exec("abc 123"),
     Err(_) -> None,
 }
 "#,
@@ -2824,5 +2824,9 @@ let captures = match RegExp.compile("(\\d+)", "") {
     assert!(
         result.contains("?? undefined"),
         "expected `?? undefined` null coercion, got: {result}"
+    );
+    assert!(
+        result.contains("r.exec(\"abc 123\")"),
+        "expected `r.exec(...)`, got: {result}"
     );
 }

--- a/crates/floe-core/src/stdlib/json.rs
+++ b/crates/floe-core/src/stdlib/json.rs
@@ -1,4 +1,4 @@
-use super::{StdlibFn, Type, err_value, ok_value, result_of, stdlib_fn, tv};
+use super::{StdlibFn, Type, result_of, stdlib_fn, try_catch_result, tv};
 
 #[rustfmt::skip]
 pub fn register(fns: &mut Vec<StdlibFn>) {
@@ -10,11 +10,7 @@ pub fn register(fns: &mut Vec<StdlibFn>) {
             "JSON", "parse",
             [Type::String],
             result_of(t.clone(), Type::Named("ParseError".to_string())),
-            concat!(
-                "(() => { try { return ", ok_value!("JSON.parse($0)"), "; ",
-                "} catch (e) { return ", err_value!("{ message: String(e) }"), "; ",
-                "} })()"
-            )
+            try_catch_result!("JSON.parse($0)")
         ),
     ]);
 }

--- a/crates/floe-core/src/stdlib/mod.rs
+++ b/crates/floe-core/src/stdlib/mod.rs
@@ -778,18 +778,17 @@ mod tests {
     }
 
     #[test]
-    fn lookup_reg_exp_match_coerces_null() {
+    fn lookup_reg_exp_exec_coerces_null() {
         let reg = StdlibRegistry::new();
-        let f = reg.lookup("RegExp", "match").unwrap();
+        let f = reg.lookup("RegExp", "exec").unwrap();
         assert!(
             f.codegen.contains("?? undefined"),
-            "RegExp.match must coerce null to undefined for Floe Option, got: {}",
+            "RegExp.exec must coerce null to undefined for Floe Option, got: {}",
             f.codegen
         );
-        // The receiver is the RegExp ($0), but `match` is called on the string ($1).
         assert!(
-            f.codegen.contains("$1.match($0)"),
-            "expected `$1.match($0)` (string.match(regexp)), got: {}",
+            f.codegen.contains("$0.exec($1)"),
+            "expected `$0.exec($1)` (regex.exec(string)), got: {}",
             f.codegen
         );
     }

--- a/crates/floe-core/src/stdlib/mod.rs
+++ b/crates/floe-core/src/stdlib/mod.rs
@@ -18,8 +18,11 @@ mod pipe;
 mod promise;
 mod record;
 mod result;
+mod regex;
 mod set;
 mod string;
+mod url;
+mod url_search_params;
 
 use std::sync::Arc;
 
@@ -214,6 +217,9 @@ fn build_stdlib() -> Vec<StdlibFn> {
     bool::register(&mut fns);
     pipe::register(&mut fns);
     json::register(&mut fns);
+    url::register(&mut fns);
+    url_search_params::register(&mut fns);
+    regex::register(&mut fns);
     fns
 }
 
@@ -538,6 +544,9 @@ mod tests {
         assert!(reg.is_module("Http"));
         assert!(reg.is_module("Date"));
         assert!(reg.is_module("Promise"));
+        assert!(reg.is_module("URL"));
+        assert!(reg.is_module("URLSearchParams"));
+        assert!(reg.is_module("RegExp"));
         assert!(!reg.is_module("Foo"));
     }
 
@@ -557,6 +566,9 @@ mod tests {
         assert!(reg.module_functions("Set").len() >= 11);
         assert!(reg.module_functions("Http").len() >= 6);
         assert!(reg.module_functions("Date").len() >= 11);
+        assert!(reg.module_functions("URL").len() >= 11);
+        assert!(reg.module_functions("URLSearchParams").len() >= 9);
+        assert!(reg.module_functions("RegExp").len() >= 5);
     }
 
     #[test]
@@ -607,6 +619,163 @@ mod tests {
         let reg = StdlibRegistry::new();
         let f = reg.lookup("Date", "toIso").unwrap();
         assert_eq!(f.codegen, "$0.toISOString()");
+    }
+
+    // ── URL ───────────────────────────────────────────────────
+
+    #[test]
+    fn url_is_module() {
+        let reg = StdlibRegistry::new();
+        assert!(reg.is_module("URL"));
+    }
+
+    #[test]
+    fn lookup_url_parse_wraps_new_url_in_try_catch() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("URL", "parse").unwrap();
+        assert!(
+            f.codegen.contains("new URL($0)"),
+            "URL.parse must construct via `new URL`, got: {}",
+            f.codegen
+        );
+        assert!(
+            f.codegen.contains("try") && f.codegen.contains("catch"),
+            "URL.parse must wrap construction so invalid input surfaces as Err, got: {}",
+            f.codegen
+        );
+        assert!(
+            f.codegen.contains("ok: true") && f.codegen.contains("ok: false"),
+            "URL.parse must return a Result literal, got: {}",
+            f.codegen
+        );
+    }
+
+    #[test]
+    fn lookup_url_field_accessors() {
+        let reg = StdlibRegistry::new();
+        for (name, expected) in [
+            ("href", "$0.href"),
+            ("origin", "$0.origin"),
+            ("protocol", "$0.protocol"),
+            ("host", "$0.host"),
+            ("hostname", "$0.hostname"),
+            ("port", "$0.port"),
+            ("pathname", "$0.pathname"),
+            ("search", "$0.search"),
+            ("hash", "$0.hash"),
+        ] {
+            let f = reg
+                .lookup("URL", name)
+                .unwrap_or_else(|| panic!("URL.{name} missing"));
+            assert_eq!(f.codegen, expected, "URL.{name}");
+        }
+    }
+
+    #[test]
+    fn lookup_url_to_string() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("URL", "toString").unwrap();
+        assert_eq!(f.codegen, "$0.toString()");
+    }
+
+    #[test]
+    fn lookup_url_search_params_returns_named_type() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("URL", "searchParams").unwrap();
+        assert_eq!(f.codegen, "$0.searchParams");
+        assert!(
+            matches!(&f.return_type, Type::Named(n) if n == "URLSearchParams"),
+            "URL.searchParams must return URLSearchParams, got: {:?}",
+            f.return_type
+        );
+    }
+
+    // ── URLSearchParams ───────────────────────────────────────
+
+    #[test]
+    fn url_search_params_is_module() {
+        let reg = StdlibRegistry::new();
+        assert!(reg.is_module("URLSearchParams"));
+    }
+
+    #[test]
+    fn lookup_url_search_params_parse_does_not_wrap_in_result() {
+        // URLSearchParams accepts arbitrary strings without throwing —
+        // no Result wrapper needed (unlike URL.parse / RegExp.compile).
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("URLSearchParams", "parse").unwrap();
+        assert_eq!(f.codegen, "new URLSearchParams($0)");
+        assert!(
+            !f.codegen.contains("try"),
+            "URLSearchParams.parse should not have try/catch, got: {}",
+            f.codegen
+        );
+    }
+
+    #[test]
+    fn lookup_url_search_params_get_coerces_null_to_undefined() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("URLSearchParams", "get").unwrap();
+        assert!(
+            f.codegen.contains("?? undefined"),
+            "URLSearchParams.get must coerce null to undefined for Floe Option, got: {}",
+            f.codegen
+        );
+    }
+
+    #[test]
+    fn lookup_url_search_params_size() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("URLSearchParams", "size").unwrap();
+        assert_eq!(f.codegen, "$0.size");
+    }
+
+    // ── RegExp ────────────────────────────────────────────────
+
+    #[test]
+    fn reg_exp_is_module() {
+        let reg = StdlibRegistry::new();
+        assert!(reg.is_module("RegExp"));
+    }
+
+    #[test]
+    fn lookup_reg_exp_compile_wraps_in_try_catch() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("RegExp", "compile").unwrap();
+        assert!(
+            f.codegen.contains("new RegExp($0, $1)"),
+            "RegExp.compile must construct via `new RegExp(pattern, flags)`, got: {}",
+            f.codegen
+        );
+        assert!(
+            f.codegen.contains("try") && f.codegen.contains("catch"),
+            "RegExp.compile must wrap construction, got: {}",
+            f.codegen
+        );
+    }
+
+    #[test]
+    fn lookup_reg_exp_test() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("RegExp", "test").unwrap();
+        assert_eq!(f.codegen, "$0.test($1)");
+    }
+
+    #[test]
+    fn lookup_reg_exp_match_coerces_null() {
+        let reg = StdlibRegistry::new();
+        let f = reg.lookup("RegExp", "match").unwrap();
+        assert!(
+            f.codegen.contains("?? undefined"),
+            "RegExp.match must coerce null to undefined for Floe Option, got: {}",
+            f.codegen
+        );
+        // The receiver is the RegExp ($0), but `match` is called on the string ($1).
+        assert!(
+            f.codegen.contains("$1.match($0)"),
+            "expected `$1.match($0)` (string.match(regexp)), got: {}",
+            f.codegen
+        );
     }
 
     #[test]

--- a/crates/floe-core/src/stdlib/mod.rs
+++ b/crates/floe-core/src/stdlib/mod.rs
@@ -17,8 +17,8 @@ mod option;
 mod pipe;
 mod promise;
 mod record;
-mod result;
 mod regex;
+mod result;
 mod set;
 mod string;
 mod url;
@@ -195,8 +195,24 @@ macro_rules! try_catch_async_result {
     };
 }
 
+/// Sync sibling of `try_catch_async_result!`. Wraps a synchronous
+/// expression that may throw and produces a Result literal with the
+/// caught error stringified into a `ParseError`-shaped object. Used by
+/// every parse-style stdlib factory (`JSON.parse`, `URL.parse`,
+/// `RegExp.compile`) that surfaces invalid input as `Err`.
+macro_rules! try_catch_result {
+    ($body:expr) => {
+        concat!(
+            "(() => { try { return { ok: true as const, value: ",
+            $body,
+            " }; } catch (e) { return { ok: false as const, ",
+            "error: { message: String(e) } }; } })()"
+        )
+    };
+}
+
 // Make the macros available to submodules.
-use {err_value, ok_value, stdlib_fn, try_catch_async_result};
+use {err_value, ok_value, stdlib_fn, try_catch_async_result, try_catch_result};
 
 /// Build the full stdlib registry.
 fn build_stdlib() -> Vec<StdlibFn> {

--- a/crates/floe-core/src/stdlib/regex.rs
+++ b/crates/floe-core/src/stdlib/regex.rs
@@ -25,13 +25,16 @@ pub fn register(fns: &mut Vec<StdlibFn>) {
             "$0.test($1)"
         ),
 
-        // `match` returns `string.match(regexp)` — `Array<string> | null`
-        // — coerced to Floe's Option<Array<string>>.
+        // Returns the captures array for the first match, or `None`.
+        // Named `exec` after the JS API (`RegExp.prototype.exec`) so the
+        // receiver order maps cleanly to `r.exec(s)` without a swap, and
+        // — incidentally — to avoid a name collision with Floe's `match`
+        // keyword which would leak into bare-name pipe completion.
         stdlib_fn!(
-            "RegExp", "match",
+            "RegExp", "exec",
             [re(), Type::String],
             option_of(array_of(Type::String)),
-            "($1.match($0) ?? undefined)"
+            "($0.exec($1) ?? undefined)"
         ),
 
         // Field accessors.

--- a/crates/floe-core/src/stdlib/regex.rs
+++ b/crates/floe-core/src/stdlib/regex.rs
@@ -1,4 +1,4 @@
-use super::{StdlibFn, Type, array_of, err_value, ok_value, option_of, result_of, stdlib_fn};
+use super::{StdlibFn, Type, array_of, option_of, result_of, stdlib_fn, try_catch_result};
 
 /// RegExp stdlib module — Floe-side surface over the runtime `RegExp`
 /// (lib.es5.d.ts). Compilation goes through `RegExp.compile(pattern,
@@ -14,11 +14,7 @@ pub fn register(fns: &mut Vec<StdlibFn>) {
             "RegExp", "compile",
             [Type::String, Type::String],
             result_of(re(), Type::Named("ParseError".to_string())),
-            concat!(
-                "(() => { try { return ", ok_value!("new RegExp($0, $1)"), "; ",
-                "} catch (e) { return ", err_value!("{ message: String(e) }"), "; ",
-                "} })()"
-            )
+            try_catch_result!("new RegExp($0, $1)")
         ),
 
         // `test` short-circuits to a boolean.

--- a/crates/floe-core/src/stdlib/regex.rs
+++ b/crates/floe-core/src/stdlib/regex.rs
@@ -1,0 +1,45 @@
+use super::{StdlibFn, Type, array_of, err_value, ok_value, option_of, result_of, stdlib_fn};
+
+/// RegExp stdlib module — Floe-side surface over the runtime `RegExp`
+/// (lib.es5.d.ts). Compilation goes through `RegExp.compile(pattern,
+/// flags) -> Result<RegExp, ParseError>` so invalid patterns surface as
+/// Err rather than throwing. `flags` is a string like `"i"`, `"gm"`,
+/// `""`; the JS constructor accepts an empty flags string.
+#[rustfmt::skip]
+pub fn register(fns: &mut Vec<StdlibFn>) {
+    let re = || Type::Named("RegExp".to_string());
+
+    fns.extend([
+        stdlib_fn!(
+            "RegExp", "compile",
+            [Type::String, Type::String],
+            result_of(re(), Type::Named("ParseError".to_string())),
+            concat!(
+                "(() => { try { return ", ok_value!("new RegExp($0, $1)"), "; ",
+                "} catch (e) { return ", err_value!("{ message: String(e) }"), "; ",
+                "} })()"
+            )
+        ),
+
+        // `test` short-circuits to a boolean.
+        stdlib_fn!(
+            "RegExp", "test",
+            [re(), Type::String],
+            Type::Bool,
+            "$0.test($1)"
+        ),
+
+        // `match` returns `string.match(regexp)` — `Array<string> | null`
+        // — coerced to Floe's Option<Array<string>>.
+        stdlib_fn!(
+            "RegExp", "match",
+            [re(), Type::String],
+            option_of(array_of(Type::String)),
+            "($1.match($0) ?? undefined)"
+        ),
+
+        // Field accessors.
+        stdlib_fn!("RegExp", "source", [re()], Type::String, "$0.source"),
+        stdlib_fn!("RegExp", "flags",  [re()], Type::String, "$0.flags"),
+    ]);
+}

--- a/crates/floe-core/src/stdlib/url.rs
+++ b/crates/floe-core/src/stdlib/url.rs
@@ -1,4 +1,4 @@
-use super::{StdlibFn, Type, err_value, ok_value, result_of, stdlib_fn};
+use super::{StdlibFn, Type, result_of, stdlib_fn, try_catch_result};
 
 /// URL stdlib module — Floe-side surface over the runtime `URL` type
 /// (lib.dom.d.ts / Node URL). The Floe-side `URL` IS the runtime URL;
@@ -17,11 +17,7 @@ pub fn register(fns: &mut Vec<StdlibFn>) {
             "URL", "parse",
             [Type::String],
             result_of(url(), Type::Named("ParseError".to_string())),
-            concat!(
-                "(() => { try { return ", ok_value!("new URL($0)"), "; ",
-                "} catch (e) { return ", err_value!("{ message: String(e) }"), "; ",
-                "} })()"
-            )
+            try_catch_result!("new URL($0)")
         ),
 
         // Field accessors. Match the runtime URL property names so users

--- a/crates/floe-core/src/stdlib/url.rs
+++ b/crates/floe-core/src/stdlib/url.rs
@@ -1,0 +1,51 @@
+use super::{StdlibFn, Type, err_value, ok_value, result_of, stdlib_fn};
+
+/// URL stdlib module — Floe-side surface over the runtime `URL` type
+/// (lib.dom.d.ts / Node URL). The Floe-side `URL` IS the runtime URL;
+/// passing a value typed `URL` to any TS function expecting `URL` is a
+/// zero-cost passthrough. Construction is `URL.parse(s) -> Result<URL,
+/// ParseError>` rather than a throwing constructor so the error case is
+/// surfaced in the type.
+#[rustfmt::skip]
+pub fn register(fns: &mut Vec<StdlibFn>) {
+    let url = || Type::Named("URL".to_string());
+
+    fns.extend([
+        // Construction: try/catch wrapper around `new URL` so invalid
+        // inputs surface as `Err`, not a runtime throw.
+        stdlib_fn!(
+            "URL", "parse",
+            [Type::String],
+            result_of(url(), Type::Named("ParseError".to_string())),
+            concat!(
+                "(() => { try { return ", ok_value!("new URL($0)"), "; ",
+                "} catch (e) { return ", err_value!("{ message: String(e) }"), "; ",
+                "} })()"
+            )
+        ),
+
+        // Field accessors. Match the runtime URL property names so users
+        // who already know the JS API don't have to re-learn naming.
+        stdlib_fn!("URL", "href",      [url()], Type::String, "$0.href"),
+        stdlib_fn!("URL", "origin",    [url()], Type::String, "$0.origin"),
+        stdlib_fn!("URL", "protocol",  [url()], Type::String, "$0.protocol"),
+        stdlib_fn!("URL", "host",      [url()], Type::String, "$0.host"),
+        stdlib_fn!("URL", "hostname",  [url()], Type::String, "$0.hostname"),
+        stdlib_fn!("URL", "port",      [url()], Type::String, "$0.port"),
+        stdlib_fn!("URL", "pathname",  [url()], Type::String, "$0.pathname"),
+        stdlib_fn!("URL", "search",    [url()], Type::String, "$0.search"),
+        stdlib_fn!("URL", "hash",      [url()], Type::String, "$0.hash"),
+
+        // Parsed query params. Returns the live URLSearchParams view —
+        // mutations on it would be reflected in the URL, but Floe's
+        // URLSearchParams surface is read-only so this is safe.
+        stdlib_fn!(
+            "URL", "searchParams",
+            [url()],
+            Type::Named("URLSearchParams".to_string()),
+            "$0.searchParams"
+        ),
+
+        stdlib_fn!("URL", "toString", [url()], Type::String, "$0.toString()"),
+    ]);
+}

--- a/crates/floe-core/src/stdlib/url_search_params.rs
+++ b/crates/floe-core/src/stdlib/url_search_params.rs
@@ -1,0 +1,84 @@
+use super::{StdlibFn, Type, array_of, option_of, stdlib_fn};
+
+/// URLSearchParams stdlib module — Floe-side read surface over the
+/// runtime `URLSearchParams` (lib.dom.d.ts / Node).
+///
+/// `URLSearchParams.parse` doesn't return a Result because the runtime
+/// constructor accepts arbitrary input — malformed pairs just become
+/// empty entries, never throw. Mutation (`set`/`append`/`delete`) is
+/// intentionally not exposed yet; callers either build from a tuple
+/// array via `fromArray` or pull from a parsed URL.
+#[rustfmt::skip]
+pub fn register(fns: &mut Vec<StdlibFn>) {
+    let usp = || Type::Named("URLSearchParams".to_string());
+    let pair = || Type::Tuple(vec![Type::String, Type::String]);
+
+    fns.extend([
+        stdlib_fn!(
+            "URLSearchParams", "parse",
+            [Type::String],
+            usp(),
+            "new URLSearchParams($0)"
+        ),
+        stdlib_fn!(
+            "URLSearchParams", "fromArray",
+            [array_of(pair())],
+            usp(),
+            "new URLSearchParams($0)"
+        ),
+
+        // Reads. `get` returns `Option<string>` because the runtime
+        // returns `string | null` — coerce null to undefined so it lines
+        // up with Floe's Option representation.
+        stdlib_fn!(
+            "URLSearchParams", "get",
+            [usp(), Type::String],
+            option_of(Type::String),
+            "($0.get($1) ?? undefined)"
+        ),
+        stdlib_fn!(
+            "URLSearchParams", "getAll",
+            [usp(), Type::String],
+            array_of(Type::String),
+            "$0.getAll($1)"
+        ),
+        stdlib_fn!(
+            "URLSearchParams", "has",
+            [usp(), Type::String],
+            Type::Bool,
+            "$0.has($1)"
+        ),
+
+        stdlib_fn!(
+            "URLSearchParams", "keys",
+            [usp()],
+            array_of(Type::String),
+            "[...$0.keys()]"
+        ),
+        stdlib_fn!(
+            "URLSearchParams", "values",
+            [usp()],
+            array_of(Type::String),
+            "[...$0.values()]"
+        ),
+        stdlib_fn!(
+            "URLSearchParams", "entries",
+            [usp()],
+            array_of(pair()),
+            "[...$0.entries()]"
+        ),
+
+        stdlib_fn!(
+            "URLSearchParams", "size",
+            [usp()],
+            Type::Number,
+            "$0.size"
+        ),
+        stdlib_fn!(
+            "URLSearchParams", "toString",
+            [usp()],
+            Type::String,
+            "$0.toString()"
+        ),
+    ]);
+}

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -546,6 +546,30 @@ let month = d |> Date.month                 // d.getMonth() + 1 (1-indexed!)
 let day = d |> Date.day                     // d.getDate()
 let ms = d |> Date.millis                   // d.getTime()
 let iso = d |> Date.toIso                   // d.toISOString()
+
+// URL — parse + field access (Result on parse so bad input is `Err`)
+match URL.parse("https://example.com/p?q=1") {
+    Ok(u) -> {
+        let host = u |> URL.host                // "example.com"
+        let path = u |> URL.pathname            // "/p"
+        let q = u |> URL.searchParams |> URLSearchParams.get("q")  // Some("1")
+    },
+    Err(e) -> Console.error(e.message),
+}
+
+// URLSearchParams — read-only query string access
+let p = URLSearchParams.parse("a=1&b=2")
+let a = p |> URLSearchParams.get("a")           // Some("1")
+let pairs = URLSearchParams.fromArray([("q", "floe")])
+
+// RegExp — compile + match (compile is `Result` so bad patterns are `Err`)
+match RegExp.compile("^[a-z]+", "i") {
+    Ok(r) -> {
+        let isWord = r |> RegExp.test("Hello")        // true
+        let captures = r |> RegExp.match("Hello")     // Some(["Hello"])
+    },
+    Err(e) -> Console.error(e.message),
+}
 ```
 
 ## Imports

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -566,7 +566,7 @@ let pairs = URLSearchParams.fromArray([("q", "floe")])
 match RegExp.compile("^[a-z]+", "i") {
     Ok(r) -> {
         let isWord = r |> RegExp.test("Hello")        // true
-        let captures = r |> RegExp.match("Hello")     // Some(["Hello"])
+        let captures = r |> RegExp.exec("Hello")      // Some(["Hello"])
     },
     Err(e) -> Console.error(e.message),
 }

--- a/docs/site/src/content/docs/docs/reference/stdlib/regex.md
+++ b/docs/site/src/content/docs/docs/reference/stdlib/regex.md
@@ -12,7 +12,7 @@ Regular expression compilation and matching. The Floe `RegExp` type is the runti
 |----------|-----------|-------------|
 | `RegExp.compile` | `(string, string) -> Result<RegExp, ParseError>` | Compile pattern + flags. Returns `Err` on invalid syntax. |
 | `RegExp.test` | `(RegExp, string) -> bool` | Whether the pattern matches the string |
-| `RegExp.match` | `(RegExp, string) -> Option<Array<string>>` | Capture groups, or `None` if no match |
+| `RegExp.exec` | `(RegExp, string) -> Option<Array<string>>` | First match's full text + capture groups, or `None` |
 | `RegExp.source` | `(RegExp) -> string` | The original pattern string |
 | `RegExp.flags` | `(RegExp) -> string` | The flags string (e.g. `"i"`, `"gm"`) |
 
@@ -22,7 +22,7 @@ Regular expression compilation and matching. The Floe `RegExp` type is the runti
 match RegExp.compile("^[a-z]+", "i") {
     Ok(r) -> {
         let isWord = r |> RegExp.test("Hello")        // true
-        let captures = r |> RegExp.match("Hello world")
+        let captures = r |> RegExp.exec("Hello world")
         // captures: Some(["Hello"])
     },
     Err(e) -> Console.error(e.message),
@@ -39,4 +39,4 @@ The `flags` argument is required — pass `""` when you don't need any. Common f
 | `"s"` | Dot matches newline |
 | `"u"` | Unicode |
 
-`RegExp.match` returns the first match (or all matches when the `g` flag is set), so the result type is `Option<Array<string>>` — the outer `Option` represents "did the pattern match at all?", and the inner `Array<string>` holds the captured groups.
+`RegExp.exec` returns the first match plus its captured groups: `Some(["fullMatch", "cap1", "cap2", ...])`, or `None` if the pattern didn't match. The name mirrors the underlying `RegExp.prototype.exec` JS API. With the `"g"` flag the underlying regex object advances `lastIndex` between calls, so re-using a global regex across calls walks through matches one at a time — bind to a fresh regex each time if that's not what you want.

--- a/docs/site/src/content/docs/docs/reference/stdlib/regex.md
+++ b/docs/site/src/content/docs/docs/reference/stdlib/regex.md
@@ -1,0 +1,42 @@
+---
+title: RegExp
+sidebar:
+  order: 18
+---
+
+Regular expression compilation and matching. The Floe `RegExp` type is the runtime `RegExp` — passing it to TS APIs that take `RegExp` is zero-cost.
+
+## Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `RegExp.compile` | `(string, string) -> Result<RegExp, ParseError>` | Compile pattern + flags. Returns `Err` on invalid syntax. |
+| `RegExp.test` | `(RegExp, string) -> bool` | Whether the pattern matches the string |
+| `RegExp.match` | `(RegExp, string) -> Option<Array<string>>` | Capture groups, or `None` if no match |
+| `RegExp.source` | `(RegExp) -> string` | The original pattern string |
+| `RegExp.flags` | `(RegExp) -> string` | The flags string (e.g. `"i"`, `"gm"`) |
+
+## Examples
+
+```floe
+match RegExp.compile("^[a-z]+", "i") {
+    Ok(r) -> {
+        let isWord = r |> RegExp.test("Hello")        // true
+        let captures = r |> RegExp.match("Hello world")
+        // captures: Some(["Hello"])
+    },
+    Err(e) -> Console.error(e.message),
+}
+```
+
+The `flags` argument is required — pass `""` when you don't need any. Common flags:
+
+| Flag | Meaning |
+|------|---------|
+| `"i"` | Case-insensitive |
+| `"g"` | Global (find all matches) |
+| `"m"` | Multiline (`^` / `$` match line boundaries) |
+| `"s"` | Dot matches newline |
+| `"u"` | Unicode |
+
+`RegExp.match` returns the first match (or all matches when the `g` flag is set), so the result type is `Option<Array<string>>` — the outer `Option` represents "did the pattern match at all?", and the inner `Array<string>` holds the captured groups.

--- a/docs/site/src/content/docs/docs/reference/stdlib/url-search-params.md
+++ b/docs/site/src/content/docs/docs/reference/stdlib/url-search-params.md
@@ -1,0 +1,42 @@
+---
+title: URLSearchParams
+sidebar:
+  order: 17
+---
+
+Read-only access to query-string parameters. Get one via `URL.searchParams` from a parsed URL, or build one directly with `URLSearchParams.parse` / `URLSearchParams.fromArray`.
+
+## Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `URLSearchParams.parse` | `(string) -> URLSearchParams` | Parse a query string. Malformed input becomes empty entries (never throws). |
+| `URLSearchParams.fromArray` | `(Array<(string, string)>) -> URLSearchParams` | Build from a tuple list |
+| `URLSearchParams.get` | `(URLSearchParams, string) -> Option<string>` | First value for a key, or `None` |
+| `URLSearchParams.getAll` | `(URLSearchParams, string) -> Array<string>` | All values for a key |
+| `URLSearchParams.has` | `(URLSearchParams, string) -> bool` | Whether a key is present |
+| `URLSearchParams.keys` | `(URLSearchParams) -> Array<string>` | All keys (with duplicates) |
+| `URLSearchParams.values` | `(URLSearchParams) -> Array<string>` | All values |
+| `URLSearchParams.entries` | `(URLSearchParams) -> Array<(string, string)>` | All key/value pairs |
+| `URLSearchParams.size` | `(URLSearchParams) -> number` | Total number of entries |
+| `URLSearchParams.toString` | `(URLSearchParams) -> string` | Encoded query string, no leading `?` |
+
+## Examples
+
+```floe
+let p = URLSearchParams.parse("a=1&b=2&a=3")
+
+let first = p |> URLSearchParams.get("a")        // Some("1")
+let all = p |> URLSearchParams.getAll("a")       // ["1", "3"]
+let n = p |> URLSearchParams.size                // 3
+let s = p |> URLSearchParams.toString            // "a=1&b=2&a=3"
+```
+
+Build from a tuple list:
+
+```floe
+let p = URLSearchParams.fromArray([("q", "floe"), ("page", "2")])
+p |> URLSearchParams.toString    // "q=floe&page=2"
+```
+
+Mutation methods (`set`, `append`, `delete`) are intentionally not exposed today — Floe favours immutable construction. If you need to add or change a key, build a new `URLSearchParams` from the merged entries.

--- a/docs/site/src/content/docs/docs/reference/stdlib/url.md
+++ b/docs/site/src/content/docs/docs/reference/stdlib/url.md
@@ -1,0 +1,40 @@
+---
+title: URL
+sidebar:
+  order: 16
+---
+
+URL parsing and field access. The Floe `URL` type is the same nominal `URL` as the runtime — passing a value to a TS function expecting `URL` is zero-cost.
+
+## Functions
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `URL.parse` | `(string) -> Result<URL, ParseError>` | Parse a URL string. Returns `Err` on invalid input. |
+| `URL.href` | `(URL) -> string` | Full URL string |
+| `URL.origin` | `(URL) -> string` | `protocol://host` |
+| `URL.protocol` | `(URL) -> string` | e.g. `"https:"` (note the colon) |
+| `URL.host` | `(URL) -> string` | `hostname` plus optional `:port` |
+| `URL.hostname` | `(URL) -> string` | Just the host, no port |
+| `URL.port` | `(URL) -> string` | Port as string, `""` when default |
+| `URL.pathname` | `(URL) -> string` | Path component |
+| `URL.search` | `(URL) -> string` | Query string including leading `?` |
+| `URL.searchParams` | `(URL) -> URLSearchParams` | Parsed query parameters |
+| `URL.hash` | `(URL) -> string` | Fragment including leading `#` |
+| `URL.toString` | `(URL) -> string` | Stringifies via `href` |
+
+## Examples
+
+```floe
+match URL.parse("https://example.com/posts?id=42") {
+    Ok(u) -> {
+        let host = u |> URL.host           // "example.com"
+        let path = u |> URL.pathname       // "/posts"
+        let id = u |> URL.searchParams |> URLSearchParams.get("id")
+        Console.log(host, path, id)
+    },
+    Err(e) -> Console.error(e.message),
+}
+```
+
+`URL.parse` is the only construction path — there is no `URL("...")` shorthand. The `Result` return type forces callers to handle malformed input rather than letting it throw at runtime.


### PR DESCRIPTION
closes #1426

## Summary

Adds three new stdlib modules covering the runtime built-ins that had no Floe-side surface — URL parsing, search-param access, regex matching.

```floe
match URL.parse("https://example.com/p?q=1") {
    Ok(u) -> {
        let host = u |> URL.host                              // "example.com"
        let q = u |> URL.searchParams |> URLSearchParams.get("q")  // Some("1")
    },
    Err(e) -> Console.error(e.message),
}

match RegExp.compile("^[a-z]+", "i") {
    Ok(r) -> r |> RegExp.test("Hello"),  // true
    Err(_) -> false,
}
```

Construction goes through Result-returning factories (`URL.parse`, `RegExp.compile`) so malformed input surfaces in the type rather than throwing. `URLSearchParams.parse` skips the wrapper because its underlying constructor accepts arbitrary strings without throwing.

Floe-side `URL`, `URLSearchParams`, `RegExp` ARE the runtime types from lib.dom.d.ts / lib.es5.d.ts — zero-cost passthrough when handed back to TS code. Same pattern as the existing `Map`, `Set`, `Date` modules.

## Side cleanup

- Extracted `try_catch_result!` macro (sibling to `try_catch_async_result!`). Three call sites — `JSON.parse`, `URL.parse`, `RegExp.compile` — now share the canonical sync try/catch IIFE shape.

## Backstory

This replaces #1358 ("TS constructor-interface types callable as Floe constructors"), which proposed compiler-level dispatch for `URL("x")` → `new URL("x")`. After investigating, that whole approach turned out to be solving a problem Floe doesn't have — `Map`/`Set`/`Number`/`String` etc. were never bareword-callable in Floe to begin with, and the few cases that genuinely needed it (URL, URLSearchParams, RegExp) are better served by curated stdlib modules. Closed #1358 and filed this with narrower scope. See the closing comment on #1358 for the full reasoning.

## Test plan

- [x] Stdlib registry tests for all three modules — module registration, function lookup, codegen template shapes
- [x] Codegen integration tests — `URL.parse("...")` emits `new URL(...)` in try/catch; field accessors emit direct property access; null-coercion (`?? undefined`) for `URLSearchParams.get` and `RegExp.match`
- [x] All 1654 + 114 LSP unit tests pass
- [x] Lib clippy clean (`cargo clippy --workspace --lib -- -D warnings`)

## Out of scope (deferred)

- **Mutating URLSearchParams ops** (`set`/`append`/`delete`) — Floe favours immutable construction; can be added if a real use case appears.
- **Type-annotation parsing for stdlib types** — `let foo(u: URL)` currently rejects `URL` as an unknown type, same as `Date` does today. Pre-existing gap, deserves its own issue if anyone hits it.
- **Compiler-level `new` dispatch for npm-imported classes** — workaround exists today (TS shim file). Defer until real demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)