### PR TITLE
chore: [#1411] dedup parser boilerplate in cst

### DIFF
--- a/crates/floe-core/src/cst.rs
+++ b/crates/floe-core/src/cst.rs
@@ -118,6 +118,13 @@ impl<'src> CstParser<'src> {
             .is_some_and(|k| std::mem::discriminant(&k) == std::mem::discriminant(kind))
     }
 
+    /// `at` for a set of alternatives. Cleaner than chained `at(...) || at(...)`
+    /// when matching multi-token operator classes (binary operators, keyword
+    /// alternatives, etc.).
+    fn at_any(&self, kinds: &[TokenKind]) -> bool {
+        kinds.iter().any(|k| self.at(k))
+    }
+
     fn at_identifier(&self, name: &str) -> bool {
         matches!(self.current_kind(), Some(TokenKind::Identifier(n)) if n == name)
     }
@@ -577,17 +584,6 @@ impl<'src> CstParser<'src> {
     }
 
     fn expect(&mut self, kind: &TokenKind) {
-        if self.at(kind) {
-            self.bump();
-        } else {
-            self.error_kind(
-                &format!("expected {:?}, found {:?}", kind, self.current_kind()),
-                CstErrorKind::UnexpectedToken,
-            );
-        }
-    }
-
-    fn expect_kind(&mut self, kind: &TokenKind) {
         if self.at(kind) {
             self.bump();
         } else {

--- a/crates/floe-core/src/cst/exprs.rs
+++ b/crates/floe-core/src/cst/exprs.rs
@@ -7,53 +7,44 @@ impl<'src> CstParser<'src> {
         self.parse_or_expr();
     }
 
-    fn parse_or_expr(&mut self) {
+    /// Generic left-associative binary parser. Parses `next (op next)*`,
+    /// wrapping each successful op + rhs into a `BINARY_EXPR` rooted at the
+    /// pre-call checkpoint (so the resulting tree is `((a op b) op c) ...`).
+    /// Used by every flat binary precedence level — pipe and comparison opt
+    /// out because they need extra rules (match-into-pipe, newline guard).
+    fn parse_left_assoc(&mut self, ops: &[TokenKind], next: fn(&mut Self)) {
         let checkpoint = self.builder.checkpoint();
-        self.parse_and_expr();
-
-        while self.at(&TokenKind::PipePipe) {
+        next(self);
+        while self.at_any(ops) {
             self.builder
                 .start_node_at(checkpoint, SyntaxKind::BINARY_EXPR.into());
             self.bump();
             self.eat_trivia();
-            self.parse_and_expr();
+            next(self);
             self.builder.finish_node();
         }
+    }
+
+    fn parse_or_expr(&mut self) {
+        self.parse_left_assoc(&[TokenKind::PipePipe], Self::parse_and_expr);
     }
 
     fn parse_and_expr(&mut self) {
-        let checkpoint = self.builder.checkpoint();
-        self.parse_equality_expr();
-
-        while self.at(&TokenKind::AmpAmp) {
-            self.builder
-                .start_node_at(checkpoint, SyntaxKind::BINARY_EXPR.into());
-            self.bump();
-            self.eat_trivia();
-            self.parse_equality_expr();
-            self.builder.finish_node();
-        }
+        self.parse_left_assoc(&[TokenKind::AmpAmp], Self::parse_equality_expr);
     }
 
     fn parse_equality_expr(&mut self) {
-        let checkpoint = self.builder.checkpoint();
-        self.parse_pipe_expr();
-
-        while self.at(&TokenKind::EqualEqual) || self.at(&TokenKind::BangEqual) {
-            self.builder
-                .start_node_at(checkpoint, SyntaxKind::BINARY_EXPR.into());
-            self.bump();
-            self.eat_trivia();
-            self.parse_pipe_expr();
-            self.builder.finish_node();
-        }
+        self.parse_left_assoc(
+            &[TokenKind::EqualEqual, TokenKind::BangEqual],
+            Self::parse_pipe_expr,
+        );
     }
 
     fn parse_pipe_expr(&mut self) {
         let checkpoint = self.builder.checkpoint();
         self.parse_comparison_expr();
 
-        while self.at(&TokenKind::Pipe) || self.at(&TokenKind::PipeUnwrap) {
+        while self.at_any(&[TokenKind::Pipe, TokenKind::PipeUnwrap]) {
             self.builder
                 .start_node_at(checkpoint, SyntaxKind::PIPE_EXPR.into());
             self.bump(); // |> or |>?
@@ -71,15 +62,18 @@ impl<'src> CstParser<'src> {
     }
 
     fn parse_comparison_expr(&mut self) {
+        // Comparison can't span a newline, otherwise `<` / `>` collide with
+        // JSX. Stays out of `parse_left_assoc` because of this guard.
+        const COMPARISON_OPS: &[TokenKind] = &[
+            TokenKind::LessThan,
+            TokenKind::GreaterThan,
+            TokenKind::LessEqual,
+            TokenKind::GreaterEqual,
+        ];
         let checkpoint = self.builder.checkpoint();
         self.parse_additive_expr();
 
-        while (self.at(&TokenKind::LessThan)
-            || self.at(&TokenKind::GreaterThan)
-            || self.at(&TokenKind::LessEqual)
-            || self.at(&TokenKind::GreaterEqual))
-            && !self.preceded_by_newline()
-        {
+        while self.at_any(COMPARISON_OPS) && !self.preceded_by_newline() {
             self.builder
                 .start_node_at(checkpoint, SyntaxKind::BINARY_EXPR.into());
             self.bump();
@@ -90,34 +84,17 @@ impl<'src> CstParser<'src> {
     }
 
     fn parse_additive_expr(&mut self) {
-        let checkpoint = self.builder.checkpoint();
-        self.parse_multiplicative_expr();
-
-        while self.at(&TokenKind::Plus) || self.at(&TokenKind::Minus) {
-            self.builder
-                .start_node_at(checkpoint, SyntaxKind::BINARY_EXPR.into());
-            self.bump();
-            self.eat_trivia();
-            self.parse_multiplicative_expr();
-            self.builder.finish_node();
-        }
+        self.parse_left_assoc(
+            &[TokenKind::Plus, TokenKind::Minus],
+            Self::parse_multiplicative_expr,
+        );
     }
 
     fn parse_multiplicative_expr(&mut self) {
-        let checkpoint = self.builder.checkpoint();
-        self.parse_unary_expr();
-
-        while self.at(&TokenKind::Star)
-            || self.at(&TokenKind::Slash)
-            || self.at(&TokenKind::Percent)
-        {
-            self.builder
-                .start_node_at(checkpoint, SyntaxKind::BINARY_EXPR.into());
-            self.bump();
-            self.eat_trivia();
-            self.parse_unary_expr();
-            self.builder.finish_node();
-        }
+        self.parse_left_assoc(
+            &[TokenKind::Star, TokenKind::Slash, TokenKind::Percent],
+            Self::parse_unary_expr,
+        );
     }
 
     fn parse_unary_expr(&mut self) {
@@ -675,21 +652,25 @@ impl<'src> CstParser<'src> {
         self.expect_ident();
         self.eat_trivia();
 
-        // Check for optional binary operator predicate
-        if self.at(&TokenKind::EqualEqual)
-            || self.at(&TokenKind::BangEqual)
-            || self.at(&TokenKind::LessThan)
-            || self.at(&TokenKind::GreaterThan)
-            || self.at(&TokenKind::LessEqual)
-            || self.at(&TokenKind::GreaterEqual)
-            || self.at(&TokenKind::AmpAmp)
-            || self.at(&TokenKind::PipePipe)
-            || self.at(&TokenKind::Plus)
-            || self.at(&TokenKind::Minus)
-            || self.at(&TokenKind::Star)
-            || self.at(&TokenKind::Slash)
-            || self.at(&TokenKind::Percent)
-        {
+        // Optional binary-operator predicate following `.field` —
+        // `.field == 1`, `.field > x`, etc. Any infix operator that
+        // returns a boolean or a refined value is allowed.
+        const DOT_PREDICATE_OPS: &[TokenKind] = &[
+            TokenKind::EqualEqual,
+            TokenKind::BangEqual,
+            TokenKind::LessThan,
+            TokenKind::GreaterThan,
+            TokenKind::LessEqual,
+            TokenKind::GreaterEqual,
+            TokenKind::AmpAmp,
+            TokenKind::PipePipe,
+            TokenKind::Plus,
+            TokenKind::Minus,
+            TokenKind::Star,
+            TokenKind::Slash,
+            TokenKind::Percent,
+        ];
+        if self.at_any(DOT_PREDICATE_OPS) {
             self.bump(); // operator
             self.eat_trivia();
             self.parse_postfix_expr();

--- a/crates/floe-core/src/cst/items.rs
+++ b/crates/floe-core/src/cst/items.rs
@@ -179,7 +179,7 @@ impl<'src> CstParser<'src> {
             self.bump();
             self.eat_trivia();
         }
-        self.expect_kind(&TokenKind::String(String::new()));
+        self.expect(&TokenKind::String(String::new()));
 
         self.builder.finish_node();
     }
@@ -196,7 +196,7 @@ impl<'src> CstParser<'src> {
 
         self.expect(&TokenKind::From);
         self.eat_trivia();
-        self.expect_kind(&TokenKind::String(String::new()));
+        self.expect(&TokenKind::String(String::new()));
 
         self.builder.finish_node();
     }
@@ -1015,7 +1015,7 @@ impl<'src> CstParser<'src> {
         self.eat_trivia();
 
         // Test name (string literal)
-        self.expect_kind(&TokenKind::String(String::new()));
+        self.expect(&TokenKind::String(String::new()));
         self.eat_trivia();
 
         self.expect(&TokenKind::LeftBrace);


### PR DESCRIPTION
closes #1411

## Summary

Pure refactor — three concrete duplications collapsed in `crates/floe-core/src/cst.rs` and `cst/exprs.rs`. Net **-23 lines**, no behavior change. All parse-tree-shaped tests still pass byte-for-byte.

### What changed

| Duplication | Fix |
|---|---|
| `expect` and `expect_kind` were byte-identical | Deleted `expect_kind`, 3 call sites in `items.rs` migrated to `expect` |
| 5 left-associative binary parsers (or, and, equality, additive, multiplicative) all followed the same checkpoint + while + bump + recurse template | Extracted `parse_left_assoc(ops, next)`. Each parser is now a one-liner. |
| Long `at(...) \|\| at(...) \|\| ...` chains, including a 13-op chain in dot-shorthand-predicate parsing | Added `at_any(&[TokenKind])`. Applied at the 13-op chain and the 4-op comparison parser. |

`parse_pipe_expr` and `parse_comparison_expr` opt out of `parse_left_assoc` because they need extra rules: pipe handles `match-into-pipe` (`x \|> match { ... }`), and comparison has the `!preceded_by_newline()` guard for JSX disambiguation. Both still use `at_any` internally.

The 2-token `Let \|\| Async` chains in `items.rs` were left as `||` chains — `at_any` only earns its keep at 3+ alternatives.

## Backstory

Spotted by reviewers on #1409 (brace-form record construction): `parse_brace_construct_expr` and `parse_constructor_args` shared a lot of scaffolding. That specific dedup is a follow-up issue, but #1411 covered the three lower-hanging duplications in the same file area.

## Test plan

- [x] All 1654 core unit tests pass (parse trees byte-identical pre/post)
- [x] All 114 LSP unit tests pass
- [x] Lib clippy clean (`cargo clippy --workspace --lib -- -D warnings`)
- [x] No example-app changes needed; no docs needed (internal compiler refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)